### PR TITLE
Find a valid parent when inserting into selected instance

### DIFF
--- a/apps/designer/app/canvas/shared/instance.test.ts
+++ b/apps/designer/app/canvas/shared/instance.test.ts
@@ -1,0 +1,48 @@
+import { type Instance } from "@webstudio-is/react-sdk";
+import { findInsertLocation } from "./instance";
+
+const tree: Instance = {
+  component: "Body",
+  id: "root",
+  cssRules: [],
+  children: [
+    { component: "Heading", id: "heading1", cssRules: [], children: [] },
+    {
+      component: "Box",
+      id: "box1",
+      cssRules: [],
+      children: [
+        { component: "Box", id: "box2", cssRules: [], children: [] },
+        { component: "Heading", id: "heading2", cssRules: [], children: [] },
+        { component: "Heading", id: "heading3", cssRules: [], children: [] },
+      ],
+    },
+  ],
+};
+
+describe("findInsertLocation", () => {
+  test("if no selected instance, insert into root", () => {
+    expect(findInsertLocation(tree, undefined)).toEqual({
+      parentId: "root",
+      position: "end",
+    });
+  });
+
+  test("if selected instance can accept children insert into it", () => {
+    expect(findInsertLocation(tree, "box1")).toEqual({
+      parentId: "box1",
+      position: "end",
+    });
+  });
+
+  test("if selected instance can not accept children insert into parent", () => {
+    expect(findInsertLocation(tree, "heading1")).toEqual({
+      parentId: "root",
+      position: 1,
+    });
+    expect(findInsertLocation(tree, "heading2")).toEqual({
+      parentId: "box1",
+      position: 2,
+    });
+  });
+});

--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -4,6 +4,7 @@ import {
   type InstanceProps,
   type Instance,
   type Tree,
+  components,
   allUserPropsContainer,
   getBrowserStyle,
   useAllUserProps,
@@ -18,6 +19,7 @@ import {
   insertInstanceMutable,
   findInstanceById,
   reparentInstanceMutable,
+  getInstancePath,
 } from "~/shared/tree-utils";
 import store from "immerhin";
 import {
@@ -48,6 +50,22 @@ export const usePopulateRootInstance = (tree: Tree) => {
   }
 };
 
+const getClosestValidParent = (
+  rootInstance: Instance,
+  instanceId: Instance["id"] | undefined
+) => {
+  if (instanceId === undefined) {
+    return rootInstance;
+  }
+
+  const path = getInstancePath(rootInstance, instanceId);
+  path.reverse();
+  return (
+    path.find((instance) => components[instance.component].canAcceptChild()) ??
+    rootInstance
+  );
+};
+
 export const useInsertInstance = () => {
   const [selectedInstance, setSelectedInstance] = useSelectedInstance();
 
@@ -69,7 +87,8 @@ export const useInsertInstance = () => {
           populatedInstance,
           {
             parentId:
-              dropTarget?.instanceId ?? selectedInstance?.id ?? rootInstance.id,
+              dropTarget?.instanceId ??
+              getClosestValidParent(rootInstance, selectedInstance?.id).id,
             position: dropTarget === undefined ? "end" : dropTarget.position,
           }
         );

--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -51,7 +51,7 @@ export const usePopulateRootInstance = (tree: Tree) => {
   }
 };
 
-const findInsertLocation = (
+export const findInsertLocation = (
   rootInstance: Instance,
   selectedInstanceId: Instance["id"] | undefined
 ): InstanceInsertionSpec => {

--- a/apps/designer/app/canvas/shared/use-drag-drop.ts
+++ b/apps/designer/app/canvas/shared/use-drag-drop.ts
@@ -7,6 +7,7 @@ import { getInstancePath, createInstance } from "~/shared/tree-utils";
 import {
   findInstanceByElement,
   getInstanceElementById,
+  getInstanceIdFromElement,
 } from "~/shared/dom-utils";
 import {
   type DropTarget,
@@ -138,15 +139,9 @@ export const useDragAndDrop = () => {
     },
 
     getValidChildren: (parent) => {
-      if (!(parent instanceof HTMLBodyElement)) {
-        return parent.children;
-      }
-      return Array.from(parent.children).filter((child) => {
-        return (
-          !(child instanceof HTMLScriptElement) &&
-          !(child instanceof HTMLLinkElement)
-        );
-      });
+      return Array.from(parent.children).filter(
+        (child) => getInstanceIdFromElement(child) !== undefined
+      );
     },
   });
 

--- a/apps/designer/app/canvas/shared/use-drag-drop.ts
+++ b/apps/designer/app/canvas/shared/use-drag-drop.ts
@@ -136,6 +136,18 @@ export const useDragAndDrop = () => {
         },
       });
     },
