### PR TITLE
Remove Vercel deployment workarounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "packages": [
       "apps/*",
       "packages/*"
-    ],
-    "nohoist": [
-      "**/designer/**"
     ]
   },
   "scripts": {


### PR DESCRIPTION
Fixes: #126 

Hey thought I'd just open a quick PR to revert any workarounds once the builder is fixed.

Once the fix is merged, @vercel/remix builder will properly be able to crawl dependencies from the entire monorepo, removing the need to "no-hoist" the designer app.