### PR TITLE
Make sure we have validated at runtime data that isn't part of Prisma

### DIFF
--- a/apps/designer/app/designer/features/breakpoints/use-update-canvas-width.ts
+++ b/apps/designer/app/designer/features/breakpoints/use-update-canvas-width.ts
@@ -1,3 +1,4 @@
+import { useSubscribe } from "@webstudio-is/sdk";
 import { useCallback, useEffect } from "react";
 import {
   useSelectedBreakpoint,
@@ -30,6 +31,8 @@ export const useUpdateCanvasWidth = () => {
 
     setCanvasWidth(Math.max(selectedBreakpoint.minWidth, minWidth));
   }, [selectedBreakpoint, setCanvasWidth]);
+
+  useSubscribe("canvasWidth", setCanvasWidth);
 
   // Set the initial canvas width based on the selected breakpoint upper bound, which starts where the next breakpoint begins.
   return useCallback(

--- a/apps/designer/app/designer/shared/client-settings/settings.ts
+++ b/apps/designer/app/designer/shared/client-settings/settings.ts
@@ -25,7 +25,7 @@ const read = (): Settings => {
     if (error instanceof Error) {
       sentryException({
         message: "Bad user settings in local storage",
-        extra: {
+        extras: {
           error: error.message,
         },
       });

--- a/apps/designer/app/designer/shared/client-settings/settings.ts
+++ b/apps/designer/app/designer/shared/client-settings/settings.ts
@@ -19,6 +19,7 @@ const read = (): Settings => {
   if (settingsString == null) return {};
 
   try {
+    // @todo add zod schema
     return JSON.parse(settingsString);
   } catch (error) {
     if (error instanceof Error) {

--- a/apps/designer/app/routes/auth/github.tsx
+++ b/apps/designer/app/routes/auth/github.tsx
@@ -20,7 +20,7 @@ export const action: ActionFunction = async ({ request }) => {
     if (error instanceof Error) {
       sentryException({
         message: error.message,
-        extra: {
+        extras: {
           loginMethod: AUTH_PROVIDERS.LOGIN_GITHUB,
         },
       });

--- a/apps/designer/app/routes/auth/google.tsx
+++ b/apps/designer/app/routes/auth/google.tsx
@@ -22,7 +22,7 @@ export const action: ActionFunction = async ({ request }) => {
     if (error instanceof Error) {
       sentryException({
         message: error.message,
-        extra: {
+        extras: {
           loginMethod: AUTH_PROVIDERS.LOGIN_GOOGLE,
         },
       });

--- a/apps/designer/app/routes/canvas/$projectId.tsx
+++ b/apps/designer/app/routes/canvas/$projectId.tsx
@@ -4,6 +4,7 @@ import { Canvas } from "~/canvas";
 import { loadCanvasData, type ErrorData, type CanvasData } from "~/shared/db";
 import env, { Env } from "~/env.server";
 import { ErrorMessage } from "~/shared/error";
+import { sentryException } from "~/shared/sentry";
 
 type Data = (CanvasData | ErrorData) & { env: Env };
 
@@ -19,12 +20,15 @@ export const loader: LoaderFunction = async ({ params }): Promise<Data> => {
     };
   } catch (error) {
     if (error instanceof Error) {
+      const message = `Bad canvas data: \n ${error.message}`;
+      sentryException({ message });
       return {
-        errors: `Loading canvas data error: \n ${error.message}`,
+        errors: message,
         env,
       };
     }
   }
+
   return { errors: "Unexpected error", env };
 };
 

--- a/apps/designer/app/routes/canvas/$projectId.tsx
+++ b/apps/designer/app/routes/canvas/$projectId.tsx
@@ -3,12 +3,11 @@ import type { LoaderFunction } from "@remix-run/node";
 import { Canvas } from "~/canvas";
 import { loadCanvasData, type ErrorData, type CanvasData } from "~/shared/db";
 import env, { Env } from "~/env.server";
+import { ErrorMessage } from "~/shared/error";
 
-type LoaderReturnTypes = Promise<
-  (CanvasData & { env: Env }) | (ErrorData & { env: Env })
->;
+type Data = (CanvasData | ErrorData) & { env: Env };
 
-export const loader: LoaderFunction = async ({ params }): LoaderReturnTypes => {
+export const loader: LoaderFunction = async ({ params }): Promise<Data> => {
   if (params.projectId === undefined) {
     return { errors: "Missing projectId", env };
   }
@@ -30,10 +29,9 @@ export const loader: LoaderFunction = async ({ params }): LoaderReturnTypes => {
 };
 
 const CanvasRoute = () => {
-  const data = useLoaderData<CanvasData | ErrorData>();
-  // @todo how should we treat this kind of errors?
+  const data = useLoaderData<Data>();
   if ("errors" in data) {
-    return <p>{data.errors}</p>;
+    return <ErrorMessage message={data.errors} />;
   }
   return <Canvas data={data} />;
 };

--- a/apps/designer/app/routes/canvas/$projectId.tsx
+++ b/apps/designer/app/routes/canvas/$projectId.tsx
@@ -20,7 +20,7 @@ export const loader: LoaderFunction = async ({ params }): Promise<Data> => {
   } catch (error) {
     if (error instanceof Error) {
       return {
-        errors: error.message,
+        errors: `Loading canvas data error: \n ${error.message}`,
         env,
       };
     }

--- a/apps/designer/app/services/auth.server.ts
+++ b/apps/designer/app/services/auth.server.ts
@@ -63,7 +63,7 @@ if (process.env.DEV_LOGIN === "true") {
           if (error instanceof Error) {
             sentryException({
               message: error.message,
-              extra: {
+              extras: {
                 loginMethod: AUTH_PROVIDERS.LOGIN_DEV,
               },
             });

--- a/apps/designer/app/shared/db/breakpoints.server.ts
+++ b/apps/designer/app/shared/db/breakpoints.server.ts
@@ -3,7 +3,6 @@ import {
   type Project,
   type Tree,
   type Breakpoint,
-  BreakpointSchema,
   BreakpointsSchema,
 } from "@webstudio-is/sdk";
 import ObjectId from "bson-objectid";

--- a/apps/designer/app/shared/db/breakpoints.server.ts
+++ b/apps/designer/app/shared/db/breakpoints.server.ts
@@ -3,7 +3,8 @@ import {
   type Project,
   type Tree,
   type Breakpoint,
-  schema,
+  BreakpointSchema,
+  BreakpointsSchema,
 } from "@webstudio-is/sdk";
 import ObjectId from "bson-objectid";
 import { applyPatches, type Patch } from "immer";
@@ -21,8 +22,8 @@ export const load = async (treeId?: Tree["id"]) => {
   if (breakpoint === null) {
     throw new Error("Breakpoint not found");
   }
-  const values = JSON.parse(breakpoint.values);
-  schema.Breakpoints.parse(values);
+  const values: Array<Breakpoint> = JSON.parse(breakpoint.values);
+  BreakpointsSchema.parse(values);
   return {
     ...breakpoint,
     values,
@@ -39,7 +40,7 @@ export const create = async (
   treeId: Project["id"],
   values: Array<Breakpoint>
 ) => {
-  schema.Breakpoints.parse(values);
+  BreakpointsSchema.parse(values);
 
   const data = {
     treeId,
@@ -74,7 +75,7 @@ export const patch = async (
   if (breakpoints === null) return;
   const nextValues = applyPatches(breakpoints.values, patches);
 
-  schema.Breakpoints.parse(nextValues);
+  BreakpointsSchema.parse(nextValues);
 
   await prisma.breakpoints.update({
     where: { treeId },

--- a/apps/designer/app/shared/db/tree.server.ts
+++ b/apps/designer/app/shared/db/tree.server.ts
@@ -119,6 +119,7 @@ export const patchRoot = async (
     throw new Error(`Tree ${treeId} not found`);
   }
   const root = applyPatches(tree.root, patches);
+  InstanceSchema.parse(root);
   await prisma.tree.update({
     data: { root: JSON.stringify(root) },
     where: { id: treeId },

--- a/apps/designer/app/shared/db/tree.server.ts
+++ b/apps/designer/app/shared/db/tree.server.ts
@@ -1,4 +1,9 @@
-import { type Instance, type Breakpoint, type Tree } from "@webstudio-is/sdk";
+import {
+  type Instance,
+  type Breakpoint,
+  type Tree,
+  InstanceSchema,
+} from "@webstudio-is/sdk";
 import { applyPatches, type Patch } from "immer";
 import { prisma } from "./prisma.server";
 import { createInstance } from "~/shared/tree-utils";
@@ -58,9 +63,10 @@ export const createRootInstance = (breakpoints: Array<Breakpoint>) => {
 };
 
 export const create = async (root: Instance): Promise<DbTree> => {
-  const newRoot = JSON.stringify(root);
+  InstanceSchema.parse(root);
+  const rootString = JSON.stringify(root);
   return await prisma.tree.create({
-    data: { root: newRoot },
+    data: { root: rootString },
   });
 };
 
@@ -71,9 +77,11 @@ export const loadById = async (treeId: string): Promise<Tree | null> => {
 
   if (tree === null) return null;
 
+  const root = JSON.parse(tree.root);
+  InstanceSchema.parse(root);
   return {
     ...tree,
-    root: JSON.parse(tree.root),
+    root,
   };
 };
 

--- a/apps/designer/app/shared/error/error-message.tsx
+++ b/apps/designer/app/shared/error/error-message.tsx
@@ -1,0 +1,14 @@
+import { publish } from "@webstudio-is/sdk";
+import { useEffect } from "react";
+
+export const ErrorMessage = ({ message }: { message: string }) => {
+  useEffect(() => {
+    publish({ type: "canvasWidth", payload: 600 });
+  }, []);
+  return (
+    <div>
+      <h1>Error</h1>
+      <pre>{message}</pre>
+    </div>
+  );
+};

--- a/apps/designer/app/shared/error/index.ts
+++ b/apps/designer/app/shared/error/index.ts
@@ -1,0 +1,1 @@
+export * from "./error-message";

--- a/apps/designer/app/shared/sentry.ts
+++ b/apps/designer/app/shared/sentry.ts
@@ -16,18 +16,18 @@ export const initSentry = ({
 
 type SentryHelperProps = {
   message: string;
-  extra?: Extras;
+  extras?: Extras;
   skipLogging?: boolean;
 };
 
 export const sentryMessage = ({
   message,
-  extra,
+  extras,
   skipLogging = false,
 }: SentryHelperProps) => {
   if (env.SENTRY_DSN) {
     Sentry.withScope((scope) => {
-      if (extra) scope.setExtras(extra);
+      if (extras) scope.setExtras(extras);
       Sentry.captureMessage(message);
     });
   }
@@ -40,12 +40,12 @@ export const sentryMessage = ({
 
 export const sentryException = ({
   message,
-  extra,
+  extras,
   skipLogging = false,
 }: SentryHelperProps) => {
   if (env.SENTRY_DSN) {
     Sentry.withScope((scope) => {
-      if (extra) scope.setExtras(extra);
+      if (extras) scope.setExtras(extras);
       Sentry.captureException(message);
     });
   }

--- a/apps/designer/package.json
+++ b/apps/designer/package.json
@@ -55,7 +55,7 @@
     "@sentry/remix": "^7.5.0",
     "@stitches/react": "^1.2.7",
     "@vercel/node": "^2.4.1",
-    "@webstudio-is/sdk": "0.4.1",
+    "@webstudio-is/sdk": "0.5.0",
     "bson-objectid": "^2.0.2",
     "camelcase": "^6.3.0",
     "debug": "^4.3.4",

--- a/apps/designer/package.json
+++ b/apps/designer/package.json
@@ -135,6 +135,6 @@
   "sideEffects": false,
   "license": "MIT",
   "relativeDependencies": {
-    "@webstudio-is/sdk": "../webstudio-sdk/"
+    "@webstudio-is/sdk": "../../../webstudio-sdk/"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4594,10 +4594,10 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@webstudio-is/sdk@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@webstudio-is/sdk/-/sdk-0.4.1.tgz#fe33f2ab77aedf023b3362c21c5597ab7f2bf573"
-  integrity sha512-Uhf+qBv9sfWMpftyxZ41NW1c9NYmLkLSUeRlYhl0DouQKPahdxM9LFFMXeEHzoBufuKvxAZzIrniNHIb4YP7OQ==
+"@webstudio-is/sdk@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@webstudio-is/sdk/-/sdk-0.5.0.tgz#578f9fae440839605f17b49c016252b4642f1eed"
+  integrity sha512-WTKAHVqiWfcthYeHV/PhlghNsTVlycFDAP+LrCmXugeS07zO9foIX2Dqj7qNcX5R4pewTXc1IBKa+CsvOOQcew==
   dependencies:
     "@prisma/client" "^3.10.0"
     "@stitches/core" "^1.2.7"
@@ -4605,6 +4605,7 @@
     mitt "^3.0.0"
     prisma "^3.10.0"
     react-nano-state "^0.4.0"
+    zod "^3.17.3"
 
 "@xobotyi/scrollbar-width@^1.9.5":
   version "1.9.5"
@@ -16444,6 +16445,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.17.3:
+  version "3.17.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.17.3.tgz#86abbc670ff0063a4588d85a4dcc917d6e4af2ba"
+  integrity sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
This is trying to prevent cases like [this](https://github.com/webstudio-is/webstudio-designer/issues/127) in the future. We need to add zod to all ingoing/outgoing data in all routes

I haven't published SDK package, so if you want to test, will have to use yarn watch:sdk and check out [this](https://github.com/webstudio-is/webstudio-sdk/pull/8) on SDK repo. This workflow is soon going to be a thing of the past.