### PR TITLE
rename worker url env to CDN url

### DIFF
--- a/apps/designer/.env.example
+++ b/apps/designer/.env.example
@@ -11,9 +11,10 @@ FILE_UPLOAD_PATH="uploads"
 # S3 envs
 S3_BUCKET=
 S3_REGION=
+S3_ACL="public-read"
 S3_ENDPOINT=
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 
 # if using r2 this your worker url
-WORKER_URL=
+ASSET_CDN_URL=

--- a/packages/asset-uploader/src/helpers/get-asset-path.test.ts
+++ b/packages/asset-uploader/src/helpers/get-asset-path.test.ts
@@ -22,7 +22,7 @@ describe("getAssetPath", () => {
       ...OLD_ENV,
       S3_ACCESS_KEY_ID: "testid",
       S3_SECRET_ACCESS_KEY: "testkey",
-      WORKER_URL: "",
+      ASSET_CDN_URL: "",
     };
   });
 
@@ -87,7 +87,7 @@ describe("getAssetPath", () => {
       process.env.S3_ENDPOINT = "https://userid.r2.cloudflarestorage.com";
       process.env.S3_BUCKET = "bucket";
       process.env.S3_REGION = "auto";
-      process.env.WORKER_URL = "https://worker-test.workers.dev";
+      process.env.ASSET_CDN_URL = "https://worker-test.workers.dev";
       const { getAssetPath } = require("./get-asset-path");
       expect(
         getAssetPath({

--- a/packages/asset-uploader/src/helpers/get-asset-path.ts
+++ b/packages/asset-uploader/src/helpers/get-asset-path.ts
@@ -13,10 +13,10 @@ export const getAssetPath = (asset: DbAsset) => {
   if (asset.location === Location.REMOTE && s3Envs.success) {
     const s3Url = new URL(s3Envs.data.S3_ENDPOINT);
 
-    if (s3Envs.data.WORKER_URL) {
-      const r2Url = new URL(s3Envs.data.WORKER_URL);
-      r2Url.pathname = asset.name;
-      return r2Url.toString();
+    if (s3Envs.data.ASSET_CDN_URL) {
+      const cndUrl = new URL(s3Envs.data.ASSET_CDN_URL);
+      cndUrl.pathname = asset.name;
+      return cndUrl.toString();
     }
     s3Url.hostname = `${s3Envs.data.S3_BUCKET}.${s3Url.hostname}`;
     s3Url.pathname = asset.name;

--- a/packages/asset-uploader/src/schema.ts
+++ b/packages/asset-uploader/src/schema.ts
@@ -20,8 +20,8 @@ export const s3EnvVariables = z.object({
   S3_ACCESS_KEY_ID: z.string(),
   S3_SECRET_ACCESS_KEY: z.string(),
   S3_BUCKET: z.string(),
-  S3_ACL: z.string().optional().default("public-read"),
-  WORKER_URL: z.string().optional(),
+  S3_ACL: z.string().optional(),
+  ASSET_CDN_URL: z.string().optional(),
 });
 
 export const fsEnvVariables = z.object({

--- a/packages/asset-uploader/src/targets/s3/handler.ts
+++ b/packages/asset-uploader/src/targets/s3/handler.ts
@@ -43,8 +43,8 @@ export const s3UploadHandler: S3UploadHandler = async ({
   const [name, extension] = getFilenameAndExtension(filename);
   const key = encodeURI(`${name}_${Date.now()}.${extension}`);
 
-  // r2 does not have ACL support so in that case we pass nothing there
-  const ACL = s3Envs.WORKER_URL ? {} : { ACL: s3Envs.S3_ACL };
+  // if there is no ACL passed we do not default since some providers do not support it
+  const ACL = s3Envs.S3_ACL ? { ACL: s3Envs.S3_ACL } : {};
 
   const params: PutObjectCommandInput = {
     Bucket: s3Envs.S3_BUCKET,


### PR DESCRIPTION
This PR removes the `WORKER_URL` env and makes it into CDN_URL to be more generic

related https://github.com/webstudio-is/webstudio-designer/issues/37