### PR TITLE
Switch on initialVisibleProps

### DIFF
--- a/packages/react-sdk/src/component-utils/image.test.ts
+++ b/packages/react-sdk/src/component-utils/image.test.ts
@@ -8,6 +8,7 @@ describe("Image optimizations applied", () => {
       src: "https://webstudio.is/logo.webp",
       srcSet: undefined,
       sizes: undefined,
+      loader: undefined,
       quality: 100,
     });
 
@@ -27,6 +28,7 @@ describe("Image optimizations applied", () => {
       src: "https://webstudio.is/logo.webp",
       srcSet: undefined,
       sizes: undefined,
+      loader: undefined,
       quality: 90,
     });
 
@@ -46,6 +48,7 @@ describe("Image optimizations applied", () => {
       src: "https://webstudio.is/logo.webp",
       srcSet: undefined,
       sizes: "100vw",
+      loader: undefined,
       quality: 70,
     });
 
@@ -88,6 +91,7 @@ describe("Image optimizations not applied", () => {
       src: "https://webstudio.is/logo.webp",
       srcSet: undefined,
       sizes: undefined,
+      loader: undefined,
       quality: 100,
     });
 
@@ -107,6 +111,7 @@ describe("Image optimizations not applied", () => {
       src: "https://webstudio.is/logo.webp",
       srcSet: "user-defined-srcset",
       sizes: undefined,
+      loader: undefined,
       quality: 100,
     });
 
@@ -126,6 +131,7 @@ describe("Image optimizations not applied", () => {
       src: "",
       srcSet: undefined,
       sizes: undefined,
+      loader: undefined,
       quality: 100,
     });
 
@@ -139,6 +145,7 @@ describe("Image optimizations not applied", () => {
       src: undefined,
       srcSet: undefined,
       sizes: undefined,
+      loader: undefined,
       quality: 100,
     });
 

--- a/packages/react-sdk/src/component-utils/image.ts
+++ b/packages/react-sdk/src/component-utils/image.ts
@@ -232,7 +232,7 @@ export const getImageAttributes = (props: {
   sizes: string | undefined;
   width: string | number | undefined;
   quality: number | undefined;
-  loader?: ImageLoader;
+  loader: ImageLoader | undefined;
   optimize: boolean;
 }): {
   src: string;

--- a/packages/react-sdk/src/component-utils/types-helpers.ts
+++ b/packages/react-sdk/src/component-utils/types-helpers.ts
@@ -1,0 +1,23 @@
+/**
+ * For any object creates a new object with Required keys only
+ * Example:
+ * type Props = RequiredKeysObject<{src: string, alt?: string}>;
+ * output: type Props = {src: string};
+ *
+ **/
+type RequiredKeysObject<T extends object> = {
+  [K in keyof T as T extends Record<K, T[K]> ? K : never]: T[K];
+};
+
+/**
+ * Forces to define in initialVisibleProps all required props default values
+ * Example:
+ * type Props = {src: string, alt?: string};
+ * const SomeComponent = (props: Props) => <img {...props} />
+ * const initialValues: InitialValueProps<React.ComponentPropsWithoutRef<typeof SomeComponent>> = {
+ *   alt: "",
+ * }
+ * Would give an error because src is required prop.
+ **/
+export type InitialVisibleProps<T extends object> = RequiredKeysObject<T> &
+  Omit<T, keyof RequiredKeysObject<T>>;

--- a/packages/react-sdk/src/components/box.ws.ts
+++ b/packages/react-sdk/src/components/box.ws.ts
@@ -18,6 +18,7 @@ const meta: WsComponentMeta<typeof Box> = {
   isInlineOnly: false,
   isListed: true,
   label: "Box",
+  initialVisibleProps: { tag: "div" },
 };
 
 export default meta;

--- a/packages/react-sdk/src/components/button.tsx
+++ b/packages/react-sdk/src/components/button.tsx
@@ -8,7 +8,4 @@ export const Button = forwardRef<ElementRef<typeof defaultTag>, ButtonProps>(
   (props, ref) => <button {...props} ref={ref} />
 );
 
-Button.defaultProps = {
-  type: "submit", // Match the platform default
-};
 Button.displayName = "Button";

--- a/packages/react-sdk/src/components/button.ws.tsx
+++ b/packages/react-sdk/src/components/button.ws.tsx
@@ -11,6 +11,7 @@ const meta: WsComponentMeta<typeof Button> = {
   isListed: true,
   label: "Button",
   children: ["Button text you can edit"],
+  initialVisibleProps: { type: "submit" },
 };
 
 export default meta;

--- a/packages/react-sdk/src/components/heading.ws.tsx
+++ b/packages/react-sdk/src/components/heading.ws.tsx
@@ -11,6 +11,7 @@ const meta: WsComponentMeta<typeof Heading> = {
   isListed: true,
   label: "Heading",
   children: ["Heading you can edit"],
+  initialVisibleProps: { tag: "h1" },
 };
 
 export default meta;

--- a/packages/react-sdk/src/components/image.tsx
+++ b/packages/react-sdk/src/components/image.tsx
@@ -30,14 +30,6 @@ export const Image = forwardRef<ElementRef<typeof defaultTag>, ImageProps>(
   }
 );
 
