### PR TITLE
Hydrate text editor instances

### DIFF
--- a/apps/designer/app/canvas/features/wrapper-component/text-editor/nodes/node-instance.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/text-editor/nodes/node-instance.tsx
@@ -10,7 +10,6 @@ import { InlineWrapperComponentDev } from "../../wrapper-component";
 type Options = {
   instance: Instance;
   text: string;
-  isNew: boolean;
 };
 
 export type SerializedInstanceNode = SerializedTextNode & Options;

--- a/apps/designer/app/canvas/features/wrapper-component/text-editor/plugins/plugin-instance.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/text-editor/plugins/plugin-instance.tsx
@@ -45,7 +45,6 @@ export const InstancePlugin = ({ children }: InstancePluginProps) => {
           const instanceNode = $createInstanceNode({
             instance,
             text,
-            isNew: true,
           });
           selection.insertNodes([instanceNode]);
           // Dirty hack. When clicking on toolbar outside of the iframe, we are loosing focus.

--- a/apps/designer/app/canvas/features/wrapper-component/text-editor/utils/to-lexical-nodes.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/text-editor/utils/to-lexical-nodes.tsx
@@ -31,7 +31,6 @@ export const toLexicalNodes = (children: Instance["children"]) => {
     const instanceNode = $createInstanceNode({
       instance: child,
       text,
-      isNew: false,
     });
     paragraph.append(instanceNode);
   }

--- a/apps/designer/app/canvas/features/wrapper-component/text-editor/utils/to-updates.test.ts
+++ b/apps/designer/app/canvas/features/wrapper-component/text-editor/utils/to-updates.test.ts
@@ -113,6 +113,7 @@ describe("toUpdates", () => {
       "a ",
       {
         id: "62bcc02160a439686c7eabde",
+        component: "Bold",
         text: "b",
       },
       "c",

--- a/apps/designer/app/canvas/features/wrapper-component/text-editor/utils/to-updates.ts
+++ b/apps/designer/app/canvas/features/wrapper-component/text-editor/utils/to-updates.ts
@@ -23,19 +23,11 @@ export const toUpdates = (
   }
 
   if (node.type === "instance" && "instance" in node) {
-    if ("isNew" in node && node.isNew === true) {
-      updates.push({
-        id: node.instance.id,
-        text: node.text,
-        component: node.instance.component,
-        createInstance: true,
-      });
-    } else {
-      updates.push({
-        id: node.instance.id,
-        text: node.text,
-      });
-    }
+    updates.push({
+      id: node.instance.id,
+      text: node.text,
+      component: node.instance.component,
+    });
   }
 
   if ("children" in node) {

--- a/apps/designer/app/shared/tree-utils/set-instance-children.ts
+++ b/apps/designer/app/shared/tree-utils/set-instance-children.ts
@@ -24,28 +24,18 @@ export const setInstanceChildrenMutable = (
       children.push(update);
       continue;
     }
-    // We need to create an instance
-    if ("createInstance" in update) {
-      const childInstance = createInstance({
+    // create new child or update existing
+    let childInstance = findInstanceById(instance, update.id);
+    if (childInstance == null) {
+      childInstance = createInstance({
         id: update.id,
         component: update.component,
         children: [update.text],
       });
       children.push(childInstance);
-      continue;
-    }
-
-    // Set text as a single child of a child instance
-    if ("text" in update) {
-      const childInstance = findInstanceById(instance, update.id);
-      // It should be impossible to have not found that instance
-      if (childInstance === undefined) continue;
+    } else {
       children.push({ ...childInstance, children: [update.text] });
-      continue;
     }
-
-    // It's a new instance.
-    children.push(update);
   }
 
   instance.children = children;

--- a/packages/project/src/shared/tree-utils/set-instance-children.ts
+++ b/packages/project/src/shared/tree-utils/set-instance-children.ts
@@ -24,28 +24,18 @@ export const setInstanceChildrenMutable = (
       children.push(update);
       continue;
     }
-    // We need to create an instance
-    if ("createInstance" in update) {
-      const childInstance = createInstance({
+    // create new child or update existing
+    let childInstance = findInstanceById(instance, update.id);
+    if (childInstance == null) {
+      childInstance = createInstance({
         id: update.id,
         component: update.component,
         children: [update.text],
       });
       children.push(childInstance);
-      continue;
-    }
-
-    // Set text as a single child of a child instance
-    if ("text" in update) {
-      const childInstance = findInstanceById(instance, update.id);
-      // It should be impossible to have not found that instance
-      if (childInstance === undefined) continue;
+    } else {
       children.push({ ...childInstance, children: [update.text] });
-      continue;
     }
-
-    // It's a new instance.
-    children.push(update);
   }
 
   instance.children = children;

--- a/packages/react-sdk/src/tree/create-elements-tree.tsx
+++ b/packages/react-sdk/src/tree/create-elements-tree.tsx
@@ -8,15 +8,7 @@ import { SessionStoragePolyfill } from "./session-storage-polyfill";
 
 export type ChildrenUpdates = Array<
   | string
-  // Updates an instance child
-  | { id: Instance["id"]; text: string }
-  // Creates a new child instance
-  | {
-      id: Instance["id"];
-      text: string;
-      component: Instance["component"];
-      createInstance: true;
-    }
+  | { id: Instance["id"]; component: Instance["component"]; text: string }
 >;
 
 export type OnChangeChildren = (change: {


### PR DESCRIPTION
isNew and createInstance flags makes state management more complex. Instead tree of instances updates should be idempotent. This will let us do more straightforward mapping from lexical nodes to designer tree.