### PR TITLE
Use floating-ui to position text toolbar

### DIFF
--- a/apps/designer/app/canvas/features/text-editor/toolbar-connector.tsx
+++ b/apps/designer/app/canvas/features/text-editor/toolbar-connector.tsx
@@ -137,7 +137,7 @@ export const ToolbarConnectorPlugin = () => {
       document.removeEventListener("mousedown", onMouseDown);
       document.removeEventListener("mouseup", onMouseUp);
     };
-  }, [updateToolbar]);
+  }, [editor, updateToolbar]);
 
   useEffect(() => {
     // hide toolbar when editor is unmounted

--- a/apps/designer/app/canvas/features/text-editor/toolbar-connector.tsx
+++ b/apps/designer/app/canvas/features/text-editor/toolbar-connector.tsx
@@ -119,6 +119,7 @@ export const ToolbarConnectorPlugin = () => {
     }
   }, []);
 
+  // prevent showing toolbar when select with mouse
   useEffect(() => {
     const onMouseDown = () => {
       isMouseDownRef.current = true;

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -66,6 +66,7 @@ type ToolbarProps = {
 
 const Toolbar = ({ state, onToggle }: ToolbarProps) => {
   const rootRef = useRef<HTMLDivElement | null>(null);
+
   useEffect(() => {
     if (rootRef.current && rootRef.current.parentElement) {
       const floating = rootRef.current;
@@ -79,7 +80,7 @@ const Toolbar = ({ state, onToggle }: ToolbarProps) => {
       };
       computePosition(reference, floating, {
         placement: "top",
-        middleware: [flip(), shift({ padding: 4 }), offset(16)],
+        middleware: [flip(), shift({ padding: 4 }), offset(12)],
       }).then(({ x, y }) => {
         floating.style.transform = `translate(${x}px, ${y}px)`;
       });

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -46,7 +46,7 @@ const onClickPreventDefault: MouseEventHandler<HTMLDivElement> = (event) => {
   event.stopPropagation();
 };
 
-const computeAbsoluteRect = (parent: DOMRect, rel: DOMRect) => {
+const getRectForRelativeRect = (parent: DOMRect, rel: DOMRect) => {
   return {
     x: parent.x + rel.x,
     y: parent.y + rel.y,
@@ -54,8 +54,8 @@ const computeAbsoluteRect = (parent: DOMRect, rel: DOMRect) => {
     height: rel.height,
     top: parent.top + rel.top,
     left: parent.left + rel.left,
-    bottom: parent.bottom - rel.bottom,
-    right: parent.right - rel.right,
+    bottom: parent.top + rel.bottom,
+    right: parent.left + rel.right,
   };
 };
 
@@ -71,7 +71,7 @@ const Toolbar = ({ state, onToggle }: ToolbarProps) => {
     if (rootRef.current?.parentElement) {
       const floating = rootRef.current;
       const parent = rootRef.current.parentElement;
-      const newRect = computeAbsoluteRect(
+      const newRect = getRectForRelativeRect(
         parent.getBoundingClientRect(),
         state.selectionRect
       );

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -1,15 +1,12 @@
+import { useRef, useEffect, type MouseEventHandler } from "react";
+import { computePosition, flip, offset, shift } from "@floating-ui/dom";
 import { type Publish } from "~/shared/pubsub";
-import { useMemo, useState, type MouseEventHandler } from "react";
 import {
   useSelectedInstanceData,
   type TextToolbarState,
   useTextToolbarState,
 } from "~/designer/shared/nano-states";
-import {
-  type CSS,
-  ToggleGroupRoot,
-  ToggleGroupItem,
-} from "@webstudio-is/design-system";
+import { ToggleGroupRoot, ToggleGroupItem } from "@webstudio-is/design-system";
 import {
   FontBoldIcon,
   FontItalicIcon,
@@ -44,51 +41,51 @@ export const useSubscribeTextToolbar = () => {
   useSubscribe("hideTextToolbar", () => setTextToolbar(undefined));
 };
 
-const getPlacement = ({
-  toolbarRect,
-  selectionRect,
-}: {
-  toolbarRect?: DOMRect;
-  selectionRect: DOMRect;
-}) => {
-  let align = "top";
-  let left = selectionRect.x + selectionRect.width / 2;
-  // We measure the size in a hidden state after we render the menu,
-  // then show it
-  let visibility = "hidden";
-  if (toolbarRect !== undefined) {
-    visibility = "visible";
-    // Prevent going further than left 0
-    left = Math.max(left, toolbarRect.width / 2);
-    // Prevent going further than window width
-    left = Math.min(left, window.innerWidth - toolbarRect.width / 2);
-    align = selectionRect.y > toolbarRect.height ? "top" : "bottom";
-  }
-
-  const marginBottom = align === "bottom" ? "-$5" : 0;
-  const marginTop = align === "bottom" ? 0 : "-$5";
-  const transform = "translateX(-50%)";
-  const top =
-    align === "top"
-      ? Math.max(selectionRect.y - selectionRect.height, 0)
-      : Math.max(selectionRect.y + selectionRect.height);
-
-  return { top, left, marginBottom, marginTop, transform, visibility };
-};
-
 const onClickPreventDefault: MouseEventHandler<HTMLDivElement> = (event) => {
   event.preventDefault();
   event.stopPropagation();
 };
 
+const computeAbsoluteRect = (parent: DOMRect, rel: DOMRect) => {
+  return {
+    x: parent.x + rel.x,
+    y: parent.y + rel.y,
+    width: rel.width,
+    height: rel.height,
+    top: parent.top + rel.top,
+    left: parent.left + rel.left,
+    bottom: parent.bottom - rel.bottom,
+    right: parent.right - rel.right,
+  };
+};
+
 type ToolbarProps = {
-  css?: CSS;
-  rootRef: React.Ref<HTMLDivElement>;
   state: TextToolbarState;
   onToggle: (value: Format) => void;
 };
 
-const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
+const Toolbar = ({ state, onToggle }: ToolbarProps) => {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (rootRef.current && rootRef.current.parentElement) {
+      const floating = rootRef.current;
+      const parent = rootRef.current.parentElement;
+      const newRect = computeAbsoluteRect(
+        parent.getBoundingClientRect(),
+        state.selectionRect
+      );
+      const reference = {
+        getBoundingClientRect: () => newRect,
+      };
+      computePosition(reference, floating, {
+        placement: "top",
+        middleware: [flip(), shift({ padding: 4 }), offset(16)],
+      }).then(({ x, y }) => {
+        floating.style.transform = `translate(${x}px, ${y}px)`;
+      });
+    }
+  }, [state.selectionRect]);
+
   const value: Format[] = [];
   if (state.isBold) {
     value.push("bold");
@@ -108,6 +105,7 @@ const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
   if (state.isSpan) {
     value.push("span");
   }
+
   return (
     <ToggleGroupRoot
       ref={rootRef}
@@ -140,10 +138,10 @@ const Toolbar = ({ css, rootRef, state, onToggle }: ToolbarProps) => {
       onClick={onClickPreventDefault}
       css={{
         position: "absolute",
-        borderRadius: "$borderRadius$4",
-        padding: "$spacing$3 $spacing$5",
+        top: 0,
+        left: 0,
         pointerEvents: "auto",
-        ...css,
+        background: "white",
       }}
     >
       <ToggleGroupItem value="bold">
@@ -178,15 +176,6 @@ type TextToolbarProps = {
 export const TextToolbar = ({ publish }: TextToolbarProps) => {
   const [textToolbar] = useTextToolbarState();
   const [selectedIntsanceData] = useSelectedInstanceData();
-  const [element, setElement] = useState<HTMLElement | null>(null);
-  const placement = useMemo(() => {
-    if (textToolbar == null || element === null) return;
-    const toolbarRect = element.getBoundingClientRect();
-    return getPlacement({
-      toolbarRect,
-      selectionRect: textToolbar.selectionRect,
-    });
-  }, [textToolbar, element]);
 
   if (textToolbar == null || selectedIntsanceData === undefined) {
     return null;
@@ -194,8 +183,6 @@ export const TextToolbar = ({ publish }: TextToolbarProps) => {
 
   return (
     <Toolbar
-      rootRef={setElement}
-      css={placement}
       state={textToolbar}
       onToggle={(value) =>
         publish({

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -68,7 +68,7 @@ const Toolbar = ({ state, onToggle }: ToolbarProps) => {
   const rootRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (rootRef.current && rootRef.current.parentElement) {
+    if (rootRef.current?.parentElement) {
       const floating = rootRef.current;
       const parent = rootRef.current.parentElement;
       const newRect = computeAbsoluteRect(

--- a/apps/designer/package.json
+++ b/apps/designer/package.json
@@ -17,6 +17,7 @@
     "ci:migrate": "migrations migrate --force"
   },
   "dependencies": {
+    "@floating-ui/dom": "^1.0.6",
     "@lexical/react": "^0.6.0",
     "@remix-run/node": "^1.6.4",
     "@remix-run/react": "^1.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,12 +2220,24 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-0.7.3.tgz#d274116678ffae87f6b60e90f88cc4083eefab86"
   integrity sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==
 
+"@floating-ui/core@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.2.tgz#d06a66d3ad8214186eda2432ac8b8d81868a571f"
+  integrity sha512-Skfy0YS3NJ5nV9us0uuPN0HDk1Q4edljaOhRBJGDWs9EBa7ZVMYBHRFlhLvvmwEoaIM9BlH6QJFn9/uZg0bACg==
+
 "@floating-ui/dom@^0.5.3":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-0.5.4.tgz#4eae73f78bcd4bd553ae2ade30e6f1f9c73fe3f1"
   integrity sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==
   dependencies:
     "@floating-ui/core" "^0.7.3"
+
+"@floating-ui/dom@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.6.tgz#e42393ec381a4fe96673fbcee137a95e86c93ebc"
+  integrity sha512-kt/tg1oip9OAH1xjCTcx1OpcUpu9rjDw3GKJ/rEhUqhO7QyJWfrHU0DpLTNsH67+JyFL5Kv9X1utsXwKFVtyEQ==
+  dependencies:
+    "@floating-ui/core" "^1.0.2"
 
 "@floating-ui/react-dom@0.7.2":
   version "0.7.2"


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/107

Text toolbar is badly positioned when flipped up. Keeping it too close to cursor makes text selection harder.

Here I replaced custom logic with computed rect from toolbar parent and state from canvas. A few middlewares polished offsets. Flip no longer overlap text.

Also fixed toolbar background.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [xx] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [x] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
