### PR TITLE
Allow span fragment in text editor

### DIFF
--- a/apps/designer/app/canvas/features/text-editor/interop.ts
+++ b/apps/designer/app/canvas/features/text-editor/interop.ts
@@ -49,7 +49,7 @@ const $writeUpdates = (
         const id = refs.get(`${child.getKey()}:span`)?.id;
         const update: ChildrenUpdates[number] = {
           id,
-          component: "Box",
+          component: "Span",
           children: [],
         };
         parentUpdates.push(update);
@@ -109,7 +109,7 @@ const $writeLexical = (
         parent.append(linkNode);
         $writeLexical(linkNode, child.children, refs);
       }
-      if (child.component === "Box") {
+      if (child.component === "Span") {
         let textNode;
         if (parent instanceof TextNode) {
           textNode = parent;

--- a/apps/designer/app/canvas/features/text-editor/interop.ts
+++ b/apps/designer/app/canvas/features/text-editor/interop.ts
@@ -9,6 +9,7 @@ import {
 } from "lexical";
 import { $createLinkNode, LinkNode } from "@lexical/link";
 import type { ChildrenUpdates, Instance } from "@webstudio-is/react-sdk";
+import { $isSpanNode, $setNodeSpan } from "./toolbar-connector";
 
 // Map<nodeKey, Instance>
 export type Refs = Map<string, Instance>;
@@ -44,6 +45,16 @@ const $writeUpdates = (
       // and add ref suffix to distinct styling on one node key
       const text = child.getTextContent();
       let parentUpdates = updates;
+      if ($isSpanNode(child)) {
+        const id = refs.get(`${child.getKey()}:span`)?.id;
+        const update: ChildrenUpdates[number] = {
+          id,
+          component: "Box",
+          children: [],
+        };
+        parentUpdates.push(update);
+        parentUpdates = update.children;
+      }
       if (child.hasFormat("bold")) {
         const id = refs.get(`${child.getKey()}:bold`)?.id;
         const update: ChildrenUpdates[number] = {
@@ -97,6 +108,18 @@ const $writeLexical = (
         refs.set(linkNode.getKey(), child);
         parent.append(linkNode);
         $writeLexical(linkNode, child.children, refs);
+      }
+      if (child.component === "Box") {
+        let textNode;
+        if (parent instanceof TextNode) {
+          textNode = parent;
+        } else {
+          textNode = $createTextNode("");
+          parent.append(textNode);
+        }
+        $setNodeSpan(textNode);
+        refs.set(`${textNode.getKey()}:span`, child);
+        $writeLexical(textNode, child.children, refs);
       }
       if (child.component === "Bold") {
         let textNode;

--- a/apps/designer/app/canvas/features/text-editor/text-editor.stories.tsx
+++ b/apps/designer/app/canvas/features/text-editor/text-editor.stories.tsx
@@ -17,11 +17,13 @@ export const Basic: ComponentStory<typeof TextEditor> = ({ onChange }) => {
   const [isBold, setIsBold] = useState(false);
   const [isItalic, setIsItalic] = useState(false);
   const [isLink, setIsLink] = useState(false);
+  const [isSpan, setIsSpan] = useState(false);
   useSubscribe("showTextToolbar", (event) => {
     setIsEnabled(true);
     setIsBold(event.isBold);
     setIsItalic(event.isItalic);
     setIsLink(event.isLink);
+    setIsSpan(event.isSpan);
   });
   useSubscribe("hideTextToolbar", () => {
     setIsEnabled(false);
@@ -51,6 +53,13 @@ export const Basic: ComponentStory<typeof TextEditor> = ({ onChange }) => {
         onClick={() => publish({ type: "formatTextToolbar", payload: "link" })}
       >
         Link
+      </button>
+      <button
+        disabled={isEnabled === false}
+        style={{ fontWeight: isSpan ? "bold" : "normal" }}
+        onClick={() => publish({ type: "formatTextToolbar", payload: "span" })}
+      >
+        span
       </button>
       <Box
         css={{

--- a/apps/designer/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/designer/app/canvas/features/text-editor/text-editor.tsx
@@ -25,15 +25,13 @@ const NodeConnector = ({
 }) => {
   const [breakpoints] = useBreakpoints();
   useEffect(() => {
-    const [key, style] = nodeKey.split(":");
+    // extract key from stored key:style format
+    const [key] = nodeKey.split(":");
     const element = editor.getElementByKey(key);
     if (element) {
       const className = css(toCss(instance.cssRules, breakpoints))().toString();
       // assume only styles are important while editing text
       element.className = className;
-      if (style === "italic") {
-        element.style.fontStyle = "italic";
-      }
     }
   }, [editor, nodeKey, instance, breakpoints]);
   return null;

--- a/apps/designer/app/canvas/features/text-editor/toolbar-connector.tsx
+++ b/apps/designer/app/canvas/features/text-editor/toolbar-connector.tsx
@@ -1,37 +1,63 @@
 import { useCallback, useEffect } from "react";
 import {
   type RangeSelection,
+  type TextNode,
   $getSelection,
   $isRangeSelection,
+  $isTextNode,
   FORMAT_TEXT_COMMAND,
   SELECTION_CHANGE_COMMAND,
   COMMAND_PRIORITY_LOW,
 } from "lexical";
-import { $isLinkNode, TOGGLE_LINK_COMMAND } from "@lexical/link";
-import { $isAtNodeEnd } from "@lexical/selection";
+import { $getNearestNodeOfType } from "@lexical/utils";
+import { $patchStyleText } from "@lexical/selection";
+import { LinkNode, TOGGLE_LINK_COMMAND } from "@lexical/link";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { useSubscribe, publish } from "~/shared/pubsub";
 
-const getSelectedNode = (selection: RangeSelection) => {
-  const anchor = selection.anchor;
-  const focus = selection.focus;
-  const anchorNode = anchor.getNode();
-  const focusNode = focus.getNode();
-  if (anchorNode === focusNode) {
-    return anchorNode;
-  }
-  const isBackward = selection.isBackward();
-  if (isBackward) {
-    return $isAtNodeEnd(focus) ? anchorNode : focusNode;
-  } else {
-    return $isAtNodeEnd(anchor) ? focusNode : anchorNode;
-  }
+const spanTriggerName = "--style-node-trigger";
+
+export const $isSpanNode = (node: TextNode) => {
+  return node.getStyle().includes(spanTriggerName);
 };
 
-const isSelectedLink = (selection: RangeSelection) => {
-  const node = getSelectedNode(selection);
-  const parent = node.getParent();
-  return $isLinkNode(parent) || $isLinkNode(node);
+export const $setNodeSpan = (node: TextNode) => {
+  return node.setStyle(`${spanTriggerName}:;`);
+};
+
+const $getSpanNodes = (selection: RangeSelection) => {
+  const nodes = selection.getNodes();
+  let spans: TextNode[] = [];
+  // check each TextNode within selection for existing span nodes
+  for (const node of nodes) {
+    if ($isTextNode(node) && $isSpanNode(node)) {
+      spans.push(node);
+    }
+  }
+  return spans;
+};
+
+function $toggleSpan(): void {
+  const selection = $getSelection();
+  if ($isRangeSelection(selection)) {
+    let spans: TextNode[] = $getSpanNodes(selection);
+    if (spans.length === 0) {
+      // lexical creates separate text node when style property do not match
+      $patchStyleText(selection, {
+        [spanTriggerName]: "",
+      });
+    } else {
+      // clear span nodes style
+      for (const node of spans) {
+        node.setStyle("");
+      }
+    }
+  }
+}
+
+const $isSelectedLink = (selection: RangeSelection) => {
+  const [selectedNode] = selection.getNodes();
+  return $getNearestNodeOfType(selectedNode, LinkNode) != null;
 };
 
 export const ToolbarConnectorPlugin = () => {
@@ -50,10 +76,11 @@ export const ToolbarConnectorPlugin = () => {
       const selectionRect = domRange.getBoundingClientRect();
       const isBold = selection.hasFormat("bold");
       const isItalic = selection.hasFormat("italic");
-      const isLink = isSelectedLink(selection);
+      const isLink = $isSelectedLink(selection);
+      const isSpan = $getSpanNodes(selection).length !== 0;
       publish({
         type: "showTextToolbar",
-        payload: { selectionRect, isBold, isItalic, isLink },
+        payload: { selectionRect, isBold, isItalic, isLink, isSpan },
       });
     } else {
       publish({ type: "hideTextToolbar" });
@@ -99,13 +126,18 @@ export const ToolbarConnectorPlugin = () => {
       let isLink = false;
       editorState.read(() => {
         const selection = $getSelection();
-        isLink = $isRangeSelection(selection) && isSelectedLink(selection);
+        isLink = $isRangeSelection(selection) && $isSelectedLink(selection);
       });
       if (isLink) {
         editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
       } else {
         editor.dispatchCommand(TOGGLE_LINK_COMMAND, "https://");
       }
+    }
+    if (type === "span") {
+      editor.update(() => {
+        $toggleSpan();
+      });
     }
   });
 

--- a/apps/designer/app/canvas/features/text-editor/toolbar-connector.tsx
+++ b/apps/designer/app/canvas/features/text-editor/toolbar-connector.tsx
@@ -27,7 +27,7 @@ export const $setNodeSpan = (node: TextNode) => {
 
 const $getSpanNodes = (selection: RangeSelection) => {
   const nodes = selection.getNodes();
-  let spans: TextNode[] = [];
+  const spans: TextNode[] = [];
   // check each TextNode within selection for existing span nodes
   for (const node of nodes) {
     if ($isTextNode(node) && $isSpanNode(node)) {
@@ -37,10 +37,10 @@ const $getSpanNodes = (selection: RangeSelection) => {
   return spans;
 };
 
-function $toggleSpan(): void {
+const $toggleSpan = () => {
   const selection = $getSelection();
   if ($isRangeSelection(selection)) {
-    let spans: TextNode[] = $getSpanNodes(selection);
+    const spans = $getSpanNodes(selection);
     if (spans.length === 0) {
       // lexical creates separate text node when style property do not match
       $patchStyleText(selection, {
@@ -53,7 +53,7 @@ function $toggleSpan(): void {
       }
     }
   }
-}
+};
 
 const $isSelectedLink = (selection: RangeSelection) => {
   const [selectedNode] = selection.getNodes();

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -6,14 +6,19 @@ import {
   useTextToolbarState,
 } from "~/designer/shared/nano-states";
 import { ToggleGroup, type CSS } from "@webstudio-is/design-system";
-import { FontBoldIcon, FontItalicIcon, Link2Icon } from "@webstudio-is/icons";
+import {
+  FontBoldIcon,
+  FontItalicIcon,
+  Link2Icon,
+  BrushIcon,
+} from "@webstudio-is/icons";
 import { useSubscribe } from "~/shared/pubsub";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
     showTextToolbar: TextToolbarState;
     hideTextToolbar: void;
-    formatTextToolbar: "bold" | "italic" | "link";
+    formatTextToolbar: "bold" | "italic" | "link" | "span";
   }
 }
 
@@ -55,7 +60,7 @@ const getPlacement = ({
   return { top, left, marginBottom, marginTop, transform, visibility };
 };
 
-type Value = "bold" | "italic" | "link";
+type Value = "bold" | "italic" | "link" | "span";
 
 const onClickPreventDefault: MouseEventHandler<HTMLDivElement> = (event) => {
   event.preventDefault();
@@ -80,6 +85,9 @@ const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
   if (state.isLink) {
     value.push("link");
   }
+  if (state.isSpan) {
+    value.push("span");
+  }
   return (
     <ToggleGroup.Root
       ref={rootRef}
@@ -95,6 +103,9 @@ const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
         }
         if (state.isLink !== newValues.includes("link")) {
           onToggle("link");
+        }
+        if (state.isSpan !== newValues.includes("span")) {
+          onToggle("span");
         }
       }}
       onClick={onClickPreventDefault}
@@ -114,6 +125,9 @@ const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
       </ToggleGroup.Item>
       <ToggleGroup.Item value="link">
         <Link2Icon />
+      </ToggleGroup.Item>
+      <ToggleGroup.Item value="span">
+        <BrushIcon />
       </ToggleGroup.Item>
     </ToggleGroup.Root>
   );

--- a/apps/designer/app/designer/shared/nano-states/index.ts
+++ b/apps/designer/app/designer/shared/nano-states/index.ts
@@ -63,6 +63,7 @@ export type TextToolbarState = {
   isBold: boolean;
   isItalic: boolean;
   isLink: boolean;
+  isSpan: boolean;
 };
 const textToolbarState = createValueContainer<null | TextToolbarState>();
 export const useTextToolbarState = () => useValue(textToolbarState);

--- a/packages/react-sdk/src/components/index.ts
+++ b/packages/react-sdk/src/components/index.ts
@@ -4,6 +4,7 @@ export { default as TextBlock } from "./text-block.ws";
 export { default as Heading } from "./heading.ws";
 export { default as Paragraph } from "./paragraph.ws";
 export { default as Link } from "./link.ws";
+export { default as Span } from "./span.ws";
 export { default as Bold } from "./bold.ws";
 export { default as Italic } from "./italic.ws";
 export { default as Button } from "./button.ws";

--- a/packages/react-sdk/src/components/meta.ts
+++ b/packages/react-sdk/src/components/meta.ts
@@ -8,5 +8,6 @@ export { default as Input } from "./input.stories";
 export { default as Italic } from "./italic.stories";
 export { default as Link } from "./link.stories";
 export { default as Paragraph } from "./paragraph.stories";
+export { default as Span } from "./span.stories";
 export { default as TextBlock } from "./text-block.stories";
 export { default as Image } from "./image.stories";

--- a/packages/react-sdk/src/components/span.props.json
+++ b/packages/react-sdk/src/components/span.props.json
@@ -1,0 +1,2205 @@
+{
+  "slot": {
+    "defaultValue": null,
+    "description": "",
+    "name": "slot",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "style": {
+    "defaultValue": null,
+    "description": "",
+    "name": "style",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "CSSProperties"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "title": {
+    "defaultValue": null,
+    "description": "",
+    "name": "title",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "defaultChecked": {
+    "defaultValue": null,
+    "description": "",
+    "name": "defaultChecked",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "defaultValue": {
+    "defaultValue": null,
+    "description": "",
+    "name": "defaultValue",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string | number | readonly string[]"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "suppressContentEditableWarning": {
+    "defaultValue": null,
+    "description": "",
+    "name": "suppressContentEditableWarning",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "suppressHydrationWarning": {
+    "defaultValue": null,
+    "description": "",
+    "name": "suppressHydrationWarning",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "accessKey": {
+    "defaultValue": null,
+    "description": "",
+    "name": "accessKey",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "className": {
+    "defaultValue": null,
+    "description": "",
+    "name": "className",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "contentEditable": {
+    "defaultValue": null,
+    "description": "",
+    "name": "contentEditable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish | \"inherit\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "contextMenu": {
+    "defaultValue": null,
+    "description": "",
+    "name": "contextMenu",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "dir": {
+    "defaultValue": null,
+    "description": "",
+    "name": "dir",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "draggable": {
+    "defaultValue": null,
+    "description": "",
+    "name": "draggable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "hidden": {
+    "defaultValue": null,
+    "description": "",
+    "name": "hidden",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "id": {
+    "defaultValue": null,
+    "description": "",
+    "name": "id",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "lang": {
+    "defaultValue": null,
+    "description": "",
+    "name": "lang",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "placeholder": {
+    "defaultValue": null,
+    "description": "",
+    "name": "placeholder",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "spellCheck": {
+    "defaultValue": null,
+    "description": "",
+    "name": "spellCheck",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "tabIndex": {
+    "defaultValue": null,
+    "description": "",
+    "name": "tabIndex",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "translate": {
+    "defaultValue": null,
+    "description": "",
+    "name": "translate",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"yes\" | \"no\"",
+      "value": [
+        {
+          "value": "\"yes\""
+        },
+        {
+          "value": "\"no\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["yes", "no"]
+  },
+  "radioGroup": {
+    "defaultValue": null,
+    "description": "",
+    "name": "radioGroup",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "role": {
+    "defaultValue": null,
+    "description": "",
+    "name": "role",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "AriaRole"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "about": {
+    "defaultValue": null,
+    "description": "",
+    "name": "about",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "datatype": {
+    "defaultValue": null,
+    "description": "",
+    "name": "datatype",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "inlist": {
+    "defaultValue": null,
+    "description": "",
+    "name": "inlist",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "any"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "prefix": {
+    "defaultValue": null,
+    "description": "",
+    "name": "prefix",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "property": {
+    "defaultValue": null,
+    "description": "",
+    "name": "property",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "resource": {
+    "defaultValue": null,
+    "description": "",
+    "name": "resource",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "typeof": {
+    "defaultValue": null,
+    "description": "",
+    "name": "typeof",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "vocab": {
+    "defaultValue": null,
+    "description": "",
+    "name": "vocab",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "autoCapitalize": {
+    "defaultValue": null,
+    "description": "",
+    "name": "autoCapitalize",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "autoCorrect": {
+    "defaultValue": null,
+    "description": "",
+    "name": "autoCorrect",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "autoSave": {
+    "defaultValue": null,
+    "description": "",
+    "name": "autoSave",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "color": {
+    "defaultValue": null,
+    "description": "",
+    "name": "color",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "color"
+    }
+  },
+  "itemProp": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemProp",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "itemScope": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemScope",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "itemType": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemType",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "itemID": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemID",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "itemRef": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemRef",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "results": {
+    "defaultValue": null,
+    "description": "",
+    "name": "results",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "security": {
+    "defaultValue": null,
+    "description": "",
+    "name": "security",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "unselectable": {
+    "defaultValue": null,
+    "description": "",
+    "name": "unselectable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"on\" | \"off\"",
+      "value": [
+        {
+          "value": "\"on\""
+        },
+        {
+          "value": "\"off\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["on", "off"]
+  },
+  "inputMode": {
+    "defaultValue": null,
+    "description": "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    "name": "inputMode",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"text\" | \"none\" | \"search\" | \"tel\" | \"url\" | \"email\" | \"numeric\" | \"decimal\"",
+      "value": [
+        {
+          "value": "\"text\""
+        },
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"search\""
+        },
+        {
+          "value": "\"tel\""
+        },
+        {
+          "value": "\"url\""
+        },
+        {
+          "value": "\"email\""
+        },
+        {
+          "value": "\"numeric\""
+        },
+        {
+          "value": "\"decimal\""
+        }
+      ]
+    },
+    "control": {
+      "type": "select"
+    },
+    "options": [
+      "text",
+      "none",
+      "search",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal"
+    ]
+  },
+  "is": {
+    "defaultValue": null,
+    "description": "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    "name": "is",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-activedescendant": {
+    "defaultValue": null,
+    "description": "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    "name": "aria-activedescendant",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-atomic": {
+    "defaultValue": null,
+    "description": "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    "name": "aria-atomic",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-autocomplete": {
+    "defaultValue": null,
+    "description": "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    "name": "aria-autocomplete",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"list\" | \"none\" | \"inline\" | \"both\"",
+      "value": [
+        {
+          "value": "\"list\""
+        },
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"inline\""
+        },
+        {
+          "value": "\"both\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["list", "none", "inline", "both"]
+  },
+  "aria-busy": {
+    "defaultValue": null,
+    "description": "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+    "name": "aria-busy",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-checked": {
+    "defaultValue": null,
+    "description": "Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.",
+    "name": "aria-checked",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"mixed\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-colcount": {
+    "defaultValue": null,
+    "description": "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    "name": "aria-colcount",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-colindex": {
+    "defaultValue": null,
+    "description": "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    "name": "aria-colindex",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-colspan": {
+    "defaultValue": null,
+    "description": "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    "name": "aria-colspan",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-controls": {
+    "defaultValue": null,
+    "description": "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    "name": "aria-controls",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-current": {
+    "defaultValue": null,
+    "description": "Indicates the element that represents the current item within a container or set of related elements.",
+    "name": "aria-current",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"time\" | \"true\" | \"false\" | \"page\" | \"step\" | \"location\" | \"date\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-describedby": {
+    "defaultValue": null,
+    "description": "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    "name": "aria-describedby",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-details": {
+    "defaultValue": null,
+    "description": "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    "name": "aria-details",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-disabled": {
+    "defaultValue": null,
+    "description": "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    "name": "aria-disabled",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-dropeffect": {
+    "defaultValue": null,
+    "description": "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    "name": "aria-dropeffect",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"link\" | \"none\" | \"copy\" | \"execute\" | \"move\" | \"popup\"",
+      "value": [
+        {
+          "value": "\"link\""
+        },
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"copy\""
+        },
+        {
+          "value": "\"execute\""
+        },
+        {
+          "value": "\"move\""
+        },
+        {
+          "value": "\"popup\""
+        }
+      ]
+    },
+    "control": {
+      "type": "select"
+    },
+    "options": ["link", "none", "copy", "execute", "move", "popup"]
+  },
+  "aria-errormessage": {
+    "defaultValue": null,
+    "description": "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    "name": "aria-errormessage",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-expanded": {
+    "defaultValue": null,
+    "description": "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    "name": "aria-expanded",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-flowto": {
+    "defaultValue": null,
+    "description": "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    "name": "aria-flowto",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-grabbed": {
+    "defaultValue": null,
+    "description": "Indicates an element's \"grabbed\" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1",
+    "name": "aria-grabbed",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-haspopup": {
+    "defaultValue": null,
+    "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    "name": "aria-haspopup",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"dialog\" | \"menu\" | \"true\" | \"false\" | \"grid\" | \"listbox\" | \"tree\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-hidden": {
+    "defaultValue": null,
+    "description": "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    "name": "aria-hidden",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-invalid": {
+    "defaultValue": null,
+    "description": "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    "name": "aria-invalid",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"grammar\" | \"spelling\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-keyshortcuts": {
+    "defaultValue": null,
+    "description": "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    "name": "aria-keyshortcuts",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-label": {
+    "defaultValue": null,
+    "description": "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    "name": "aria-label",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-labelledby": {
+    "defaultValue": null,
+    "description": "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    "name": "aria-labelledby",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-level": {
+    "defaultValue": null,
+    "description": "Defines the hierarchical level of an element within a structure.",
+    "name": "aria-level",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-live": {
+    "defaultValue": null,
+    "description": "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    "name": "aria-live",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"off\" | \"assertive\" | \"polite\"",
+      "value": [
+        {
+          "value": "\"off\""
+        },
+        {
+          "value": "\"assertive\""
+        },
+        {
+          "value": "\"polite\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["off", "assertive", "polite"]
+  },
+  "aria-modal": {
+    "defaultValue": null,
+    "description": "Indicates whether an element is modal when displayed.",
+    "name": "aria-modal",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-multiline": {
+    "defaultValue": null,
+    "description": "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    "name": "aria-multiline",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-multiselectable": {
+    "defaultValue": null,
+    "description": "Indicates that the user may select more than one item from the current selectable descendants.",
+    "name": "aria-multiselectable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-orientation": {
+    "defaultValue": null,
+    "description": "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    "name": "aria-orientation",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"horizontal\" | \"vertical\"",
+      "value": [
+        {
+          "value": "\"horizontal\""
+        },
+        {
+          "value": "\"vertical\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["horizontal", "vertical"]
+  },
+  "aria-owns": {
+    "defaultValue": null,
+    "description": "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    "name": "aria-owns",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-placeholder": {
+    "defaultValue": null,
+    "description": "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    "name": "aria-placeholder",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-posinset": {
+    "defaultValue": null,
+    "description": "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    "name": "aria-posinset",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-pressed": {
+    "defaultValue": null,
+    "description": "Indicates the current \"pressed\" state of toggle buttons.\n@see aria-checked\n@see aria-selected.",
+    "name": "aria-pressed",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"mixed\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-readonly": {
+    "defaultValue": null,
+    "description": "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    "name": "aria-readonly",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-relevant": {
+    "defaultValue": null,
+    "description": "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    "name": "aria-relevant",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"text\" | \"additions\" | \"additions removals\" | \"additions text\" | \"all\" | \"removals\" | \"removals additions\" | \"removals text\" | \"text additions\" | \"text removals\"",
+      "value": [
+        {
+          "value": "\"text\""
+        },
+        {
+          "value": "\"additions\""
+        },
+        {
+          "value": "\"additions removals\""
+        },
+        {
+          "value": "\"additions text\""
+        },
+        {
+          "value": "\"all\""
+        },
+        {
+          "value": "\"removals\""
+        },
+        {
+          "value": "\"removals additions\""
+        },
+        {
+          "value": "\"removals text\""
+        },
+        {
+          "value": "\"text additions\""
+        },
+        {
+          "value": "\"text removals\""
+        }
+      ]
+    },
+    "control": {
+      "type": "select"
+    },
+    "options": [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals"
+    ]
+  },
+  "aria-required": {
+    "defaultValue": null,
+    "description": "Indicates that user input is required on the element before a form may be submitted.",
+    "name": "aria-required",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-roledescription": {
+    "defaultValue": null,
+    "description": "Defines a human-readable, author-localized description for the role of an element.",
+    "name": "aria-roledescription",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-rowcount": {
+    "defaultValue": null,
+    "description": "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    "name": "aria-rowcount",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-rowindex": {
+    "defaultValue": null,
+    "description": "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    "name": "aria-rowindex",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-rowspan": {
+    "defaultValue": null,
+    "description": "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    "name": "aria-rowspan",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-selected": {
+    "defaultValue": null,
+    "description": "Indicates the current \"selected\" state of various widgets.\n@see aria-checked\n@see aria-pressed.",
+    "name": "aria-selected",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-setsize": {
+    "defaultValue": null,
+    "description": "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    "name": "aria-setsize",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-sort": {
+    "defaultValue": null,
+    "description": "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    "name": "aria-sort",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"none\" | \"ascending\" | \"descending\" | \"other\"",
+      "value": [
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"ascending\""
+        },
+        {
+          "value": "\"descending\""
+        },
+        {
+          "value": "\"other\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["none", "ascending", "descending", "other"]
+  },
+  "aria-valuemax": {
+    "defaultValue": null,
+    "description": "Defines the maximum allowed value for a range widget.",
+    "name": "aria-valuemax",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-valuemin": {
+    "defaultValue": null,
+    "description": "Defines the minimum allowed value for a range widget.",
+    "name": "aria-valuemin",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-valuenow": {
+    "defaultValue": null,
+    "description": "Defines the current value for a range widget.\n@see aria-valuetext.",
+    "name": "aria-valuenow",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-valuetext": {
+    "defaultValue": null,
+    "description": "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    "name": "aria-valuetext",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  }
+}

--- a/packages/react-sdk/src/components/span.stories.tsx
+++ b/packages/react-sdk/src/components/span.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Span as SpanPrimitive } from "./span";
+import argTypes from "./span.props.json";
+
+export default {
+  title: "Components/Span",
+  component: SpanPrimitive,
+  argTypes,
+} as ComponentMeta<typeof SpanPrimitive>;
+
+const Template: ComponentStory<typeof SpanPrimitive> = (args) => (
+  <SpanPrimitive {...args} />
+);
+
+export const Span = Template.bind({});
+Span.args = {
+  children: "some span text",
+};

--- a/packages/react-sdk/src/components/span.tsx
+++ b/packages/react-sdk/src/components/span.tsx
@@ -1,0 +1,10 @@
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
+
+const defaultTag = "span";
+
+export const Span = forwardRef<
+  ElementRef<typeof defaultTag>,
+  ComponentProps<typeof defaultTag>
+>((props, ref) => <span {...props} ref={ref} />);
+
+Span.displayName = "Span";

--- a/packages/react-sdk/src/components/span.ws.tsx
+++ b/packages/react-sdk/src/components/span.ws.tsx
@@ -1,0 +1,15 @@
+import { BrushIcon } from "@webstudio-is/icons";
+import type { WsComponentMeta } from "./component-type";
+import { Span } from "./span";
+
+const meta: WsComponentMeta<typeof Span> = {
+  Icon: BrushIcon,
+  Component: Span,
+  canAcceptChildren: false,
+  isContentEditable: false,
+  label: "Span Text",
+  isInlineOnly: true,
+  isListed: false,
+};
+
+export default meta;

--- a/packages/react-sdk/src/components/span.ws.tsx
+++ b/packages/react-sdk/src/components/span.ws.tsx
@@ -7,7 +7,7 @@ const meta: WsComponentMeta<typeof Span> = {
   Component: Span,
   canAcceptChildren: false,
   isContentEditable: false,
-  label: "Span Text",
+  label: "Styled Text",
   isInlineOnly: true,
   isListed: false,
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/400

- added span component to sdk
- added span support to text editor toolbar

Lexical has a great utility $patchStyleText which does exaactly what we need, split selection into stylable element. Though there is a catch. It requires to apply some styles. We do styling lazily and with clases so it doesn't fit to trigger split. To workaroud it I instead patch with css custom property which does not affect styling and considered a trigger for lexical.

<img width="248" alt="image" src="https://user-images.githubusercontent.com/5635476/201028529-0e5ec32e-a00a-43b0-899c-671f0edcad5b.png">


## Before requesting a review

- [x] if the PR is WIP - use draft mode
- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")
- [x] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [x] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
