### PR TITLE
Use corepack to setup yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "yarn@1.22.19",
   "name": "turbo",
   "version": "0.0.0",
   "private": true,
@@ -32,7 +33,7 @@
   },
   "engines": {
     "npm": ">=7.0.0",
-    "node": "16"
+    "node": ">=16.9"
   },
   "dependencies": {
     "golden-fleece": "^1.0.9"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "typescript": "4.7.4"
   },
   "engines": {
-    "npm": ">=7.0.0",
     "node": ">=16.9 <17"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typescript": "4.7.4"
   },
   "engines": {
-    "node": ">=16.9 <17"
+    "node": "16"
   },
   "dependencies": {
     "golden-fleece": "^1.0.9"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "engines": {
     "npm": ">=7.0.0",
-    "node": ">=16.9"
+    "node": ">=16.9 <17"
   },
   "dependencies": {
     "golden-fleece": "^1.0.9"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "typescript": "4.7.4"
   },
   "engines": {
-    "node": "16"
+    "node": "16",
+    "yarn": "1.22"
   },
   "dependencies": {
     "golden-fleece": "^1.0.9"


### PR DESCRIPTION
See https://nodejs.org/api/corepack.html

Corepack is a way to setup specific yarn/pnpm version on the fly. Builtin with Node 16.9+

Requires to run `corepack enable`

Replaces https://github.com/webstudio-is/webstudio-designer/pull/370
