### PR TITLE
Enforce the version of Yarn

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.19.cjs


### PR DESCRIPTION
According to this https://yarnpkg.com/cli/set/version this is +- recommended way to use the same package yarn version.
Having that my system yarn version is berry this solves issues with yarn for me and for anyone else with non 1.xx yarn.