### PR TITLE
Update selected instance when running undo

### DIFF
--- a/app/canvas/canvas.tsx
+++ b/app/canvas/canvas.tsx
@@ -25,6 +25,7 @@ import {
   useReparentInstance,
   usePublishSelectedInstance,
   usePublishRootInstance,
+  useUpdateSelectedInstance,
 } from "./shared/instance";
 import { useUpdateStyle } from "./shared/style";
 import { useActiveElementTracking } from "./shared/active-element";
@@ -100,6 +101,7 @@ const DesignMode = ({ treeId, project }: DesignModeProps) => {
   usePublishRootInstance();
   useActiveElementTracking();
   useSync({ project });
+  useUpdateSelectedInstance();
   const elements = useElementsTree();
   return (
     // Using touch backend becuase html5 drag&drop doesn't fire drag events in our case

--- a/app/canvas/shared/instance.ts
+++ b/app/canvas/shared/instance.ts
@@ -14,6 +14,7 @@ import {
   findParentInstance,
   findClosestSiblingInstance,
   insertInstanceMutable,
+  findInstanceById,
 } from "~/shared/tree-utils";
 import store from "immerhin";
 import { DropData, type SelectedInstanceData } from "~/shared/component";
@@ -154,6 +155,26 @@ export const usePublishSelectedInstance = ({
       payload,
     });
   }, [instance, allUserProps, treeId, browserStyle]);
+};
+
+/**
+ *  We need to set the selected instance after a any root instance update,
+ *  because anything that we change on the selected instance is actually done on the root, so
+ *  when we run "undo", root is going to be undone but not the selected instance, unless we update it here.
+ */
+export const useUpdateSelectedInstance = () => {
+  const [rootInstance] = useRootInstance();
+  const [selectedInstance, setSelectedInstance] = useSelectedInstance();
+
+  useEffect(() => {
+    if (rootInstance === undefined || selectedInstance === undefined) return;
+    const nextSelectedInstance = findInstanceById(
+      rootInstance,
+      selectedInstance.id
+    );
+    if (nextSelectedInstance === undefined) return;
+    setSelectedInstance(nextSelectedInstance);
+  }, [rootInstance, selectedInstance, setSelectedInstance]);
 };
 
 export const usePublishRootInstance = () => {

--- a/app/canvas/shared/style.ts
+++ b/app/canvas/shared/style.ts
@@ -1,11 +1,11 @@
 import store from "immerhin";
 import { type StyleUpdates } from "~/shared/component";
-import { findInstanceById, setInstanceStyleMutable } from "~/shared/tree-utils";
+import { setInstanceStyleMutable } from "~/shared/tree-utils";
 import { rootInstanceContainer, useSelectedInstance } from "./nano-values";
 import { useSubscribe } from "./pubsub";
 
 export const useUpdateStyle = () => {
-  const [selectedInstance, setSelectedInstance] = useSelectedInstance();
+  const [selectedInstance] = useSelectedInstance();
   useSubscribe<"updateStyle", StyleUpdates>(
     "updateStyle",
     ({ id, updates, breakpoint }) => {
@@ -19,13 +19,6 @@ export const useUpdateStyle = () => {
         }
         setInstanceStyleMutable(rootInstance, id, updates, breakpoint);
       });
-
-      if (rootInstanceContainer.value === undefined) return;
-      const instance = findInstanceById(rootInstanceContainer.value, id);
-      if (instance === undefined) return;
-      // We need to set new version of the selected instance after a style update,
-      // so that anything that depends on instance.cssRules gets updated too.
-      setSelectedInstance(instance);
     }
   );
 };

--- a/app/designer/features/style-panel/use-style-data.ts
+++ b/app/designer/features/style-panel/use-style-data.ts
@@ -47,7 +47,8 @@ export const useStyleData = ({
   const [currentStyle, setCurrentStyle] = useState(getCurrentStyle());
 
   useEffect(() => {
-    setCurrentStyle(getCurrentStyle());
+    const currentStyle = getCurrentStyle();
+    setCurrentStyle(currentStyle);
   }, [getCurrentStyle]);
 
   const inheritedStyle = useMemo(() => {


### PR DESCRIPTION
All tree changes are running on the root instance, so when we undo changes, we need to set a new instance as a selected instance

Fixes #33 