### PR TITLE
fix: http-client should not have process.env

### DIFF
--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webstudio-is/http-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Webstudio HTTP Client",
   "author": "Webstudio <github@webstudio.is>",
   "homepage": "https://webstudio.is",

--- a/packages/http-client/src/index.test.ts
+++ b/packages/http-client/src/index.test.ts
@@ -2,21 +2,27 @@ import { loadProject } from "./index";
 
 const existingProject = "ab3619d3-831f-46f8-abb6-609558cffd99";
 const notPublishedProject = "7ec397c6-b3d0-4967-9073-9d83623fcf8e";
+const webstudioAPIUrl = "http://localhost:3000";
 const nonExistingProject = "1";
 
 describe("getProjectDetails", () => {
   test("loads existing project", async () => {
-    const response = await loadProject({ projectId: existingProject });
+    const response = await loadProject({
+      webstudioAPIUrl,
+      projectId: existingProject,
+    });
     expect(response.tree.id).toBeTruthy();
   });
   test("loads non-existing project", async () => {
     const response = await loadProject({
+      webstudioAPIUrl,
       projectId: nonExistingProject,
     });
     expect(response.tree.errors).toBe("Project required");
   });
   test("loads not published project", async () => {
     const response = await loadProject({
+      webstudioAPIUrl,
       projectId: notPublishedProject,
     });
     expect(response.tree.errors).toBe(

--- a/packages/http-client/src/index.test.ts
+++ b/packages/http-client/src/index.test.ts
@@ -1,32 +1,24 @@
 import { loadProject } from "./index";
 
-const existingProject = "ab3619d3-831f-46f8-abb6-609558cffd99";
-const notPublishedProject = "7ec397c6-b3d0-4967-9073-9d83623fcf8e";
-const webstudioAPIUrl = "http://localhost:3000";
-const nonExistingProject = "1";
+const existingProjectId = "ab3619d3-831f-46f8-abb6-609558cffd99";
+const notPublishedProjectId = "7ec397c6-b3d0-4967-9073-9d83623fcf8e";
+const apiUrl = "http://localhost:3000";
 
 describe("getProjectDetails", () => {
   test("loads existing project", async () => {
     const response = await loadProject({
-      webstudioAPIUrl,
-      projectId: existingProject,
+      apiUrl,
+      projectId: existingProjectId,
     });
     expect(response.tree.id).toBeTruthy();
   });
-  test("loads non-existing project", async () => {
-    const response = await loadProject({
-      webstudioAPIUrl,
-      projectId: nonExistingProject,
-    });
-    expect(response.tree.errors).toBe("Project required");
-  });
   test("loads not published project", async () => {
     const response = await loadProject({
-      webstudioAPIUrl,
-      projectId: notPublishedProject,
+      apiUrl,
+      projectId: notPublishedProjectId,
     });
     expect(response.tree.errors).toBe(
-      "Site needs to be published, production tree ID is null."
+      "Project 7ec397c6-b3d0-4967-9073-9d83623fcf8e needs to be published first"
     );
   });
 });

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -2,18 +2,18 @@ import fetch from "isomorphic-fetch";
 import type { Includes, Project } from "./index.d";
 
 export const loadProject = async ({
-  webstudioAPIUrl = null,
+  apiUrl,
   projectId,
   include = { tree: true, props: true, breakpoints: true },
 }: {
-  webstudioAPIUrl: string | null;
+  apiUrl: string;
   projectId: string;
   include?: Includes<boolean>;
 }): Promise<Project> => {
-  if (!webstudioAPIUrl) {
+  if (apiUrl === undefined) {
     throw new Error("Webstudio API URL is required.");
   }
-  const baseUrl = new URL("/", `${webstudioAPIUrl}`);
+  const baseUrl = new URL(`${apiUrl}`);
   const treeUrl = new URL(`/rest/tree/${projectId}`, baseUrl);
   const propsUrl = new URL(`/rest/props/${projectId}`, baseUrl);
   const breakpointsUrl = new URL(`/rest/breakpoints/${projectId}`, baseUrl);

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -1,18 +1,19 @@
 import fetch from "isomorphic-fetch";
 import type { Includes, Project } from "./index.d";
 
-const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-
 export const loadProject = async ({
+  webstudioAPIUrl = null,
   projectId,
-  host = process.env.DESIGNER_HOST || "localhost:3000",
   include = { tree: true, props: true, breakpoints: true },
 }: {
+  webstudioAPIUrl: string | null;
   projectId: string;
-  host?: string;
   include?: Includes<boolean>;
 }): Promise<Project> => {
-  const baseUrl = new URL("/", `${protocol}://${host}`);
+  if (!webstudioAPIUrl) {
+    throw new Error("Webstudio API URL is required.");
+  }
+  const baseUrl = new URL("/", `${webstudioAPIUrl}`);
   const treeUrl = new URL(`/rest/tree/${projectId}`, baseUrl);
   const propsUrl = new URL(`/rest/props/${projectId}`, baseUrl);
   const breakpointsUrl = new URL(`/rest/breakpoints/${projectId}`, baseUrl);


### PR DESCRIPTION
`process.env` is not defined in the worker state, so URL is defined in a different way.
