### PR TITLE
Fix stale unit change in scrub logic

### DIFF
--- a/apps/designer/app/designer/features/style-panel/controls/text/text-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/text/text-control.tsx
@@ -18,22 +18,22 @@ export const TextControl = ({
 
   const setValue = setProperty(styleConfig.property);
 
-  const [ephemeralValue, setEphemeralValue] = useState<StyleValue | null>(null);
+  const [currerntValue, setCurrentValue] = useState<StyleValue>();
 
   return (
     <CssValueInput
       property={styleConfig.property}
-      value={ephemeralValue ?? value}
+      value={currerntValue ?? value}
       keywords={styleConfig.items.map((item) => ({
         type: "keyword",
         value: item.name,
       }))}
       onChange={(styleValue) => {
-        setEphemeralValue(styleValue);
+        setCurrentValue(styleValue);
         setValue(toValue(styleValue), { isEphemeral: true });
       }}
       onItemHighlight={(styleValue) => {
-        const nextValue = styleValue ?? ephemeralValue ?? value;
+        const nextValue = styleValue ?? currerntValue ?? value;
         if (nextValue) {
           setValue(toValue(nextValue), {
             isEphemeral: true,
@@ -41,7 +41,7 @@ export const TextControl = ({
         }
       }}
       onChangeComplete={(styleValue) => {
-        setEphemeralValue(null);
+        setCurrentValue(undefined);
         setValue(toValue(styleValue));
       }}
     />

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -83,15 +83,11 @@ const useScrub = (options: {
 }) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const optionsRef = useRef(options);
-
-  useEffect(() => {
-    optionsRef.current = options;
-  }, [options]);
+  optionsRef.current = options;
 
   useEffect(() => {
     const { value, onChange, onChangeComplete } = optionsRef.current;
     if (value.type !== "unit" || inputRef.current === null) return;
-
     const scrub = numericScrubControl(inputRef.current, {
       initialValue: value.value,
       onValueInput(event) {
@@ -109,7 +105,7 @@ const useScrub = (options: {
     });
 
     return scrub.disconnectedCallback;
-  }, [options.value.type]);
+  }, [options.value.type, options.value?.unit]);
 
   return inputRef;
 };


### PR DESCRIPTION
https://github.com/webstudio-is/webstudio-designer/issues/333

Reproduction: 

1. Click on any unit text control
2. Select a different unit
3. Start scrubbing 
4. See unit is not reverted back to previous value

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