+
+    getValidChildren: (parent) => {
+      if (!(parent instanceof HTMLBodyElement)) {
+        return parent.children;
+      }
+      return Array.from(parent.children).filter((child) => {
+        return (
+          !(child instanceof HTMLScriptElement) &&
+          !(child instanceof HTMLLinkElement)
+        );
+      });
+    },
   });
 
   const dragHandlers = useDrag<Instance>({

--- a/apps/designer/app/canvas/shared/use-drag-drop.ts
+++ b/apps/designer/app/canvas/shared/use-drag-drop.ts
@@ -280,14 +280,14 @@ export const useDragAndDrop = () => {
             "insertInstance",
             {
               instance: Instance;
-              dropTarget: { instanceId: Instance["id"]; position: number };
+              dropTarget: { parentId: Instance["id"]; position: number };
             }
           >({
             type: "insertInstance",
             payload: {
               instance: createInstance({ component: dragItem.component }),
               dropTarget: {
-                instanceId: dropTarget.data.id,
+                parentId: dropTarget.data.id,
                 position: dropTarget.indexWithinChildren,
               },
             },

--- a/apps/designer/app/shared/tree-utils/get-instance-path.test.ts
+++ b/apps/designer/app/shared/tree-utils/get-instance-path.test.ts
@@ -1,5 +1,8 @@
 import { type Instance } from "@webstudio-is/react-sdk";
-import { getInstancePath } from "./get-instance-path";
+import {
+  getInstancePath,
+  getInstancePathWithPositions,
+} from "./get-instance-path";
 
 const getIds = (array: Array<{ id: string }>) => array.map((item) => item.id);
 
@@ -67,5 +70,89 @@ describe("Get instance path", () => {
     expect(getIds(path1)).toEqual(["1", "2b", "3b"]);
     const path2 = getInstancePath(instance, "3a");
     expect(getIds(path2)).toEqual(["1", "2a", "3a"]);
+  });
+});
+
+const getIdAndPosition = (
+  array: Array<{ instance: { id: string }; position: number }>
+) => array.map((item) => [item.instance.id, item.position]);
+
+describe("Get instance path with positions", () => {
+  test("single possible path", () => {
+    const instance: Instance = {
+      component: "Box",
+      id: "1",
+      cssRules: [],
+      children: [
+        {
+          component: "Box",
+          id: "2",
+          cssRules: [],
+          children: [
+            {
+              component: "Box",
+              id: "3",
+              cssRules: [],
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+    const path = getInstancePathWithPositions(instance, "3");
+    expect(getIdAndPosition(path)).toEqual([
+      ["1", 0],
+      ["2", 0],
+      ["3", 0],
+    ]);
+  });
+
+  test("two possible paths", () => {
+    const instance: Instance = {
+      component: "Box",
+      id: "1",
+      cssRules: [],
+      children: [
+        {
+          component: "Box",
+          id: "2a",
+          cssRules: [],
+          children: [
+            {
+              component: "Box",
+              id: "3a",
+              cssRules: [],
+              children: [],
+            },
+          ],
+        },
+        {
+          component: "Box",
+          id: "2b",
+          cssRules: [],
+          children: [
+            {
+              component: "Box",
+              id: "3b",
+              cssRules: [],
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+    const path1 = getInstancePathWithPositions(instance, "3b");
+    expect(getIdAndPosition(path1)).toEqual([
+      ["1", 0],
+      ["2b", 1],
+      ["3b", 0],
+    ]);
+
+    const path2 = getInstancePathWithPositions(instance, "3a");
+    expect(getIdAndPosition(path2)).toEqual([
+      ["1", 0],
+      ["2a", 0],
+      ["3a", 0],
+    ]);
   });
 });

--- a/apps/designer/app/shared/tree-utils/get-instance-path.ts
+++ b/apps/designer/app/shared/tree-utils/get-instance-path.ts
@@ -24,3 +24,29 @@ export const getInstancePath = (
 
   return path.reverse();
 };
+
+export const getInstancePathWithPositions = (
+  instance: Instance,
+  instanceId: Instance["id"]
+) => {
+  const path = [];
+
+  const find = (instance: Instance) => {
+    if (instance.id === instanceId) return true;
+    for (let i = 0; i < instance.children.length; i++) {
+      const child = instance.children[i];
+      if (typeof child === "string") continue;
+      const found = find(child);
+      if (found) {
+        path.push({ instance: child, position: i });
+        return true;
+      }
+    }
+  };
+
+  if (find(instance)) {
+    path.push({ instance, position: 0 });
+  }
+
+  return path.reverse();
+};

--- a/apps/designer/docs/test-cases.md
+++ b/apps/designer/docs/test-cases.md
@@ -14,6 +14,15 @@
    - Drag a box to the bottom edge - check if parent box gets outlined and insertion happened after that dragged over box inside that outlined parent
    - Drag a box to the top edge - check if parent box gets outlined and insertion happened before that dragged over box inside that outlined parent
 
+1. Create instance by clicking on a component
+
+   - Make sure no instance is selected (no outline in the canvas)
+   - Click on a component in the panel - check that it's inserted at the end of the root instance
+   - Select an istance that can accept children (e.g. Box), by clicking on it on the canvas
+   - Click on a component in the panel - check that it's inserted at the end of the selected instance
+   - Select an instance that cannot accept children (e.g. Heading), but choose one that is not the last child of its parent
+   - Click on a component in the panel - check that it's inserted in the parent of the selected instance, and that it's positioned right after the selected instance
+
 1. Styles apply
 
    - Select an instance

--- a/packages/design-system/src/components/primitives/dnd/dom-utils.ts
+++ b/packages/design-system/src/components/primitives/dnd/dom-utils.ts
@@ -38,7 +38,10 @@ export const getLocalChildrenOrientation = (
   return getRectsOrientation(previous, current, next);
 };
 
-export const getChildrenRects = (parent: Element) => {
+export const getChildrenRects = (
+  parent: Element,
+  children: Element[] | HTMLCollection
+) => {
   const parentRect = parent.getBoundingClientRect();
 
   // We convert to relative coordinates to be able to store the result in cache.
@@ -50,7 +53,7 @@ export const getChildrenRects = (parent: Element) => {
     height: rect.height,
   });
 
-  return Array.from(parent.children).map((child) =>
+  return Array.from(children).map((child) =>
     toRelativeCoordinates(child.getBoundingClientRect())
   );
 };

--- a/packages/design-system/src/components/primitives/dnd/use-drop.ts
+++ b/packages/design-system/src/components/primitives/dnd/use-drop.ts
@@ -45,6 +45,10 @@ export type UseDropProps<Data> = {
   ) => PartialDropTarget<Data>;
 
   onDropTargetChange: (dropTarget: DropTarget<Data>) => void;
+
+  // Allows you to customize children
+  // that will be used to determine placement and indexWithinChildren
+  getValidChildren?: (parent: Element) => Element[] | HTMLCollection;
 };
 
 export type UseDropHandlers = {
@@ -81,7 +85,11 @@ export const useDrop = <Data>(props: UseDropProps<Data>): UseDropHandlers => {
       if (fromCache !== undefined) {
         return fromCache;
       }
-      const result = getChildrenRects(parent);
+      const children =
+        latestProps.current.getValidChildren !== undefined
+          ? latestProps.current.getValidChildren(parent)
+          : parent.children;
+      const result = getChildrenRects(parent, children);
       state.current.childrenRectsCache.set(parent, result);
       return result;
     };

--- a/packages/design-system/src/components/primitives/dnd/use-drop.ts
+++ b/packages/design-system/src/components/primitives/dnd/use-drop.ts
@@ -81,15 +81,13 @@ export const useDrop = <Data>(props: UseDropProps<Data>): UseDropHandlers => {
   // We want to return a stable object to avoid re-renders when it's a dependency
   return useMemo(() => {
     const getChildrenRectsMemoized = (parent: Element) => {
+      const { getValidChildren = (parent) => parent.children } =
+        latestProps.current;
       const fromCache = state.current.childrenRectsCache.get(parent);
       if (fromCache !== undefined) {
         return fromCache;
       }
-      const children =
-        latestProps.current.getValidChildren !== undefined
-          ? latestProps.current.getValidChildren(parent)
-          : parent.children;
-      const result = getChildrenRects(parent, children);
+      const result = getChildrenRects(parent, getValidChildren(parent));
       state.current.childrenRectsCache.set(parent, result);
       return result;
     };


### PR DESCRIPTION
- This fixes the remaining todo item in #7
- Also fixed a bug with DnD when `<body>` is a drop target

### step by step interaction description and what is expected to happen

When inserting an instance by clicking on a button in the panel instead of dragging it, the instance should be inserted in the current selected instance.

But if the current selected instance cannot accept a child, for example if it's a Heading, then the new instance should be inserted next to the selected instance.

-------------------------------

## Before requesting a review

- [x] if the PR is WIP - use draft mode
- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")
- [x] what kind of review is needed?
  - [x] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [x] step by step interaction description and what is expected to happen

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [x] added tests
- [x] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
