### PR TITLE
Speed up CI a bit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-          cache: "npm"
+          cache: "yarn"
           
       - run: yarn install --frozen-lockfile
       - run: yarn prisma generate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,14 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-      - run: yarn install
+        
+      - name: Setup Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: "npm"
+          
+      - run: yarn install --frozen-lockfile
       - run: yarn prisma generate
       - run: yarn checks
       - run: yarn build

--- a/README.md
+++ b/README.md
@@ -15,5 +15,3 @@ Don't hesitate to reach out of you have questions around contributing to the pro
 [Discussions](https://github.com/webstudio-is/webstudio/discussions)
 
 [Discord](https://discord.gg/UNdyrDkq5r)
-
-1

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Don't hesitate to reach out of you have questions around contributing to the pro
 [Discussions](https://github.com/webstudio-is/webstudio/discussions)
 
 [Discord](https://discord.gg/UNdyrDkq5r)
+
+1

--- a/packages/react-sdk/bin/generate-arg-types.ts
+++ b/packages/react-sdk/bin/generate-arg-types.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env -S node --experimental-loader esbuild-node-loader
-
 import path from "path";
 import docgen from "react-docgen-typescript";
 import fg from "fast-glob";

--- a/packages/react-sdk/bin/mdn-data.ts
+++ b/packages/react-sdk/bin/mdn-data.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env -S node --experimental-loader esbuild-node-loader
-
 import { definitionSyntax, type DSNode } from "css-tree";
 import properties from "mdn-data/css/properties.json";
 import units from "mdn-data/css/units.json";

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -6,8 +6,8 @@
   "homepage": "https://webstudio.is",
   "scripts": {
     "build": "yarn build:mdn-data && yarn build:args",
-    "build:mdn-data": "./bin/mdn-data.ts ./src/css",
-    "build:args": "./bin/generate-arg-types.ts './src/components/*.tsx !./src/**/*.stories.tsx'",
+    "build:mdn-data": "node --experimental-loader esbuild-node-loader ./bin/mdn-data.ts ./src/css",
+    "build:args": "node --experimental-loader esbuild-node-loader ./bin/generate-arg-types.ts './src/components/*.tsx !./src/**/*.stories.tsx'",
     "build:prisma": "prisma format && prisma generate",
     "typecheck": "tsc --noEmit",
     "build:lib": "rm -fr lib && tsc",


### PR DESCRIPTION
This speeds up CI runs by about 20 seconds by caching downloaded dependencies.

I was hopping to cache the entire node_modules folder to cut install time to 0, but apparently it's not trivial and not recommended: https://stackoverflow.com/a/68565233/478603