### PR TITLE
Save db state after docker compose down

### DIFF
--- a/apps/designer/docker-compose.yaml
+++ b/apps/designer/docker-compose.yaml
@@ -1,4 +1,7 @@
-version: '3.1'
+version: "3.1"
+
+volumes:
+  db:
 
 services:
   db:
@@ -9,5 +12,7 @@ services:
       POSTGRES_PASSWORD: pass
       POSTGRES_DB: webstudio
       POSTGRES_USER: user
+    volumes:
+      - db:/var/lib/postgresql/data
     ports:
       - ${PGPORT:-5432}:5432

--- a/apps/designer/package.json
+++ b/apps/designer/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "Webstudio Designer UI as a service",
   "scripts": {
+    "bootstrap": "docker compose up -d && migrations migrate --dev --force",
     "build": "remix build",
     "dev": "remix dev",
     "start": "remix-serve build",

--- a/apps/designer/package.json
+++ b/apps/designer/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "Webstudio Designer UI as a service",
   "scripts": {
-    "bootstrap": "docker compose up -d && migrations migrate --dev --force",
     "build": "remix build",
     "dev": "remix dev",
     "start": "remix-serve build",


### PR DESCRIPTION
With previous docker setup I have a problem when switched between projects had to setup migrations again and loose current session.

Docker compose volumes solve this problem and preserve current db state. Can be destroyed with `docker compose down -v`.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [x] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
