### PR TITLE
Add a tag prop with a list of predefined container tags

### DIFF
--- a/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
@@ -102,20 +102,26 @@ describe("usePropsLogic", () => {
       })
     );
 
-    expect(result.current.userProps.length).toEqual(0);
+    expect(result.current.userProps.length).toEqual(1);
 
     act(() => {
       result.current.addEmptyProp();
     });
 
-    expect(result.current.userProps.length).toEqual(1);
-    expect(result.current.userProps[0]).toMatchObject({ prop: "", value: "" });
+    expect(result.current.userProps.length).toEqual(2);
+    expect(result.current.userProps[1]).toMatchObject({ prop: "", value: "" });
   });
 
   test("should remove a prop", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
         selectedInstanceData: getSelectedInstanceData("Box", [
+          {
+            id: "1",
+            prop: "tag",
+            value: "div",
+            required: true,
+          },
           {
             id: "disabled",
             prop: "disabled",
@@ -130,14 +136,29 @@ describe("usePropsLogic", () => {
       result.current.handleDeleteProp("disabled");
     });
 
-    expect(result.current.userProps.length).toEqual(0);
-    expect(result.current.userProps).toMatchInlineSnapshot(`Array []`);
+    expect(result.current.userProps.length).toEqual(1);
+    expect(result.current.userProps).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "id": "1",
+          "prop": "tag",
+          "required": true,
+          "value": "div",
+        },
+      ]
+    `);
   });
 
   test("should update a prop", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
         selectedInstanceData: getSelectedInstanceData("Box", [
+          {
+            id: "1",
+            prop: "tag",
+            value: "div",
+            required: true,
+          },
           {
             id: "disabled",
             prop: "disabled",
@@ -159,6 +180,12 @@ describe("usePropsLogic", () => {
     expect(result.current.userProps).toMatchInlineSnapshot(`
       Array [
         Object {
+          "id": "1",
+          "prop": "tag",
+          "required": true,
+          "value": "div",
+        },
+        Object {
           "id": "disabled",
           "prop": "disabled2",
           "value": false,
@@ -172,6 +199,12 @@ describe("usePropsLogic", () => {
       usePropsLogic({
         selectedInstanceData: getSelectedInstanceData("Box", [
           {
+            id: "1",
+            prop: "tag",
+            value: "div",
+            required: true,
+          },
+          {
             id: "disabled",
             prop: "disabled",
             value: "true",
@@ -182,15 +215,21 @@ describe("usePropsLogic", () => {
       })
     );
 
-    expect(result.current.userProps.length).toEqual(1);
+    expect(result.current.userProps.length).toEqual(2);
 
     act(() => {
       result.current.handleDeleteProp("disabled");
     });
 
-    expect(result.current.userProps.length).toEqual(1);
+    expect(result.current.userProps.length).toEqual(2);
     expect(result.current.userProps).toMatchInlineSnapshot(`
       Array [
+        Object {
+          "id": "1",
+          "prop": "tag",
+          "required": true,
+          "value": "div",
+        },
         Object {
           "id": "disabled",
           "prop": "disabled",
@@ -206,7 +245,13 @@ describe("usePropsLogic", () => {
       usePropsLogic({
         selectedInstanceData: getSelectedInstanceData("Box", [
           {
-            id: "test",
+            id: "1",
+            prop: "tag",
+            value: "div",
+            required: true,
+          },
+          {
+            id: "2",
             prop: "test",
             value: "test",
             required: true,
@@ -217,13 +262,19 @@ describe("usePropsLogic", () => {
     );
 
     act(() => {
-      result.current.handleChangeProp("test", "prop", "test-example");
+      result.current.handleChangeProp("2", "prop", "test-example");
     });
 
     expect(result.current.userProps).toMatchInlineSnapshot(`
       Array [
         Object {
-          "id": "test",
+          "id": "1",
+          "prop": "tag",
+          "required": true,
+          "value": "div",
+        },
+        Object {
+          "id": "2",
           "prop": "test",
           "required": true,
           "value": "test",
@@ -237,7 +288,13 @@ describe("usePropsLogic", () => {
       usePropsLogic({
         selectedInstanceData: getSelectedInstanceData("Box", [
           {
-            id: "test",
+            id: "1",
+            prop: "tag",
+            value: "div",
+            required: true,
+          },
+          {
+            id: "2",
             prop: "test",
             value: true,
             required: true,
@@ -248,13 +305,19 @@ describe("usePropsLogic", () => {
     );
 
     act(() => {
-      result.current.handleChangeProp("test", "value", false);
+      result.current.handleChangeProp("2", "value", false);
     });
 
     expect(result.current.userProps).toMatchInlineSnapshot(`
       Array [
         Object {
-          "id": "test",
+          "id": "1",
+          "prop": "tag",
+          "required": true,
+          "value": "div",
+        },
+        Object {
+          "id": "2",
           "prop": "test",
           "required": true,
           "value": false,

--- a/apps/designer/docs/test-cases.md
+++ b/apps/designer/docs/test-cases.md
@@ -59,6 +59,7 @@
    - Resizing canvas width in preview mode doesn't limit resize slider to each breakpoint
 
 1. Auth
+
    - Try to access the dashboard when not logged in to make sure you will be redirected to the login page
    - Open the login page when logged in to make sure you are redirected to the dashboard
    - Ensure you can view a built site in an incognito tab
@@ -67,3 +68,9 @@
    - Click on dev login and write a wrong value to make sure you get an error message and stay in the login page.
    - Click on login with GitHub and make sure that you are redirected to the dashboard
    - Click on login with Google and make sure that you are redirected to the dashboard
+
+1. Default properties
+
+   - Add a Box component to the canvas
+   - Open Props panel
+   - See the default tag is provided and can be modified

--- a/packages/react-sdk/src/components/box.props.json
+++ b/packages/react-sdk/src/components/box.props.json
@@ -2200,5 +2200,70 @@
     "control": {
       "type": "text"
     }
+  },
+  "tag": {
+    "defaultValue": {
+      "value": "div"
+    },
+    "description": "",
+    "name": "tag",
+    "declarations": [
+      {
+        "fileName": "src/components/box.tsx",
+        "name": "TypeLiteral"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"div\" | \"address\" | \"article\" | \"aside\" | \"figure\" | \"footer\" | \"header\" | \"main\" | \"nav\" | \"section\"",
+      "value": [
+        {
+          "value": "\"div\""
+        },
+        {
+          "value": "\"address\""
+        },
+        {
+          "value": "\"article\""
+        },
+        {
+          "value": "\"aside\""
+        },
+        {
+          "value": "\"figure\""
+        },
+        {
+          "value": "\"footer\""
+        },
+        {
+          "value": "\"header\""
+        },
+        {
+          "value": "\"main\""
+        },
+        {
+          "value": "\"nav\""
+        },
+        {
+          "value": "\"section\""
+        }
+      ]
+    },
+    "control": {
+      "type": "select"
+    },
+    "options": [
+      "div",
+      "address",
+      "article",
+      "aside",
+      "figure",
+      "footer",
+      "header",
+      "main",
+      "nav",
+      "section"
+    ]
   }
 }

--- a/packages/react-sdk/src/components/box.tsx
+++ b/packages/react-sdk/src/components/box.tsx
@@ -7,6 +7,7 @@ import React, {
 
 const defaultTag = "div";
 
+// We don't want to enable all tags because Box is usually a container and we have specific components for many tags.
 type Props = ComponentProps<typeof defaultTag> & {
   tag?:
     | "div"

--- a/packages/react-sdk/src/components/box.tsx
+++ b/packages/react-sdk/src/components/box.tsx
@@ -1,10 +1,30 @@
-import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
+import React, {
+  createElement,
+  forwardRef,
+  type ElementRef,
+  type ComponentProps,
+} from "react";
 
 const defaultTag = "div";
 
-export const Box = forwardRef<
-  ElementRef<typeof defaultTag>,
-  ComponentProps<typeof defaultTag>
->((props, ref) => <div {...props} ref={ref} />);
+type Props = ComponentProps<typeof defaultTag> & {
+  tag?:
+    | "div"
+    | "header"
+    | "footer"
+    | "nav"
+    | "main"
+    | "section"
+    | "article"
+    | "aside"
+    | "address"
+    | "figure";
+};
+
+export const Box = forwardRef<ElementRef<typeof defaultTag>, Props>(
+  ({ tag = defaultTag, ...props }, ref) => {
+    return createElement(tag as string, { ...props, ref });
+  }
+);
 
 Box.displayName = "Box";

--- a/packages/react-sdk/src/components/heading.tsx
+++ b/packages/react-sdk/src/components/heading.tsx
@@ -12,13 +12,9 @@ type Props = ComponentProps<typeof defaultTag> & {
 };
 
 export const Heading = forwardRef<ElementRef<typeof defaultTag>, Props>(
-  ({ tag, ...props }, ref) => {
+  ({ tag = defaultTag, ...props }, ref) => {
     return createElement(tag as string, { ...props, ref });
   }
 );
-
-Heading.defaultProps = {
-  tag: "h1",
-};
 
 Heading.displayName = "Heading";


### PR DESCRIPTION
Box component should be able to render as a different tag than a div, but it seems there is no not-hardcoded way to select the tag, because you don't want to list all tags there, because for many tags we have separate components and others are not supposed to be used as a container, e.g. span


https://user-images.githubusercontent.com/52824/180659227-3b8ab1ba-e3ae-49f1-9428-8619bff6cc3b.mp4




## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [x] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [x] step by step interaction description and what is expected to happen

## Before merging

- [x] tested locally and on preview environment
- [x] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [x] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
