### PR TITLE
Fix styles when enter editor mode

### DIFF
--- a/apps/designer/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/designer/app/canvas/features/text-editor/text-editor.tsx
@@ -8,6 +8,7 @@ import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import type { ChildrenUpdates, Instance } from "@webstudio-is/react-sdk";
+import { idAttribute } from "@webstudio-is/react-sdk";
 import { ToolbarConnectorPlugin } from "./toolbar-connector";
 import { type Refs, $convertToLexical, $convertToUpdates } from "./interop";
 
@@ -19,7 +20,7 @@ const BindInstanceToNodePlugin = ({ refs }: { refs: Refs }) => {
       const [key] = nodeKey.split(":");
       const element = editor.getElementByKey(key);
       if (element) {
-        element.setAttribute("data-ws-id", instance.id);
+        element.setAttribute(idAttribute, instance.id);
       }
     }
   }, [editor, refs]);

--- a/apps/designer/app/canvas/features/text-editor/text-editor.tsx
+++ b/apps/designer/app/canvas/features/text-editor/text-editor.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { LinkNode } from "@lexical/link";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import LexicalErrorBoundary from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
@@ -9,6 +10,21 @@ import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import type { ChildrenUpdates, Instance } from "@webstudio-is/react-sdk";
 import { ToolbarConnectorPlugin } from "./toolbar-connector";
 import { type Refs, $convertToLexical, $convertToUpdates } from "./interop";
+
+const BindInstanceToNodePlugin = ({ refs }: { refs: Refs }) => {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    for (const [nodeKey, instance] of refs) {
+      // extract key from stored key:style format
+      const [key] = nodeKey.split(":");
+      const element = editor.getElementByKey(key);
+      if (element) {
+        element.setAttribute("data-ws-id", instance.id);
+      }
+    }
+  }, [editor, refs]);
+  return null;
+};
 
 const onError = (error: Error) => {
   throw error;
@@ -44,6 +60,7 @@ export const TextEditor = ({
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <ToolbarConnectorPlugin />
+      <BindInstanceToNodePlugin refs={refs} />
       <RichTextPlugin
         ErrorBoundary={LexicalErrorBoundary}
         contentEditable={contentEditable}

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -142,7 +142,7 @@ const Toolbar = ({ state, onToggle }: ToolbarProps) => {
         top: 0,
         left: 0,
         pointerEvents: "auto",
-        background: "white",
+        background: "$loContrast",
       }}
     >
       <ToggleGroupItem value="bold">


### PR DESCRIPTION
Styles were lost when refactored with new css engine. Here used the same way as with className before but instead set data-ws-id attribute. Did not add data-ws-component to avoid selecting.

Fixed text toolbar background for dark mode.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [x] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
