### PR TITLE
[jest] Allow inline snapshots

### DIFF
--- a/packages/jest-config/index.js
+++ b/packages/jest-config/index.js
@@ -2,7 +2,12 @@ module.exports = {
   testEnvironment: "node",
   testMatch: ["<rootDir>/src/**/*.test.ts"],
   transform: {
-    "^.+\\.tsx?$": "esbuild-jest",
+    "^.+\\.tsx?$": [
+      "esbuild-jest",
+      {
+        sourcemap: true,
+      },
+    ],
   },
   moduleNameMapper: {
     "^~/(.*)$": "<rootDir>/src/$1",


### PR DESCRIPTION
Cherry picked from #378

`expect(obj).toMatchInlineSnapshot()`
cause `Jest: Couldn't locate all inline snapshots.` error without source maps support enabled. 

