### PR TITLE
Add more options to text editor

### DIFF
--- a/apps/designer/app/canvas/features/text-editor/interop.ts
+++ b/apps/designer/app/canvas/features/text-editor/interop.ts
@@ -1,18 +1,28 @@
 import {
+  type TextNode,
+  type ElementNode,
   $getRoot,
   $createTextNode,
   $createParagraphNode,
-  TextNode,
-  ElementNode,
-  LineBreakNode,
-  ParagraphNode,
+  $createLineBreakNode,
+  $isTextNode,
+  $isElementNode,
+  $isParagraphNode,
+  $isLineBreakNode,
 } from "lexical";
-import { $createLinkNode, LinkNode } from "@lexical/link";
+import { $createLinkNode, $isLinkNode } from "@lexical/link";
 import type { ChildrenUpdates, Instance } from "@webstudio-is/react-sdk";
 import { $isSpanNode, $setNodeSpan } from "./toolbar-connector";
 
 // Map<nodeKey, Instance>
 export type Refs = Map<string, Instance>;
+
+const lexicalFormats = [
+  ["bold", "Bold"],
+  ["italic", "Italic"],
+  ["superscript", "Superscript"],
+  ["subscript", "Subscript"],
+] as const;
 
 const $writeUpdates = (
   node: ElementNode,
@@ -21,25 +31,25 @@ const $writeUpdates = (
 ) => {
   const children = node.getChildren();
   for (const child of children) {
-    if (child instanceof ParagraphNode) {
+    if ($isParagraphNode(child)) {
       if (updates.length !== 0) {
         updates.push("\n");
       }
       $writeUpdates(child, updates, refs);
     }
-    if (child instanceof LineBreakNode) {
+    if ($isLineBreakNode(child)) {
       if (updates.length !== 0) {
         // @todo should we visually distinct line breaks and paragraphs?
         updates.push("\n");
       }
     }
-    if (child instanceof LinkNode) {
+    if ($isLinkNode(child)) {
       const id = refs.get(child.getKey())?.id;
       const childrenUpdates: ChildrenUpdates = [];
       $writeUpdates(child, childrenUpdates, refs);
       updates.push({ id, component: "Link", children: childrenUpdates });
     }
-    if (child instanceof TextNode) {
+    if ($isTextNode(child)) {
       // support nesting bold into italic and vice versa
       // considering lexical represents both as single node
       // and add ref suffix to distinct styling on one node key
@@ -55,25 +65,18 @@ const $writeUpdates = (
         parentUpdates.push(update);
         parentUpdates = update.children;
       }
-      if (child.hasFormat("bold")) {
-        const id = refs.get(`${child.getKey()}:bold`)?.id;
-        const update: ChildrenUpdates[number] = {
-          id,
-          component: "Bold",
-          children: [],
-        };
-        parentUpdates.push(update);
-        parentUpdates = update.children;
-      }
-      if (child.hasFormat("italic")) {
-        const id = refs.get(`${child.getKey()}:italic`)?.id;
-        const update: ChildrenUpdates[number] = {
-          id,
-          component: "Italic",
-          children: [],
-        };
-        parentUpdates.push(update);
-        parentUpdates = update.children;
+      // convert all lexical formats
+      for (const [format, component] of lexicalFormats) {
+        if (child.hasFormat(format)) {
+          const id = refs.get(`${child.getKey()}:${format}`)?.id;
+          const update: ChildrenUpdates[number] = {
+            id,
+            component,
+            children: [],
+          };
+          parentUpdates.push(update);
+          parentUpdates = update.children;
+        }
       }
       parentUpdates.push(text);
     }
@@ -95,54 +98,53 @@ const $writeLexical = (
   refs: Refs
 ) => {
   for (const child of children) {
+    // convert text
+    if (child === "\n" && $isElementNode(parent)) {
+      const lineBreakNode = $createLineBreakNode();
+      parent.append(lineBreakNode);
+      continue;
+    }
     if (typeof child === "string") {
-      if (parent instanceof TextNode) {
+      if ($isTextNode(parent)) {
         parent.setTextContent(child);
       } else {
         const textNode = $createTextNode(child);
         parent.append(textNode);
       }
-    } else {
-      if (parent instanceof ElementNode && child.component === "Link") {
-        const linkNode = $createLinkNode("");
-        refs.set(linkNode.getKey(), child);
-        parent.append(linkNode);
-        $writeLexical(linkNode, child.children, refs);
+      continue;
+    }
+
+    // convert instances
+    if (child.component === "Link" && $isElementNode(parent)) {
+      const linkNode = $createLinkNode("");
+      refs.set(linkNode.getKey(), child);
+      parent.append(linkNode);
+      $writeLexical(linkNode, child.children, refs);
+    }
+    if (child.component === "Span") {
+      let textNode;
+      if ($isTextNode(parent)) {
+        textNode = parent;
+      } else {
+        textNode = $createTextNode("");
+        parent.append(textNode);
       }
-      if (child.component === "Span") {
+      $setNodeSpan(textNode);
+      refs.set(`${textNode.getKey()}:span`, child);
+      $writeLexical(textNode, child.children, refs);
+    }
+    // convert all lexical formats
+    for (const [format, component] of lexicalFormats) {
+      if (child.component === component) {
         let textNode;
-        if (parent instanceof TextNode) {
+        if ($isTextNode(parent)) {
           textNode = parent;
         } else {
           textNode = $createTextNode("");
           parent.append(textNode);
         }
-        $setNodeSpan(textNode);
-        refs.set(`${textNode.getKey()}:span`, child);
-        $writeLexical(textNode, child.children, refs);
-      }
-      if (child.component === "Bold") {
-        let textNode;
-        if (parent instanceof TextNode) {
-          textNode = parent;
-        } else {
-          textNode = $createTextNode("");
-          parent.append(textNode);
-        }
-        textNode.toggleFormat("bold");
-        refs.set(`${textNode.getKey()}:bold`, child);
-        $writeLexical(textNode, child.children, refs);
-      }
-      if (child.component === "Italic") {
-        let textNode;
-        if (parent instanceof TextNode) {
-          textNode = parent;
-        } else {
-          textNode = $createTextNode("");
-          parent.append(textNode);
-        }
-        textNode.toggleFormat("italic");
-        refs.set(`${textNode.getKey()}:italic`, child);
+        textNode.toggleFormat(format);
+        refs.set(`${textNode.getKey()}:${format}`, child);
         $writeLexical(textNode, child.children, refs);
       }
     }
@@ -151,14 +153,7 @@ const $writeLexical = (
 
 export const $convertToLexical = (instance: Instance, refs: Refs) => {
   const root = $getRoot();
-  let p = $createParagraphNode();
+  const p = $createParagraphNode();
   root.append(p);
-  for (const child of instance.children) {
-    if (child === "\n") {
-      p = $createParagraphNode();
-      root.append(p);
-    } else {
-      $writeLexical(p, [child], refs);
-    }
-  }
+  $writeLexical(p, instance.children, refs);
 };

--- a/apps/designer/app/canvas/features/text-editor/text-editor.stories.tsx
+++ b/apps/designer/app/canvas/features/text-editor/text-editor.stories.tsx
@@ -5,6 +5,7 @@ import { action } from "@storybook/addon-actions";
 import { Box } from "@webstudio-is/design-system";
 import { useSubscribe, publish } from "~/shared/pubsub";
 import { createInstance } from "~/shared/tree-utils";
+import type { TextToolbarState } from "~/designer/shared/nano-states";
 import { TextEditor } from "./text-editor";
 
 export default {
@@ -12,54 +13,78 @@ export default {
   title: "Text Editor 2",
 } as ComponentMeta<typeof TextEditor>;
 
+type Format =
+  | "bold"
+  | "italic"
+  | "superscript"
+  | "subscript"
+  | "link"
+  | "span"
+  | "clear";
+
 export const Basic: ComponentStory<typeof TextEditor> = ({ onChange }) => {
-  const [isEnabled, setIsEnabled] = useState(false);
-  const [isBold, setIsBold] = useState(false);
-  const [isItalic, setIsItalic] = useState(false);
-  const [isLink, setIsLink] = useState(false);
-  const [isSpan, setIsSpan] = useState(false);
+  const [state, setState] = useState<null | TextToolbarState>(null);
   useSubscribe("showTextToolbar", (event) => {
-    setIsEnabled(true);
-    setIsBold(event.isBold);
-    setIsItalic(event.isItalic);
-    setIsLink(event.isLink);
-    setIsSpan(event.isSpan);
+    setState(event);
   });
   useSubscribe("hideTextToolbar", () => {
-    setIsEnabled(false);
+    setState(null);
   });
+
+  const setFormat = (type: Format) => {
+    publish({ type: "formatTextToolbar", payload: type });
+  };
 
   return (
     <div>
       <button
-        disabled={isEnabled === false}
-        style={{ fontWeight: isBold ? "bold" : "normal" }}
-        onClick={() => publish({ type: "formatTextToolbar", payload: "bold" })}
+        disabled={state == null}
+        style={{ fontWeight: state?.isBold ? "bold" : "normal" }}
+        onClick={() => setFormat("bold")}
       >
         Bold
       </button>
       <button
-        disabled={isEnabled === false}
-        style={{ fontWeight: isItalic ? "bold" : "normal" }}
-        onClick={() =>
-          publish({ type: "formatTextToolbar", payload: "italic" })
-        }
+        disabled={state == null}
+        style={{ fontWeight: state?.isItalic ? "bold" : "normal" }}
+        onClick={() => setFormat("italic")}
       >
         Italic
       </button>
       <button
-        disabled={isEnabled === false}
-        style={{ fontWeight: isLink ? "bold" : "normal" }}
-        onClick={() => publish({ type: "formatTextToolbar", payload: "link" })}
+        disabled={state == null}
+        style={{ fontWeight: state?.isSuperscript ? "bold" : "normal" }}
+        onClick={() => setFormat("superscript")}
+      >
+        Superscript
+      </button>
+      <button
+        disabled={state == null}
+        style={{ fontWeight: state?.isSubscript ? "bold" : "normal" }}
+        onClick={() => setFormat("subscript")}
+      >
+        Subscript
+      </button>
+      <button
+        disabled={state == null}
+        style={{ fontWeight: state?.isLink ? "bold" : "normal" }}
+        onClick={() => setFormat("link")}
       >
         Link
       </button>
       <button
-        disabled={isEnabled === false}
-        style={{ fontWeight: isSpan ? "bold" : "normal" }}
-        onClick={() => publish({ type: "formatTextToolbar", payload: "span" })}
+        disabled={state == null}
+        style={{ fontWeight: state?.isSpan ? "bold" : "normal" }}
+        onClick={() => setFormat("span")}
       >
-        span
+        Span
+      </button>
+      <button
+        disabled={state == null}
+        style={{ fontWeight: "normal" }}
+        onClick={() => setFormat("clear")}
+      >
+        Clear
       </button>
       <Box
         css={{

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -14,11 +14,20 @@ import {
 } from "@webstudio-is/icons";
 import { useSubscribe } from "~/shared/pubsub";
 
+type Format =
+  | "bold"
+  | "italic"
+  | "superscript"
+  | "subscript"
+  | "link"
+  | "span"
+  | "clear";
+
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
     showTextToolbar: TextToolbarState;
     hideTextToolbar: void;
-    formatTextToolbar: "bold" | "italic" | "link" | "span";
+    formatTextToolbar: Format;
   }
 }
 
@@ -60,8 +69,6 @@ const getPlacement = ({
   return { top, left, marginBottom, marginTop, transform, visibility };
 };
 
-type Value = "bold" | "italic" | "link" | "span";
-
 const onClickPreventDefault: MouseEventHandler<HTMLDivElement> = (event) => {
   event.preventDefault();
   event.stopPropagation();
@@ -71,16 +78,22 @@ type ToolbarProps = {
   css?: CSS;
   rootRef: React.Ref<HTMLDivElement>;
   state: TextToolbarState;
-  onToggle: (value: Value) => void;
+  onToggle: (value: Format) => void;
 };
 
 const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
-  const value: Value[] = [];
+  const value: Format[] = [];
   if (state.isBold) {
     value.push("bold");
   }
   if (state.isItalic) {
     value.push("italic");
+  }
+  if (state.isSuperscript) {
+    value.push("superscript");
+  }
+  if (state.isSubscript) {
+    value.push("subscript");
   }
   if (state.isLink) {
     value.push("link");
@@ -93,7 +106,7 @@ const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
       ref={rootRef}
       type="multiple"
       value={value}
-      onValueChange={(newValues: Value[]) => {
+      onValueChange={(newValues: Format[]) => {
         // @todo refactor with per button callback
         if (state.isBold !== newValues.includes("bold")) {
           onToggle("bold");
@@ -101,11 +114,20 @@ const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
         if (state.isItalic !== newValues.includes("italic")) {
           onToggle("italic");
         }
+        if (state.isSuperscript !== newValues.includes("superscript")) {
+          onToggle("superscript");
+        }
+        if (state.isSubscript !== newValues.includes("subscript")) {
+          onToggle("subscript");
+        }
         if (state.isLink !== newValues.includes("link")) {
           onToggle("link");
         }
         if (state.isSpan !== newValues.includes("span")) {
           onToggle("span");
+        }
+        if (newValues.includes("clear")) {
+          onToggle("clear");
         }
       }}
       onClick={onClickPreventDefault}
@@ -123,10 +145,19 @@ const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
       <ToggleGroup.Item value="italic">
         <FontItalicIcon />
       </ToggleGroup.Item>
+      <ToggleGroup.Item value="superscript">
+        <BrushIcon />
+      </ToggleGroup.Item>
+      <ToggleGroup.Item value="subscript">
+        <BrushIcon />
+      </ToggleGroup.Item>
       <ToggleGroup.Item value="link">
         <Link2Icon />
       </ToggleGroup.Item>
       <ToggleGroup.Item value="span">
+        <BrushIcon />
+      </ToggleGroup.Item>
+      <ToggleGroup.Item value="clear">
         <BrushIcon />
       </ToggleGroup.Item>
     </ToggleGroup.Root>

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -9,8 +9,11 @@ import { ToggleGroup, type CSS } from "@webstudio-is/design-system";
 import {
   FontBoldIcon,
   FontItalicIcon,
+  SuperscriptIcon,
+  SubscriptIcon,
   Link2Icon,
   BrushIcon,
+  FormatClearIcon,
 } from "@webstudio-is/icons";
 import { useSubscribe } from "~/shared/pubsub";
 
@@ -146,10 +149,10 @@ const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
         <FontItalicIcon />
       </ToggleGroup.Item>
       <ToggleGroup.Item value="superscript">
-        <BrushIcon />
+        <SuperscriptIcon />
       </ToggleGroup.Item>
       <ToggleGroup.Item value="subscript">
-        <BrushIcon />
+        <SubscriptIcon />
       </ToggleGroup.Item>
       <ToggleGroup.Item value="link">
         <Link2Icon />
@@ -158,7 +161,7 @@ const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
         <BrushIcon />
       </ToggleGroup.Item>
       <ToggleGroup.Item value="clear">
-        <BrushIcon />
+        <FormatClearIcon />
       </ToggleGroup.Item>
     </ToggleGroup.Root>
   );

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -37,7 +37,7 @@ declare module "~/shared/pubsub" {
 export const useSubscribeTextToolbar = () => {
   const [, setTextToolbar] = useTextToolbarState();
   useSubscribe("showTextToolbar", setTextToolbar);
-  useSubscribe("hideTextToolbar", () => setTextToolbar(null));
+  useSubscribe("hideTextToolbar", () => setTextToolbar(undefined));
 };
 
 const getPlacement = ({

--- a/apps/designer/app/designer/shared/nano-states/index.ts
+++ b/apps/designer/app/designer/shared/nano-states/index.ts
@@ -67,5 +67,5 @@ export type TextToolbarState = {
   isLink: boolean;
   isSpan: boolean;
 };
-const textToolbarState = createValueContainer<null | TextToolbarState>();
+const textToolbarState = createValueContainer<undefined | TextToolbarState>();
 export const useTextToolbarState = () => useValue(textToolbarState);

--- a/apps/designer/app/designer/shared/nano-states/index.ts
+++ b/apps/designer/app/designer/shared/nano-states/index.ts
@@ -62,6 +62,8 @@ export type TextToolbarState = {
   selectionRect: DOMRect;
   isBold: boolean;
   isItalic: boolean;
+  isSuperscript: boolean;
+  isSubscript: boolean;
   isLink: boolean;
   isSpan: boolean;
 };

--- a/packages/react-sdk/src/components/index.ts
+++ b/packages/react-sdk/src/components/index.ts
@@ -7,6 +7,8 @@ export { default as Link } from "./link.ws";
 export { default as Span } from "./span.ws";
 export { default as Bold } from "./bold.ws";
 export { default as Italic } from "./italic.ws";
+export { default as Superscript } from "./superscript.ws";
+export { default as Subscript } from "./subscript.ws";
 export { default as Button } from "./button.ws";
 export { default as Input } from "./input.ws";
 export { default as Form } from "./form.ws";

--- a/packages/react-sdk/src/components/meta.ts
+++ b/packages/react-sdk/src/components/meta.ts
@@ -6,6 +6,8 @@ export { default as Form } from "./form.stories";
 export { default as Heading } from "./heading.stories";
 export { default as Input } from "./input.stories";
 export { default as Italic } from "./italic.stories";
+export { default as Superscript } from "./superscript.stories";
+export { default as Subscript } from "./subscript.stories";
 export { default as Link } from "./link.stories";
 export { default as Paragraph } from "./paragraph.stories";
 export { default as Span } from "./span.stories";

--- a/packages/react-sdk/src/components/subscript.props.json
+++ b/packages/react-sdk/src/components/subscript.props.json
@@ -1,0 +1,2205 @@
+{
+  "slot": {
+    "defaultValue": null,
+    "description": "",
+    "name": "slot",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "style": {
+    "defaultValue": null,
+    "description": "",
+    "name": "style",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "CSSProperties"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "title": {
+    "defaultValue": null,
+    "description": "",
+    "name": "title",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "defaultChecked": {
+    "defaultValue": null,
+    "description": "",
+    "name": "defaultChecked",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "defaultValue": {
+    "defaultValue": null,
+    "description": "",
+    "name": "defaultValue",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string | number | readonly string[]"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "suppressContentEditableWarning": {
+    "defaultValue": null,
+    "description": "",
+    "name": "suppressContentEditableWarning",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "suppressHydrationWarning": {
+    "defaultValue": null,
+    "description": "",
+    "name": "suppressHydrationWarning",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "accessKey": {
+    "defaultValue": null,
+    "description": "",
+    "name": "accessKey",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "className": {
+    "defaultValue": null,
+    "description": "",
+    "name": "className",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "contentEditable": {
+    "defaultValue": null,
+    "description": "",
+    "name": "contentEditable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish | \"inherit\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "contextMenu": {
+    "defaultValue": null,
+    "description": "",
+    "name": "contextMenu",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "dir": {
+    "defaultValue": null,
+    "description": "",
+    "name": "dir",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "draggable": {
+    "defaultValue": null,
+    "description": "",
+    "name": "draggable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "hidden": {
+    "defaultValue": null,
+    "description": "",
+    "name": "hidden",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "id": {
+    "defaultValue": null,
+    "description": "",
+    "name": "id",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "lang": {
+    "defaultValue": null,
+    "description": "",
+    "name": "lang",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "placeholder": {
+    "defaultValue": null,
+    "description": "",
+    "name": "placeholder",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "spellCheck": {
+    "defaultValue": null,
+    "description": "",
+    "name": "spellCheck",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "tabIndex": {
+    "defaultValue": null,
+    "description": "",
+    "name": "tabIndex",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "translate": {
+    "defaultValue": null,
+    "description": "",
+    "name": "translate",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"yes\" | \"no\"",
+      "value": [
+        {
+          "value": "\"yes\""
+        },
+        {
+          "value": "\"no\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["yes", "no"]
+  },
+  "radioGroup": {
+    "defaultValue": null,
+    "description": "",
+    "name": "radioGroup",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "role": {
+    "defaultValue": null,
+    "description": "",
+    "name": "role",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "AriaRole"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "about": {
+    "defaultValue": null,
+    "description": "",
+    "name": "about",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "datatype": {
+    "defaultValue": null,
+    "description": "",
+    "name": "datatype",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "inlist": {
+    "defaultValue": null,
+    "description": "",
+    "name": "inlist",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "any"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "prefix": {
+    "defaultValue": null,
+    "description": "",
+    "name": "prefix",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "property": {
+    "defaultValue": null,
+    "description": "",
+    "name": "property",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "resource": {
+    "defaultValue": null,
+    "description": "",
+    "name": "resource",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "typeof": {
+    "defaultValue": null,
+    "description": "",
+    "name": "typeof",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "vocab": {
+    "defaultValue": null,
+    "description": "",
+    "name": "vocab",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "autoCapitalize": {
+    "defaultValue": null,
+    "description": "",
+    "name": "autoCapitalize",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "autoCorrect": {
+    "defaultValue": null,
+    "description": "",
+    "name": "autoCorrect",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "autoSave": {
+    "defaultValue": null,
+    "description": "",
+    "name": "autoSave",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "color": {
+    "defaultValue": null,
+    "description": "",
+    "name": "color",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "color"
+    }
+  },
+  "itemProp": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemProp",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "itemScope": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemScope",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "itemType": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemType",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "itemID": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemID",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "itemRef": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemRef",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "results": {
+    "defaultValue": null,
+    "description": "",
+    "name": "results",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "security": {
+    "defaultValue": null,
+    "description": "",
+    "name": "security",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "unselectable": {
+    "defaultValue": null,
+    "description": "",
+    "name": "unselectable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"on\" | \"off\"",
+      "value": [
+        {
+          "value": "\"on\""
+        },
+        {
+          "value": "\"off\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["on", "off"]
+  },
+  "inputMode": {
+    "defaultValue": null,
+    "description": "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    "name": "inputMode",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"text\" | \"none\" | \"search\" | \"tel\" | \"url\" | \"email\" | \"numeric\" | \"decimal\"",
+      "value": [
+        {
+          "value": "\"text\""
+        },
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"search\""
+        },
+        {
+          "value": "\"tel\""
+        },
+        {
+          "value": "\"url\""
+        },
+        {
+          "value": "\"email\""
+        },
+        {
+          "value": "\"numeric\""
+        },
+        {
+          "value": "\"decimal\""
+        }
+      ]
+    },
+    "control": {
+      "type": "select"
+    },
+    "options": [
+      "text",
+      "none",
+      "search",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal"
+    ]
+  },
+  "is": {
+    "defaultValue": null,
+    "description": "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    "name": "is",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-activedescendant": {
+    "defaultValue": null,
+    "description": "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    "name": "aria-activedescendant",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-atomic": {
+    "defaultValue": null,
+    "description": "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    "name": "aria-atomic",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-autocomplete": {
+    "defaultValue": null,
+    "description": "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    "name": "aria-autocomplete",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"list\" | \"none\" | \"inline\" | \"both\"",
+      "value": [
+        {
+          "value": "\"list\""
+        },
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"inline\""
+        },
+        {
+          "value": "\"both\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["list", "none", "inline", "both"]
+  },
+  "aria-busy": {
+    "defaultValue": null,
+    "description": "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+    "name": "aria-busy",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-checked": {
+    "defaultValue": null,
+    "description": "Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.",
+    "name": "aria-checked",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"mixed\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-colcount": {
+    "defaultValue": null,
+    "description": "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    "name": "aria-colcount",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-colindex": {
+    "defaultValue": null,
+    "description": "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    "name": "aria-colindex",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-colspan": {
+    "defaultValue": null,
+    "description": "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    "name": "aria-colspan",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-controls": {
+    "defaultValue": null,
+    "description": "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    "name": "aria-controls",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-current": {
+    "defaultValue": null,
+    "description": "Indicates the element that represents the current item within a container or set of related elements.",
+    "name": "aria-current",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"time\" | \"true\" | \"false\" | \"page\" | \"step\" | \"location\" | \"date\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-describedby": {
+    "defaultValue": null,
+    "description": "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    "name": "aria-describedby",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-details": {
+    "defaultValue": null,
+    "description": "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    "name": "aria-details",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-disabled": {
+    "defaultValue": null,
+    "description": "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    "name": "aria-disabled",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-dropeffect": {
+    "defaultValue": null,
+    "description": "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    "name": "aria-dropeffect",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"link\" | \"none\" | \"copy\" | \"execute\" | \"move\" | \"popup\"",
+      "value": [
+        {
+          "value": "\"link\""
+        },
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"copy\""
+        },
+        {
+          "value": "\"execute\""
+        },
+        {
+          "value": "\"move\""
+        },
+        {
+          "value": "\"popup\""
+        }
+      ]
+    },
+    "control": {
+      "type": "select"
+    },
+    "options": ["link", "none", "copy", "execute", "move", "popup"]
+  },
+  "aria-errormessage": {
+    "defaultValue": null,
+    "description": "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    "name": "aria-errormessage",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-expanded": {
+    "defaultValue": null,
+    "description": "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    "name": "aria-expanded",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-flowto": {
+    "defaultValue": null,
+    "description": "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    "name": "aria-flowto",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-grabbed": {
+    "defaultValue": null,
+    "description": "Indicates an element's \"grabbed\" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1",
+    "name": "aria-grabbed",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-haspopup": {
+    "defaultValue": null,
+    "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    "name": "aria-haspopup",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"dialog\" | \"menu\" | \"true\" | \"false\" | \"grid\" | \"listbox\" | \"tree\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-hidden": {
+    "defaultValue": null,
+    "description": "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    "name": "aria-hidden",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-invalid": {
+    "defaultValue": null,
+    "description": "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    "name": "aria-invalid",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"grammar\" | \"spelling\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-keyshortcuts": {
+    "defaultValue": null,
+    "description": "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    "name": "aria-keyshortcuts",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-label": {
+    "defaultValue": null,
+    "description": "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    "name": "aria-label",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-labelledby": {
+    "defaultValue": null,
+    "description": "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    "name": "aria-labelledby",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-level": {
+    "defaultValue": null,
+    "description": "Defines the hierarchical level of an element within a structure.",
+    "name": "aria-level",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-live": {
+    "defaultValue": null,
+    "description": "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    "name": "aria-live",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"off\" | \"assertive\" | \"polite\"",
+      "value": [
+        {
+          "value": "\"off\""
+        },
+        {
+          "value": "\"assertive\""
+        },
+        {
+          "value": "\"polite\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["off", "assertive", "polite"]
+  },
+  "aria-modal": {
+    "defaultValue": null,
+    "description": "Indicates whether an element is modal when displayed.",
+    "name": "aria-modal",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-multiline": {
+    "defaultValue": null,
+    "description": "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    "name": "aria-multiline",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-multiselectable": {
+    "defaultValue": null,
+    "description": "Indicates that the user may select more than one item from the current selectable descendants.",
+    "name": "aria-multiselectable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-orientation": {
+    "defaultValue": null,
+    "description": "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    "name": "aria-orientation",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"horizontal\" | \"vertical\"",
+      "value": [
+        {
+          "value": "\"horizontal\""
+        },
+        {
+          "value": "\"vertical\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["horizontal", "vertical"]
+  },
+  "aria-owns": {
+    "defaultValue": null,
+    "description": "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    "name": "aria-owns",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-placeholder": {
+    "defaultValue": null,
+    "description": "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    "name": "aria-placeholder",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-posinset": {
+    "defaultValue": null,
+    "description": "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    "name": "aria-posinset",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-pressed": {
+    "defaultValue": null,
+    "description": "Indicates the current \"pressed\" state of toggle buttons.\n@see aria-checked\n@see aria-selected.",
+    "name": "aria-pressed",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"mixed\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-readonly": {
+    "defaultValue": null,
+    "description": "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    "name": "aria-readonly",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-relevant": {
+    "defaultValue": null,
+    "description": "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    "name": "aria-relevant",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"text\" | \"additions\" | \"additions removals\" | \"additions text\" | \"all\" | \"removals\" | \"removals additions\" | \"removals text\" | \"text additions\" | \"text removals\"",
+      "value": [
+        {
+          "value": "\"text\""
+        },
+        {
+          "value": "\"additions\""
+        },
+        {
+          "value": "\"additions removals\""
+        },
+        {
+          "value": "\"additions text\""
+        },
+        {
+          "value": "\"all\""
+        },
+        {
+          "value": "\"removals\""
+        },
+        {
+          "value": "\"removals additions\""
+        },
+        {
+          "value": "\"removals text\""
+        },
+        {
+          "value": "\"text additions\""
+        },
+        {
+          "value": "\"text removals\""
+        }
+      ]
+    },
+    "control": {
+      "type": "select"
+    },
+    "options": [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals"
+    ]
+  },
+  "aria-required": {
+    "defaultValue": null,
+    "description": "Indicates that user input is required on the element before a form may be submitted.",
+    "name": "aria-required",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-roledescription": {
+    "defaultValue": null,
+    "description": "Defines a human-readable, author-localized description for the role of an element.",
+    "name": "aria-roledescription",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-rowcount": {
+    "defaultValue": null,
+    "description": "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    "name": "aria-rowcount",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-rowindex": {
+    "defaultValue": null,
+    "description": "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    "name": "aria-rowindex",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-rowspan": {
+    "defaultValue": null,
+    "description": "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    "name": "aria-rowspan",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-selected": {
+    "defaultValue": null,
+    "description": "Indicates the current \"selected\" state of various widgets.\n@see aria-checked\n@see aria-pressed.",
+    "name": "aria-selected",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-setsize": {
+    "defaultValue": null,
+    "description": "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    "name": "aria-setsize",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-sort": {
+    "defaultValue": null,
+    "description": "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    "name": "aria-sort",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"none\" | \"ascending\" | \"descending\" | \"other\"",
+      "value": [
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"ascending\""
+        },
+        {
+          "value": "\"descending\""
+        },
+        {
+          "value": "\"other\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["none", "ascending", "descending", "other"]
+  },
+  "aria-valuemax": {
+    "defaultValue": null,
+    "description": "Defines the maximum allowed value for a range widget.",
+    "name": "aria-valuemax",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-valuemin": {
+    "defaultValue": null,
+    "description": "Defines the minimum allowed value for a range widget.",
+    "name": "aria-valuemin",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-valuenow": {
+    "defaultValue": null,
+    "description": "Defines the current value for a range widget.\n@see aria-valuetext.",
+    "name": "aria-valuenow",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-valuetext": {
+    "defaultValue": null,
+    "description": "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    "name": "aria-valuetext",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  }
+}

--- a/packages/react-sdk/src/components/subscript.stories.tsx
+++ b/packages/react-sdk/src/components/subscript.stories.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import type { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Bold as BoldPrimitive } from "./bold";
+import argTypes from "./bold.props.json";
+
+export default {
+  title: "Components/Bold",
+  component: BoldPrimitive,
+  argTypes,
+} as ComponentMeta<typeof BoldPrimitive>;
+
+const Template: ComponentStory<typeof BoldPrimitive> = (args) => (
+  <BoldPrimitive {...args} />
+);
+
+export const Bold = Template.bind({});
+Bold.args = {
+  children: "some bold text",
+};

--- a/packages/react-sdk/src/components/subscript.tsx
+++ b/packages/react-sdk/src/components/subscript.tsx
@@ -1,0 +1,10 @@
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
+
+const defaultTag = "sub";
+
+export const Subscript = forwardRef<
+  ElementRef<typeof defaultTag>,
+  ComponentProps<typeof defaultTag>
+>((props, ref) => <sub {...props} ref={ref} />);
+
+Subscript.displayName = "Subscript";

--- a/packages/react-sdk/src/components/subscript.ws.tsx
+++ b/packages/react-sdk/src/components/subscript.ws.tsx
@@ -1,0 +1,15 @@
+import { BrushIcon } from "@webstudio-is/icons";
+import type { WsComponentMeta } from "./component-type";
+import { Subscript } from "./subscript";
+
+const meta: WsComponentMeta<typeof Subscript> = {
+  Icon: BrushIcon,
+  Component: Subscript,
+  canAcceptChildren: false,
+  isContentEditable: false,
+  label: "Subscript Text",
+  isInlineOnly: true,
+  isListed: false,
+};
+
+export default meta;

--- a/packages/react-sdk/src/components/subscript.ws.tsx
+++ b/packages/react-sdk/src/components/subscript.ws.tsx
@@ -1,9 +1,9 @@
-import { BrushIcon } from "@webstudio-is/icons";
+import { SubscriptIcon } from "@webstudio-is/icons";
 import type { WsComponentMeta } from "./component-type";
 import { Subscript } from "./subscript";
 
 const meta: WsComponentMeta<typeof Subscript> = {
-  Icon: BrushIcon,
+  Icon: SubscriptIcon,
   Component: Subscript,
   canAcceptChildren: false,
   isContentEditable: false,

--- a/packages/react-sdk/src/components/superscript.props.json
+++ b/packages/react-sdk/src/components/superscript.props.json
@@ -1,0 +1,2205 @@
+{
+  "slot": {
+    "defaultValue": null,
+    "description": "",
+    "name": "slot",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "style": {
+    "defaultValue": null,
+    "description": "",
+    "name": "style",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "CSSProperties"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "title": {
+    "defaultValue": null,
+    "description": "",
+    "name": "title",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "defaultChecked": {
+    "defaultValue": null,
+    "description": "",
+    "name": "defaultChecked",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "defaultValue": {
+    "defaultValue": null,
+    "description": "",
+    "name": "defaultValue",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string | number | readonly string[]"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "suppressContentEditableWarning": {
+    "defaultValue": null,
+    "description": "",
+    "name": "suppressContentEditableWarning",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "suppressHydrationWarning": {
+    "defaultValue": null,
+    "description": "",
+    "name": "suppressHydrationWarning",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "accessKey": {
+    "defaultValue": null,
+    "description": "",
+    "name": "accessKey",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "className": {
+    "defaultValue": null,
+    "description": "",
+    "name": "className",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "contentEditable": {
+    "defaultValue": null,
+    "description": "",
+    "name": "contentEditable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish | \"inherit\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "contextMenu": {
+    "defaultValue": null,
+    "description": "",
+    "name": "contextMenu",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "dir": {
+    "defaultValue": null,
+    "description": "",
+    "name": "dir",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "draggable": {
+    "defaultValue": null,
+    "description": "",
+    "name": "draggable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "hidden": {
+    "defaultValue": null,
+    "description": "",
+    "name": "hidden",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "id": {
+    "defaultValue": null,
+    "description": "",
+    "name": "id",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "lang": {
+    "defaultValue": null,
+    "description": "",
+    "name": "lang",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "placeholder": {
+    "defaultValue": null,
+    "description": "",
+    "name": "placeholder",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "spellCheck": {
+    "defaultValue": null,
+    "description": "",
+    "name": "spellCheck",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "tabIndex": {
+    "defaultValue": null,
+    "description": "",
+    "name": "tabIndex",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "translate": {
+    "defaultValue": null,
+    "description": "",
+    "name": "translate",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"yes\" | \"no\"",
+      "value": [
+        {
+          "value": "\"yes\""
+        },
+        {
+          "value": "\"no\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["yes", "no"]
+  },
+  "radioGroup": {
+    "defaultValue": null,
+    "description": "",
+    "name": "radioGroup",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "role": {
+    "defaultValue": null,
+    "description": "",
+    "name": "role",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "AriaRole"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "about": {
+    "defaultValue": null,
+    "description": "",
+    "name": "about",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "datatype": {
+    "defaultValue": null,
+    "description": "",
+    "name": "datatype",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "inlist": {
+    "defaultValue": null,
+    "description": "",
+    "name": "inlist",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "any"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "prefix": {
+    "defaultValue": null,
+    "description": "",
+    "name": "prefix",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "property": {
+    "defaultValue": null,
+    "description": "",
+    "name": "property",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "resource": {
+    "defaultValue": null,
+    "description": "",
+    "name": "resource",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "typeof": {
+    "defaultValue": null,
+    "description": "",
+    "name": "typeof",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "vocab": {
+    "defaultValue": null,
+    "description": "",
+    "name": "vocab",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "autoCapitalize": {
+    "defaultValue": null,
+    "description": "",
+    "name": "autoCapitalize",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "autoCorrect": {
+    "defaultValue": null,
+    "description": "",
+    "name": "autoCorrect",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "autoSave": {
+    "defaultValue": null,
+    "description": "",
+    "name": "autoSave",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "color": {
+    "defaultValue": null,
+    "description": "",
+    "name": "color",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "color"
+    }
+  },
+  "itemProp": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemProp",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "itemScope": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemScope",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "itemType": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemType",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "itemID": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemID",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "itemRef": {
+    "defaultValue": null,
+    "description": "",
+    "name": "itemRef",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "results": {
+    "defaultValue": null,
+    "description": "",
+    "name": "results",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "security": {
+    "defaultValue": null,
+    "description": "",
+    "name": "security",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "unselectable": {
+    "defaultValue": null,
+    "description": "",
+    "name": "unselectable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"on\" | \"off\"",
+      "value": [
+        {
+          "value": "\"on\""
+        },
+        {
+          "value": "\"off\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["on", "off"]
+  },
+  "inputMode": {
+    "defaultValue": null,
+    "description": "Hints at the type of data that might be entered by the user while editing the element or its contents\n@see https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute",
+    "name": "inputMode",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"text\" | \"none\" | \"search\" | \"tel\" | \"url\" | \"email\" | \"numeric\" | \"decimal\"",
+      "value": [
+        {
+          "value": "\"text\""
+        },
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"search\""
+        },
+        {
+          "value": "\"tel\""
+        },
+        {
+          "value": "\"url\""
+        },
+        {
+          "value": "\"email\""
+        },
+        {
+          "value": "\"numeric\""
+        },
+        {
+          "value": "\"decimal\""
+        }
+      ]
+    },
+    "control": {
+      "type": "select"
+    },
+    "options": [
+      "text",
+      "none",
+      "search",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal"
+    ]
+  },
+  "is": {
+    "defaultValue": null,
+    "description": "Specify that a standard HTML element should behave like a defined custom built-in element\n@see https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is",
+    "name": "is",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "HTMLAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "HTMLAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-activedescendant": {
+    "defaultValue": null,
+    "description": "Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.",
+    "name": "aria-activedescendant",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-atomic": {
+    "defaultValue": null,
+    "description": "Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.",
+    "name": "aria-atomic",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-autocomplete": {
+    "defaultValue": null,
+    "description": "Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be\npresented if they are made.",
+    "name": "aria-autocomplete",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"list\" | \"none\" | \"inline\" | \"both\"",
+      "value": [
+        {
+          "value": "\"list\""
+        },
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"inline\""
+        },
+        {
+          "value": "\"both\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["list", "none", "inline", "both"]
+  },
+  "aria-busy": {
+    "defaultValue": null,
+    "description": "Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.",
+    "name": "aria-busy",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-checked": {
+    "defaultValue": null,
+    "description": "Indicates the current \"checked\" state of checkboxes, radio buttons, and other widgets.\n@see aria-pressed\n@see aria-selected.",
+    "name": "aria-checked",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"mixed\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-colcount": {
+    "defaultValue": null,
+    "description": "Defines the total number of columns in a table, grid, or treegrid.\n@see aria-colindex.",
+    "name": "aria-colcount",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-colindex": {
+    "defaultValue": null,
+    "description": "Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.\n@see aria-colcount\n@see aria-colspan.",
+    "name": "aria-colindex",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-colspan": {
+    "defaultValue": null,
+    "description": "Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-colindex\n@see aria-rowspan.",
+    "name": "aria-colspan",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-controls": {
+    "defaultValue": null,
+    "description": "Identifies the element (or elements) whose contents or presence are controlled by the current element.\n@see aria-owns.",
+    "name": "aria-controls",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-current": {
+    "defaultValue": null,
+    "description": "Indicates the element that represents the current item within a container or set of related elements.",
+    "name": "aria-current",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"time\" | \"true\" | \"false\" | \"page\" | \"step\" | \"location\" | \"date\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-describedby": {
+    "defaultValue": null,
+    "description": "Identifies the element (or elements) that describes the object.\n@see aria-labelledby",
+    "name": "aria-describedby",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-details": {
+    "defaultValue": null,
+    "description": "Identifies the element that provides a detailed, extended description for the object.\n@see aria-describedby.",
+    "name": "aria-details",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-disabled": {
+    "defaultValue": null,
+    "description": "Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.\n@see aria-hidden\n@see aria-readonly.",
+    "name": "aria-disabled",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-dropeffect": {
+    "defaultValue": null,
+    "description": "Indicates what functions can be performed when a dragged object is released on the drop target.\n@deprecated in ARIA 1.1",
+    "name": "aria-dropeffect",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"link\" | \"none\" | \"copy\" | \"execute\" | \"move\" | \"popup\"",
+      "value": [
+        {
+          "value": "\"link\""
+        },
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"copy\""
+        },
+        {
+          "value": "\"execute\""
+        },
+        {
+          "value": "\"move\""
+        },
+        {
+          "value": "\"popup\""
+        }
+      ]
+    },
+    "control": {
+      "type": "select"
+    },
+    "options": ["link", "none", "copy", "execute", "move", "popup"]
+  },
+  "aria-errormessage": {
+    "defaultValue": null,
+    "description": "Identifies the element that provides an error message for the object.\n@see aria-invalid\n@see aria-describedby.",
+    "name": "aria-errormessage",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-expanded": {
+    "defaultValue": null,
+    "description": "Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.",
+    "name": "aria-expanded",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-flowto": {
+    "defaultValue": null,
+    "description": "Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,\nallows assistive technology to override the general default of reading in document source order.",
+    "name": "aria-flowto",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-grabbed": {
+    "defaultValue": null,
+    "description": "Indicates an element's \"grabbed\" state in a drag-and-drop operation.\n@deprecated in ARIA 1.1",
+    "name": "aria-grabbed",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-haspopup": {
+    "defaultValue": null,
+    "description": "Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.",
+    "name": "aria-haspopup",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"dialog\" | \"menu\" | \"true\" | \"false\" | \"grid\" | \"listbox\" | \"tree\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-hidden": {
+    "defaultValue": null,
+    "description": "Indicates whether the element is exposed to an accessibility API.\n@see aria-disabled.",
+    "name": "aria-hidden",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-invalid": {
+    "defaultValue": null,
+    "description": "Indicates the entered value does not conform to the format expected by the application.\n@see aria-errormessage.",
+    "name": "aria-invalid",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"grammar\" | \"spelling\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-keyshortcuts": {
+    "defaultValue": null,
+    "description": "Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.",
+    "name": "aria-keyshortcuts",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-label": {
+    "defaultValue": null,
+    "description": "Defines a string value that labels the current element.\n@see aria-labelledby.",
+    "name": "aria-label",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-labelledby": {
+    "defaultValue": null,
+    "description": "Identifies the element (or elements) that labels the current element.\n@see aria-describedby.",
+    "name": "aria-labelledby",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-level": {
+    "defaultValue": null,
+    "description": "Defines the hierarchical level of an element within a structure.",
+    "name": "aria-level",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-live": {
+    "defaultValue": null,
+    "description": "Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.",
+    "name": "aria-live",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"off\" | \"assertive\" | \"polite\"",
+      "value": [
+        {
+          "value": "\"off\""
+        },
+        {
+          "value": "\"assertive\""
+        },
+        {
+          "value": "\"polite\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["off", "assertive", "polite"]
+  },
+  "aria-modal": {
+    "defaultValue": null,
+    "description": "Indicates whether an element is modal when displayed.",
+    "name": "aria-modal",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-multiline": {
+    "defaultValue": null,
+    "description": "Indicates whether a text box accepts multiple lines of input or only a single line.",
+    "name": "aria-multiline",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-multiselectable": {
+    "defaultValue": null,
+    "description": "Indicates that the user may select more than one item from the current selectable descendants.",
+    "name": "aria-multiselectable",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-orientation": {
+    "defaultValue": null,
+    "description": "Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.",
+    "name": "aria-orientation",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"horizontal\" | \"vertical\"",
+      "value": [
+        {
+          "value": "\"horizontal\""
+        },
+        {
+          "value": "\"vertical\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["horizontal", "vertical"]
+  },
+  "aria-owns": {
+    "defaultValue": null,
+    "description": "Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship\nbetween DOM elements where the DOM hierarchy cannot be used to represent the relationship.\n@see aria-controls.",
+    "name": "aria-owns",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-placeholder": {
+    "defaultValue": null,
+    "description": "Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.\nA hint could be a sample value or a brief description of the expected format.",
+    "name": "aria-placeholder",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-posinset": {
+    "defaultValue": null,
+    "description": "Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-setsize.",
+    "name": "aria-posinset",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-pressed": {
+    "defaultValue": null,
+    "description": "Indicates the current \"pressed\" state of toggle buttons.\n@see aria-checked\n@see aria-selected.",
+    "name": "aria-pressed",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "boolean | \"true\" | \"false\" | \"mixed\""
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-readonly": {
+    "defaultValue": null,
+    "description": "Indicates that the element is not editable, but is otherwise operable.\n@see aria-disabled.",
+    "name": "aria-readonly",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-relevant": {
+    "defaultValue": null,
+    "description": "Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.\n@see aria-atomic.",
+    "name": "aria-relevant",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"text\" | \"additions\" | \"additions removals\" | \"additions text\" | \"all\" | \"removals\" | \"removals additions\" | \"removals text\" | \"text additions\" | \"text removals\"",
+      "value": [
+        {
+          "value": "\"text\""
+        },
+        {
+          "value": "\"additions\""
+        },
+        {
+          "value": "\"additions removals\""
+        },
+        {
+          "value": "\"additions text\""
+        },
+        {
+          "value": "\"all\""
+        },
+        {
+          "value": "\"removals\""
+        },
+        {
+          "value": "\"removals additions\""
+        },
+        {
+          "value": "\"removals text\""
+        },
+        {
+          "value": "\"text additions\""
+        },
+        {
+          "value": "\"text removals\""
+        }
+      ]
+    },
+    "control": {
+      "type": "select"
+    },
+    "options": [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals"
+    ]
+  },
+  "aria-required": {
+    "defaultValue": null,
+    "description": "Indicates that user input is required on the element before a form may be submitted.",
+    "name": "aria-required",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-roledescription": {
+    "defaultValue": null,
+    "description": "Defines a human-readable, author-localized description for the role of an element.",
+    "name": "aria-roledescription",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  },
+  "aria-rowcount": {
+    "defaultValue": null,
+    "description": "Defines the total number of rows in a table, grid, or treegrid.\n@see aria-rowindex.",
+    "name": "aria-rowcount",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-rowindex": {
+    "defaultValue": null,
+    "description": "Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.\n@see aria-rowcount\n@see aria-rowspan.",
+    "name": "aria-rowindex",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-rowspan": {
+    "defaultValue": null,
+    "description": "Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.\n@see aria-rowindex\n@see aria-colspan.",
+    "name": "aria-rowspan",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-selected": {
+    "defaultValue": null,
+    "description": "Indicates the current \"selected\" state of various widgets.\n@see aria-checked\n@see aria-pressed.",
+    "name": "aria-selected",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "Booleanish"
+    },
+    "control": {
+      "type": "boolean"
+    }
+  },
+  "aria-setsize": {
+    "defaultValue": null,
+    "description": "Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.\n@see aria-posinset.",
+    "name": "aria-setsize",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-sort": {
+    "defaultValue": null,
+    "description": "Indicates if items in a table or grid are sorted in ascending or descending order.",
+    "name": "aria-sort",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "enum",
+      "raw": "\"none\" | \"ascending\" | \"descending\" | \"other\"",
+      "value": [
+        {
+          "value": "\"none\""
+        },
+        {
+          "value": "\"ascending\""
+        },
+        {
+          "value": "\"descending\""
+        },
+        {
+          "value": "\"other\""
+        }
+      ]
+    },
+    "control": {
+      "type": "radio"
+    },
+    "options": ["none", "ascending", "descending", "other"]
+  },
+  "aria-valuemax": {
+    "defaultValue": null,
+    "description": "Defines the maximum allowed value for a range widget.",
+    "name": "aria-valuemax",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-valuemin": {
+    "defaultValue": null,
+    "description": "Defines the minimum allowed value for a range widget.",
+    "name": "aria-valuemin",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-valuenow": {
+    "defaultValue": null,
+    "description": "Defines the current value for a range widget.\n@see aria-valuetext.",
+    "name": "aria-valuenow",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "number"
+    },
+    "control": {
+      "type": "number"
+    }
+  },
+  "aria-valuetext": {
+    "defaultValue": null,
+    "description": "Defines the human readable text alternative of aria-valuenow for a range widget.",
+    "name": "aria-valuetext",
+    "parent": {
+      "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+      "name": "AriaAttributes"
+    },
+    "declarations": [
+      {
+        "fileName": "webstudio-designer/node_modules/@types/react/index.d.ts",
+        "name": "AriaAttributes"
+      }
+    ],
+    "required": false,
+    "type": {
+      "name": "string"
+    },
+    "control": {
+      "type": "text"
+    }
+  }
+}

--- a/packages/react-sdk/src/components/superscript.stories.tsx
+++ b/packages/react-sdk/src/components/superscript.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Superscript as SuperscriptPrimitive } from "./superscript";
+import argTypes from "./superscript.props.json";
+
+export default {
+  title: "Components/Superscript",
+  component: SuperscriptPrimitive,
+  argTypes,
+} as ComponentMeta<typeof SuperscriptPrimitive>;
+
+const Template: ComponentStory<typeof SuperscriptPrimitive> = (args) => (
+  <SuperscriptPrimitive {...args} />
+);
+
+export const Superscript = Template.bind({});
+Superscript.args = {
+  children: "some superscript text",
+};

--- a/packages/react-sdk/src/components/superscript.tsx
+++ b/packages/react-sdk/src/components/superscript.tsx
@@ -1,0 +1,10 @@
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
+
+const defaultTag = "sup";
+
+export const Superscript = forwardRef<
+  ElementRef<typeof defaultTag>,
+  ComponentProps<typeof defaultTag>
+>((props, ref) => <sup {...props} ref={ref} />);
+
+Superscript.displayName = "Bold";

--- a/packages/react-sdk/src/components/superscript.ws.tsx
+++ b/packages/react-sdk/src/components/superscript.ws.tsx
@@ -1,9 +1,9 @@
-import { BrushIcon } from "@webstudio-is/icons";
+import { SuperscriptIcon } from "@webstudio-is/icons";
 import type { WsComponentMeta } from "./component-type";
 import { Superscript } from "./superscript";
 
 const meta: WsComponentMeta<typeof Superscript> = {
-  Icon: BrushIcon,
+  Icon: SuperscriptIcon,
   Component: Superscript,
   canAcceptChildren: false,
   isContentEditable: false,

--- a/packages/react-sdk/src/components/superscript.ws.tsx
+++ b/packages/react-sdk/src/components/superscript.ws.tsx
@@ -1,0 +1,15 @@
+import { BrushIcon } from "@webstudio-is/icons";
+import type { WsComponentMeta } from "./component-type";
+import { Superscript } from "./superscript";
+
+const meta: WsComponentMeta<typeof Superscript> = {
+  Icon: BrushIcon,
+  Component: Superscript,
+  canAcceptChildren: false,
+  isContentEditable: false,
+  label: "Superscript Text",
+  isInlineOnly: true,
+  isListed: false,
+};
+
+export default meta;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/400

- added superscript
- added subscript
- added clear formatting, used same trick as with span
- refactored interop to cover more options with less code
- convert newlines to linebreaks instead of paragraphs when convert instances to lexical tree

Still missing icons for superscript, subscript and clear

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [x] conceptual
  - [ ] detailed
  - [x] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
