### PR TITLE
Fix migration yarn scripts

### DIFF
--- a/apps/designer/package.json
+++ b/apps/designer/package.json
@@ -14,7 +14,6 @@
     "prettier": "prettier \"*.{js,md,json,ts}\" \"{docs,app}/**/*.{js,md,json,ts}\"",
     "storybook:run": "start-storybook -p 6006",
     "storybook:build": "build-storybook",
-    "migrations": "migrations --dev",
     "migrate": "migrations migrate --force --dev",
     "ci:migrate": "migrations migrate --force"
   },

--- a/apps/designer/package.json
+++ b/apps/designer/package.json
@@ -14,7 +14,6 @@
     "prettier": "prettier \"*.{js,md,json,ts}\" \"{docs,app}/**/*.{js,md,json,ts}\"",
     "storybook:run": "start-storybook -p 6006",
     "storybook:build": "build-storybook",
-    "migrate": "migrations migrate --force --dev",
     "ci:migrate": "migrations migrate --force"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "migrate": "turbo run migrate",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prepare": "husky install",
-    "storybook": "turbo run storybook:run"
+    "storybook": "turbo run storybook:run",
+    "migrations": "cd apps/designer && migrations --dev"
   },
   "devDependencies": {
     "@webstudio-is/eslint-config-custom": "*",


### PR DESCRIPTION
1. Moved the `"migrations"` script from app to root
2. Deleted `"migrate"` script from root as now `migrations migrate` can be used instead (see https://github.com/webstudio-is/webstudio/pull/17 )

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
