### PR TITLE
Use only the first four characters in AUTH_SECRET

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 
 ## Before merging
 
-- [ ] tested locally and on preview environment
+- [ ] tested locally and on preview environment (preview dev login: 5de6e)
 - [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
 - [ ] added tests
 - [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory

--- a/apps/designer/app/services/auth.server.ts
+++ b/apps/designer/app/services/auth.server.ts
@@ -55,7 +55,7 @@ if (process.env.DEV_LOGIN === "true") {
     new FormStrategy(async ({ form }) => {
       const secret = form.get("secret");
 
-      if (secret === process.env.AUTH_SECRET) {
+      if (secret === process.env.AUTH_SECRET?.slice(0, 4)) {
         try {
           const user = await db.user.createOrLoginWithDev();
           return user;

--- a/apps/designer/docs/test-cases.md
+++ b/apps/designer/docs/test-cases.md
@@ -64,7 +64,7 @@
    - Open the login page when logged in to make sure you are redirected to the dashboard
    - Ensure you can view a built site in an incognito tab
    - Ensure you can view a forked site in an incognito tab
-   - Click on dev login, add the AUTH_SECRET value in the `.env` value and make sure user is authenticated and redirected to the dashboard
+   - Click on dev login, add the first four characters in AUTH_SECRET value in the `.env` value and make sure user is authenticated and redirected to the dashboard
    - Click on dev login and write a wrong value to make sure you get an error message and stay in the login page.
    - Click on login with GitHub and make sure that you are redirected to the dashboard
    - Click on login with Google and make sure that you are redirected to the dashboard


### PR DESCRIPTION
The idea of this PR is that we only check the first four characters of the `AUTH_SECRET` so that in that way we can share it and make it easier fore anyone to contribute and deploy their branch

Also adds it to the pull request template

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ x] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ x] step by step interaction description and what is expected to happen

## Before merging

- [ x] tested locally and on preview environment (preview dev login: 5de6e)
- [ x] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
