### PR TITLE
Fix tree flicker

### DIFF
--- a/apps/designer/app/designer/shared/tree/tree.tsx
+++ b/apps/designer/app/designer/shared/tree/tree.tsx
@@ -127,7 +127,7 @@ export const Tree = ({
           <Text>{label}</Text>
         </Button>
       </Flex>
-      <CollapsibleContent>{children}</CollapsibleContent>
+      {children != null && <CollapsibleContent>{children}</CollapsibleContent>}
     </Collapsible.Root>
   );
 };

--- a/apps/designer/app/designer/shared/tree/tree.tsx
+++ b/apps/designer/app/designer/shared/tree/tree.tsx
@@ -64,7 +64,7 @@ export const Tree = ({
     instance.children.length > 1 || typeof instance.children[0] === "object";
 
   const children = useMemo(() => {
-    if (isOpen === false || showChildren === false) {
+    if ((isOpen === false && animate === false) || showChildren === false) {
       return null;
     }
     const children = [];


### PR DESCRIPTION
Related issue: #128

The flicker is caused by broken open/close animation ( https://www.radix-ui.com/docs/primitives/components/collapsible#animating-content-size )

The animation relies on `--radix-collapsible-content-height` CSS variable. In order for animation to work correctly the variable must be present during the animation.

There were two problems:

1. For the nodes that have children we used to remove the children as soon as the node is collapsed, which caused `--radix-collapsible-content-height` to disappear and animation to use incorrect height value.
2. For the nodes without children, the variable `--radix-collapsible-content-height` is never present, so animation was always broken.