### PR TITLE
Fix a bug where navigator attempts to show `string` children of Bold and crashes 

### DIFF
--- a/apps/designer/app/designer/shared/tree/index.tsx
+++ b/apps/designer/app/designer/shared/tree/index.tsx
@@ -23,9 +23,14 @@ const instanceRelatedProps = {
     return components[item.component].canAcceptChildren;
   },
   getItemChildren(item: Instance) {
-    // Only content editable components can have `string` children
-    // and this cab be a hot path for performance.
-    if (components[item.component].isContentEditable === false) {
+    const component = components[item.component];
+
+    // We want to avoid calling .filter() unnecessarily, because this is a hot path for performance.
+    // We rely on the fact that only content editable or inline components may have `string` children.
+    if (
+      component.isContentEditable === false &&
+      component.isInlineOnly === false
+    ) {
       return item.children as Instance[];
     }
 


### PR DESCRIPTION
Fixes #257

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
