### PR TITLE
Fix critical css for global styles, reset styles for ssr

### DIFF
--- a/apps/designer/app/critical-css.ts
+++ b/apps/designer/app/critical-css.ts
@@ -1,24 +1,40 @@
 import {
   insertCriticalCss as insert,
   getCssText as getCanvasCssText,
+  resetCss as resetCanvasCss,
 } from "@webstudio-is/react-sdk";
-import { getCssText as getDesignerCssText } from "@webstudio-is/design-system";
+import {
+  getCssText as getDesignerCssText,
+  reset as resetDesignerCss,
+} from "@webstudio-is/design-system";
 import config from "./config";
 
-const getCssTextFunctions = {
-  [config.previewPath]: getCanvasCssText,
-  [config.canvasPath]: getCanvasCssText,
-  [config.designerPath]: getDesignerCssText,
-  [config.dashboardPath]: getDesignerCssText,
-  [config.loginPath]: getDesignerCssText,
+const flushCanvas = () => {
+  const css = getCanvasCssText();
+  resetCanvasCss();
+  return css;
 };
 
-const getCssTextFunction = (url: string) => {
+const flushDesigner = () => {
+  const css = getDesignerCssText();
+  resetDesignerCss();
+  return css;
+};
+
+const flushFunctions = {
+  [config.previewPath]: flushCanvas,
+  [config.canvasPath]: flushCanvas,
+  [config.designerPath]: flushDesigner,
+  [config.dashboardPath]: flushDesigner,
+  [config.loginPath]: flushDesigner,
+};
+
+const getFlushFunction = (url: string) => {
   const { pathname } = new URL(url);
-  let path: keyof typeof getCssTextFunctions;
-  for (path in getCssTextFunctions) {
+  let path: keyof typeof flushFunctions;
+  for (path in flushFunctions) {
     if (pathname.indexOf(path) === 0) {
-      return getCssTextFunctions[path];
+      return flushFunctions[path];
     }
   }
   return getCanvasCssText;
@@ -30,5 +46,5 @@ const getCssTextFunction = (url: string) => {
  * @todo find a better way
  */
 export const insertCriticalCss = (markup: string, url: string): string => {
-  return insert(markup, getCssTextFunction(url));
+  return insert(markup, getFlushFunction(url));
 };

--- a/packages/react-sdk/src/stitches/css.ts
+++ b/packages/react-sdk/src/stitches/css.ts
@@ -1,6 +1,6 @@
 import {
   createStitches,
-  globalCss,
+  globalCss as globalCssImport,
   type CSS,
   css as createCss,
 } from "@stitches/core";
@@ -11,6 +11,8 @@ let media = {};
 // @todo needs fixing
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let stitches: any;
+
+export { type CSS };
 
 export const getCachedConfig = () => {
   if (stitches === undefined) {
@@ -23,11 +25,16 @@ export const css: typeof createCss = (...args) => {
   return getCachedConfig().css(...args);
 };
 
-export { globalCss };
-export { type CSS };
+export const globalCss: typeof globalCssImport = (...args) => {
+  return getCachedConfig().globalCss(...args);
+};
 
 export const getCssText = (): string => {
   return getCachedConfig().getCssText();
+};
+
+export const resetCss = () => {
+  getCachedConfig().reset();
 };
 
 export const setBreakpoints = (breakpoints: Array<Breakpoint>) => {


### PR DESCRIPTION
We had 2 problems in https://github.com/webstudio-is/webstudio-designer/issues/305

1. globalStyles wasn't using the same stitches instance we were using to get the ssr'd styles for critical css
2. we weren't resetting the instance, which would be a potential problem for ssr with load

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
