### PR TITLE
Prepare text toolbar to new text editor

### DIFF
--- a/apps/designer/app/canvas/features/wrapper-component/text-editor/example-text-editor.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/text-editor/example-text-editor.tsx
@@ -28,7 +28,7 @@ const Menu = () => {
       <Button
         onClick={() => {
           publish({
-            type: "textToolbarFormat",
+            type: "formatTextToolbar",
             payload: "bold",
           });
         }}
@@ -38,7 +38,7 @@ const Menu = () => {
       <Button
         onClick={() => {
           publish({
-            type: "textToolbarFormat",
+            type: "formatTextToolbar",
             payload: "italic",
           });
         }}
@@ -49,7 +49,7 @@ const Menu = () => {
         onClick={() => {
           const instance = createInstance({ component: "Link" });
           publish({
-            type: "textToolbarFormat",
+            type: "formatTextToolbar",
             payload: "link",
           });
           const url = prompt("Enter url");

--- a/apps/designer/app/canvas/features/wrapper-component/text-editor/example-text-editor.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/text-editor/example-text-editor.tsx
@@ -11,12 +11,6 @@ import { config } from "./config";
 import Editor from "./editor";
 import { publish } from "~/shared/pubsub";
 
-declare module "~/shared/pubsub" {
-  export interface PubsubMap {
-    insertInlineInstance: Instance;
-  }
-}
-
 type ExampleTextEditorProps = {
   onChange: (state: ChildrenUpdates) => void;
 };
@@ -34,8 +28,8 @@ const Menu = () => {
       <Button
         onClick={() => {
           publish({
-            type: "insertInlineInstance",
-            payload: createInstance({ component: "Bold" }),
+            type: "textToolbarFormat",
+            payload: "bold",
           });
         }}
       >
@@ -44,8 +38,8 @@ const Menu = () => {
       <Button
         onClick={() => {
           publish({
-            type: "insertInlineInstance",
-            payload: createInstance({ component: "Italic" }),
+            type: "textToolbarFormat",
+            payload: "italic",
           });
         }}
       >
@@ -55,8 +49,8 @@ const Menu = () => {
         onClick={() => {
           const instance = createInstance({ component: "Link" });
           publish({
-            type: "insertInlineInstance",
-            payload: instance,
+            type: "textToolbarFormat",
+            payload: "link",
           });
           const url = prompt("Enter url");
           if (url === null) return;

--- a/apps/designer/app/canvas/features/wrapper-component/text-editor/plugins/plugin-instance.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/text-editor/plugins/plugin-instance.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { type Instance } from "@webstudio-is/react-sdk";
 import { useSubscribe } from "~/shared/pubsub";
+import { createInstance } from "~/shared/tree-utils";
 import { $createInstanceNode, InstanceNode } from "../nodes/node-instance";
 import {
   createCommand,
@@ -67,11 +68,23 @@ export const InstancePlugin = ({ children }: InstancePluginProps) => {
     });
   }, [editor, children]);
 
-  useSubscribe("insertInlineInstance", (payload) => {
-    editor.dispatchCommand<LexicalCommand<Instance>>(
-      INSERT_INSTANCE_COMMAND,
-      payload
-    );
+  useSubscribe("textToolbarFormat", (type) => {
+    let component: null | "Bold" | "Italic" | "Link" = null;
+    if (type === "bold") {
+      component = "Bold";
+    }
+    if (type === "italic") {
+      component = "Italic";
+    }
+    if (type === "link") {
+      component = "Link";
+    }
+    if (component) {
+      editor.dispatchCommand<LexicalCommand<Instance>>(
+        INSERT_INSTANCE_COMMAND,
+        createInstance({ component })
+      );
+    }
   });
 
   return null;

--- a/apps/designer/app/canvas/features/wrapper-component/text-editor/plugins/plugin-instance.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/text-editor/plugins/plugin-instance.tsx
@@ -68,7 +68,7 @@ export const InstancePlugin = ({ children }: InstancePluginProps) => {
     });
   }, [editor, children]);
 
-  useSubscribe("textToolbarFormat", (type) => {
+  useSubscribe("formatTextToolbar", (type) => {
     let component: null | "Bold" | "Italic" | "Link" = null;
     if (type === "bold") {
       component = "Bold";

--- a/apps/designer/app/canvas/features/wrapper-component/text-editor/plugins/plugin-toolbar-connector.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/text-editor/plugins/plugin-toolbar-connector.tsx
@@ -16,7 +16,7 @@ export const ToolbarConnectorPlugin = () => {
   const clearSelectionRect = () => {
     if (lastSelectionRef.current) {
       // Undefined Rect will hide toolbar
-      publish({ type: "textToolbarHide" });
+      publish({ type: "hideTextToolbar" });
       lastSelectionRef.current = undefined;
     }
   };
@@ -32,7 +32,7 @@ export const ToolbarConnectorPlugin = () => {
       const domRange = nativeSelection.getRangeAt(0);
       const selectionRect = domRange.getBoundingClientRect();
       publish({
-        type: "textToolbarShow",
+        type: "showTextToolbar",
         payload: {
           selectionRect,
           isBold: false,

--- a/apps/designer/app/canvas/features/wrapper-component/text-editor/plugins/plugin-toolbar-connector.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/text-editor/plugins/plugin-toolbar-connector.tsx
@@ -9,12 +9,6 @@ import {
 } from "../lexical";
 import { publish } from "~/shared/pubsub";
 
-declare module "~/shared/pubsub" {
-  export interface PubsubMap {
-    selectionRect?: DOMRect;
-  }
-}
-
 export const ToolbarConnectorPlugin = () => {
   const [editor] = useLexicalComposerContext();
   const lastSelectionRef = useRef<unknown>();
@@ -22,7 +16,7 @@ export const ToolbarConnectorPlugin = () => {
   const clearSelectionRect = () => {
     if (lastSelectionRef.current) {
       // Undefined Rect will hide toolbar
-      publish({ type: "selectionRect", payload: undefined });
+      publish({ type: "textToolbarHide" });
       lastSelectionRef.current = undefined;
     }
   };
@@ -36,10 +30,15 @@ export const ToolbarConnectorPlugin = () => {
 
     if (isTextSelected) {
       const domRange = nativeSelection.getRangeAt(0);
-      const rect = domRange.getBoundingClientRect();
+      const selectionRect = domRange.getBoundingClientRect();
       publish({
-        type: "selectionRect",
-        payload: rect,
+        type: "textToolbarShow",
+        payload: {
+          selectionRect,
+          isBold: false,
+          isItalic: false,
+          isLink: false,
+        },
       });
       lastSelectionRef.current = selection;
       return true;

--- a/apps/designer/app/designer/features/workspace/canvas-tools/canvas-tools.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/canvas-tools.tsx
@@ -13,9 +13,8 @@ import {
   SelectedInstanceOutline,
   DropTargetOutline,
 } from "./outline";
-import { TextToolbar } from "./text-toolbar";
+import { useSubscribeTextToolbar, TextToolbar } from "./text-toolbar";
 import { useSubscribeInstanceRect } from "./hooks/use-subscribe-instance-rect";
-import { useSubscribeSelectionRect } from "./hooks/use-subscribe-selection-rect";
 import { useSubscribeTextEditingInstanceId } from "./hooks/use-subscribe-editing-instance-id";
 
 const toolsStyle = {
@@ -33,8 +32,9 @@ type CanvasToolsProps = {
 };
 
 export const CanvasTools = ({ publish }: CanvasToolsProps) => {
+  // TODO try to setup cross-frame atoms to vaoid this
   useSubscribeInstanceRect();
-  useSubscribeSelectionRect();
+  useSubscribeTextToolbar();
   useSubscribeScrollState();
   useSubscribeDragAndDropState();
   useSubscribeTextEditingInstanceId();

--- a/apps/designer/app/designer/features/workspace/canvas-tools/canvas-tools.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/canvas-tools.tsx
@@ -32,7 +32,7 @@ type CanvasToolsProps = {
 };
 
 export const CanvasTools = ({ publish }: CanvasToolsProps) => {
-  // TODO try to setup cross-frame atoms to vaoid this
+  // @todo try to setup cross-frame atoms to vaoid this
   useSubscribeInstanceRect();
   useSubscribeTextToolbar();
   useSubscribeScrollState();

--- a/apps/designer/app/designer/features/workspace/canvas-tools/hooks/use-subscribe-selection-rect.ts
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/hooks/use-subscribe-selection-rect.ts
@@ -1,7 +1,0 @@
-import { useSubscribe } from "~/shared/pubsub";
-import { useSelectionRect } from "~/designer/shared/nano-states";
-
-export const useSubscribeSelectionRect = () => {
-  const [, setSelectionRect] = useSelectionRect();
-  useSubscribe("selectionRect", setSelectionRect);
-};

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -2,8 +2,8 @@ import { type Publish } from "~/shared/pubsub";
 import { useMemo, useState, type MouseEventHandler } from "react";
 import {
   useSelectedInstanceData,
-  type TextToolbarValue,
-  useTextToolbar,
+  type TextToolbarState,
+  useTextToolbarState,
 } from "~/designer/shared/nano-states";
 import { ToggleGroup, type CSS } from "@webstudio-is/design-system";
 import { FontBoldIcon, FontItalicIcon, Link2Icon } from "@webstudio-is/icons";
@@ -11,14 +11,14 @@ import { useSubscribe } from "~/shared/pubsub";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
-    showTextToolbar: TextToolbarValue;
+    showTextToolbar: TextToolbarState;
     hideTextToolbar: void;
     formatTextToolbar: "bold" | "italic" | "link";
   }
 }
 
 export const useSubscribeTextToolbar = () => {
-  const [, setTextToolbar] = useTextToolbar();
+  const [, setTextToolbar] = useTextToolbarState();
   useSubscribe("showTextToolbar", setTextToolbar);
   useSubscribe("hideTextToolbar", () => setTextToolbar(null));
 };
@@ -65,19 +65,19 @@ const onClickPreventDefault: MouseEventHandler<HTMLDivElement> = (event) => {
 type ToolbarProps = {
   css?: CSS;
   rootRef: React.Ref<HTMLDivElement>;
-  textToolbar: TextToolbarValue;
+  state: TextToolbarState;
   publish: Publish;
 };
 
-const Toolbar = ({ css, rootRef, textToolbar, publish }: ToolbarProps) => {
+const Toolbar = ({ css, rootRef, state, publish }: ToolbarProps) => {
   const value: Value[] = [];
-  if (textToolbar.isBold) {
+  if (state.isBold) {
     value.push("Bold");
   }
-  if (textToolbar.isItalic) {
+  if (state.isItalic) {
     value.push("Italic");
   }
-  if (textToolbar.isLink) {
+  if (state.isLink) {
     value.push("Link");
   }
   return (
@@ -87,28 +87,19 @@ const Toolbar = ({ css, rootRef, textToolbar, publish }: ToolbarProps) => {
       value={value}
       onValueChange={(newValues: Value[]) => {
         // @todo refactor with per button callback
-        if (
-          textToolbar.isBold === false &&
-          newValues.includes("Bold") === true
-        ) {
+        if (state.isBold === false && newValues.includes("Bold") === true) {
           publish({
             type: "formatTextToolbar",
             payload: "bold",
           });
         }
-        if (
-          textToolbar.isItalic === false &&
-          newValues.includes("Italic") === true
-        ) {
+        if (state.isItalic === false && newValues.includes("Italic") === true) {
           publish({
             type: "formatTextToolbar",
             payload: "italic",
           });
         }
-        if (
-          textToolbar.isLink === false &&
-          newValues.includes("Link") === true
-        ) {
+        if (state.isLink === false && newValues.includes("Link") === true) {
           publish({
             type: "formatTextToolbar",
             payload: "link",
@@ -142,7 +133,7 @@ type TextToolbarProps = {
 };
 
 export const TextToolbar = ({ publish }: TextToolbarProps) => {
-  const [textToolbar] = useTextToolbar();
+  const [textToolbar] = useTextToolbarState();
   const [selectedIntsanceData] = useSelectedInstanceData();
   const [element, setElement] = useState<HTMLElement | null>(null);
   const placement = useMemo(() => {
@@ -162,7 +153,7 @@ export const TextToolbar = ({ publish }: TextToolbarProps) => {
     <Toolbar
       rootRef={setElement}
       css={placement}
-      textToolbar={textToolbar}
+      state={textToolbar}
       publish={publish}
     />
   );

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -11,16 +11,16 @@ import { useSubscribe } from "~/shared/pubsub";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
-    textToolbarShow: TextToolbarValue;
-    textToolbarHide: void;
-    textToolbarFormat: "bold" | "italic" | "link";
+    showTextToolbar: TextToolbarValue;
+    hideTextToolbar: void;
+    formatTextToolbar: "bold" | "italic" | "link";
   }
 }
 
 export const useSubscribeTextToolbar = () => {
   const [, setTextToolbar] = useTextToolbar();
-  useSubscribe("textToolbarShow", setTextToolbar);
-  useSubscribe("textToolbarHide", () => setTextToolbar(null));
+  useSubscribe("showTextToolbar", setTextToolbar);
+  useSubscribe("hideTextToolbar", () => setTextToolbar(null));
 };
 
 const getPlacement = ({
@@ -86,13 +86,13 @@ const Toolbar = ({ css, rootRef, textToolbar, publish }: ToolbarProps) => {
       type="multiple"
       value={value}
       onValueChange={(newValues: Value[]) => {
-        // TODO refactor with per button callback
+        // @todo refactor with per button callback
         if (
           textToolbar.isBold === false &&
           newValues.includes("Bold") === true
         ) {
           publish({
-            type: "textToolbarFormat",
+            type: "formatTextToolbar",
             payload: "bold",
           });
         }
@@ -101,7 +101,7 @@ const Toolbar = ({ css, rootRef, textToolbar, publish }: ToolbarProps) => {
           newValues.includes("Italic") === true
         ) {
           publish({
-            type: "textToolbarFormat",
+            type: "formatTextToolbar",
             payload: "italic",
           });
         }
@@ -110,7 +110,7 @@ const Toolbar = ({ css, rootRef, textToolbar, publish }: ToolbarProps) => {
           newValues.includes("Link") === true
         ) {
           publish({
-            type: "textToolbarFormat",
+            type: "formatTextToolbar",
             payload: "link",
           });
         }

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -55,7 +55,7 @@ const getPlacement = ({
   return { top, left, marginBottom, marginTop, transform, visibility };
 };
 
-type Value = "Bold" | "Italic" | "Link";
+type Value = "bold" | "italic" | "link";
 
 const onClickPreventDefault: MouseEventHandler<HTMLDivElement> = (event) => {
   event.preventDefault();
@@ -66,19 +66,19 @@ type ToolbarProps = {
   css?: CSS;
   rootRef: React.Ref<HTMLDivElement>;
   state: TextToolbarState;
-  publish: Publish;
+  onToggle: (value: Value) => void;
 };
 
-const Toolbar = ({ css, rootRef, state, publish }: ToolbarProps) => {
+const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
   const value: Value[] = [];
   if (state.isBold) {
-    value.push("Bold");
+    value.push("bold");
   }
   if (state.isItalic) {
-    value.push("Italic");
+    value.push("italic");
   }
   if (state.isLink) {
-    value.push("Link");
+    value.push("link");
   }
   return (
     <ToggleGroup.Root
@@ -87,23 +87,14 @@ const Toolbar = ({ css, rootRef, state, publish }: ToolbarProps) => {
       value={value}
       onValueChange={(newValues: Value[]) => {
         // @todo refactor with per button callback
-        if (state.isBold === false && newValues.includes("Bold") === true) {
-          publish({
-            type: "formatTextToolbar",
-            payload: "bold",
-          });
+        if (state.isBold !== newValues.includes("bold")) {
+          onToggle("bold");
         }
-        if (state.isItalic === false && newValues.includes("Italic") === true) {
-          publish({
-            type: "formatTextToolbar",
-            payload: "italic",
-          });
+        if (state.isItalic !== newValues.includes("italic")) {
+          onToggle("italic");
         }
-        if (state.isLink === false && newValues.includes("Link") === true) {
-          publish({
-            type: "formatTextToolbar",
-            payload: "link",
-          });
+        if (state.isLink !== newValues.includes("link")) {
+          onToggle("link");
         }
       }}
       onClick={onClickPreventDefault}
@@ -115,13 +106,13 @@ const Toolbar = ({ css, rootRef, state, publish }: ToolbarProps) => {
         ...css,
       }}
     >
-      <ToggleGroup.Item value="Bold">
+      <ToggleGroup.Item value="bold">
         <FontBoldIcon />
       </ToggleGroup.Item>
-      <ToggleGroup.Item value="Italic">
+      <ToggleGroup.Item value="italic">
         <FontItalicIcon />
       </ToggleGroup.Item>
-      <ToggleGroup.Item value="Link">
+      <ToggleGroup.Item value="link">
         <Link2Icon />
       </ToggleGroup.Item>
     </ToggleGroup.Root>
@@ -154,7 +145,12 @@ export const TextToolbar = ({ publish }: TextToolbarProps) => {
       rootRef={setElement}
       css={placement}
       state={textToolbar}
-      publish={publish}
+      onToggle={(value) =>
+        publish({
+          type: "formatTextToolbar",
+          payload: value,
+        })
+      }
     />
   );
 };

--- a/apps/designer/app/designer/shared/nano-states/index.ts
+++ b/apps/designer/app/designer/shared/nano-states/index.ts
@@ -46,9 +46,6 @@ export const useCanvasRect = () => useValue(canvasRectContainer);
 const syncStatusContainer = createValueContainer<SyncStatus>("idle");
 export const useSyncStatus = () => useValue(syncStatusContainer);
 
-const selectionRectContainer = createValueContainer<DOMRect | undefined>();
-export const useSelectionRect = () => useValue(selectionRectContainer);
-
 const assetsContainer = createValueContainer<Array<Asset | PreviewAsset>>([]);
 export const useAssets = () => useValue(assetsContainer);
 
@@ -60,3 +57,12 @@ export const useCurrentPageId = () => useValue(currentPageIdContainer);
 
 const projectContainer = createValueContainer<Project | undefined>();
 export const useProject = () => useValue(projectContainer);
+
+export type TextToolbarValue = {
+  selectionRect: DOMRect;
+  isBold: boolean;
+  isItalic: boolean;
+  isLink: boolean;
+};
+const textToolbar = createValueContainer<null | TextToolbarValue>();
+export const useTextToolbar = () => useValue(textToolbar);

--- a/apps/designer/app/designer/shared/nano-states/index.ts
+++ b/apps/designer/app/designer/shared/nano-states/index.ts
@@ -58,11 +58,11 @@ export const useCurrentPageId = () => useValue(currentPageIdContainer);
 const projectContainer = createValueContainer<Project | undefined>();
 export const useProject = () => useValue(projectContainer);
 
-export type TextToolbarValue = {
+export type TextToolbarState = {
   selectionRect: DOMRect;
   isBold: boolean;
   isItalic: boolean;
   isLink: boolean;
 };
-const textToolbar = createValueContainer<null | TextToolbarValue>();
-export const useTextToolbar = () => useValue(textToolbar);
+const textToolbarState = createValueContainer<null | TextToolbarState>();
+export const useTextToolbarState = () => useValue(textToolbarState);


### PR DESCRIPTION
Added events to handle toolbar rect and toggled states.
Moved atom subscriber and events types to text toolbar for clarity.
Added event for formatting and moved instance creation to editor side.