-Image.defaultProps = {
-  src: "",
-  width: "",
-  height: "",
-  loading: "lazy",
-  alt: "",
-};
-
 Image.displayName = "Image";
 
 const imagePlaceholderSvg = `data:image/svg+xml;base64,${btoa(`<svg

--- a/packages/react-sdk/src/components/image.ws.tsx
+++ b/packages/react-sdk/src/components/image.ws.tsx
@@ -26,6 +26,15 @@ const meta: WsComponentMeta<typeof Image> = {
   isInlineOnly: false,
   isListed: true,
   label: "Image",
+  initialVisibleProps: {
+    src: "",
+    alt: "",
+    width: undefined,
+    height: undefined,
+    quality: undefined,
+    optimize: undefined,
+    loading: "lazy",
+  },
 };
 
 export default meta;

--- a/packages/react-sdk/src/components/link.tsx
+++ b/packages/react-sdk/src/components/link.tsx
@@ -2,12 +2,10 @@ import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 const defaultTag = "a";
 
-type LinkProps = Omit<ComponentProps<typeof defaultTag>, "href"> & {
-  href?: string;
-};
+type LinkProps = ComponentProps<typeof defaultTag>;
 
 export const Link = forwardRef<ElementRef<typeof defaultTag>, LinkProps>(
-  ({ href = "", ...props }, ref) => <a {...props} href={href} ref={ref} />
+  (props, ref) => <a {...props} ref={ref} />
 );
 
 Link.displayName = "Link";

--- a/packages/react-sdk/src/components/link.ws.tsx
+++ b/packages/react-sdk/src/components/link.ws.tsx
@@ -24,6 +24,7 @@ const meta: WsComponentMeta<typeof Link> = {
   isListed: true,
   label: "Link",
   children: ["Link text you can edit"],
+  initialVisibleProps: { href: "" },
 };
 
 export default meta;


### PR DESCRIPTION
Draft Preview to show the idea.

ref #192

The idea is that instead of multiple sources of properties must be one.
That simplifies all things and removes questions like 
- props ordering
- bugs in `react-docgen-typescript` generation (it doesn't allow to make non-optional properties required etc)
- moves all props we need to show initially into the single place
- no clear way to define default props for functional components exists, `defaultProps` should gone some day for functional components, ({a='default', b, v}) 'default' is not exists in type information.

It's defined at `${component}.ws.ts` file and called  `initialVisibleProps`

Type on `initialVisibleProps` forces you to put into ALL required properties of the component with default values.
Also, it forces default values to be the right type too.
<img width="729" alt="image" src="https://user-images.githubusercontent.com/5077042/200848590-c4514769-a671-4b23-83a4-ae25900cbf3f.png">

In the case of inexisted properties:
<img width="736" alt="image" src="https://user-images.githubusercontent.com/5077042/200849353-38f31e30-9f24-4daf-b572-a403d4e12c39.png">

I think we can make properties like `tag` as required, no reason to make it optional IMO.
Also in case of structure like `key => value` is not enough its possible to force with types to move `required` etc props into `initialVisibleProps` to have that parameters explicit at least for internal components.


