### PR TITLE
Find unused variables with typescript

### DIFF
--- a/apps/designer/app/designer/features/props-panel/control.tsx
+++ b/apps/designer/app/designer/features/props-panel/control.tsx
@@ -1,5 +1,5 @@
 import { UserProp } from "@webstudio-is/react-sdk";
-import React, { ComponentProps } from "react";
+import type { ComponentProps } from "react";
 import {
   Flex,
   Label,
@@ -143,8 +143,6 @@ const RangeControl = ({
   </Flex>
 );
 
-const NotImplemented = () => <div />;
-
 type PrimitiveControlProps = BaseControlProps & {
   type: "array" | "boolean" | "date" | "number" | "object" | "text";
 };
@@ -218,8 +216,8 @@ export function Control(props: ControlProps) {
     case "text":
       return <TextControl {...props} />;
     default: {
-      const _exhaustiveCheck: never = props;
-      return <NotImplemented />;
+      const _exhaustivecheck: never = props;
+      return _exhaustivecheck;
     }
   }
 }

--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   useState,
   forwardRef,
   useCallback,

--- a/packages/design-system/src/components/text.stories.tsx
+++ b/packages/design-system/src/components/text.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ComponentStory } from "@storybook/react";
 import { Text } from "./text";
 

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -29,16 +29,8 @@ module.exports = {
     // It's too dumb to understand properly what's defined in ts
     "react/prop-types": 0,
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      {
-        argsIgnorePattern: "^_",
-        varsIgnorePattern: "^_",
-        caughtErrorsIgnorePattern: "^_",
-        ignoreRestSiblings: true,
-      },
-    ],
-    "react/react-in-jsx-scope": 0,
+    "react/react-in-jsx-scope": "off",
+    "@typescript-eslint/no-unused-vars": "off",
     "func-style": ["error", "expression", { allowArrowFunctions: true }],
     "unicorn/filename-case": [
       "error",

--- a/packages/react-sdk/src/components/body.stories.tsx
+++ b/packages/react-sdk/src/components/body.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Body as BodyPrimitive } from "./body";
 import argTypes from "./body.props.json";

--- a/packages/react-sdk/src/components/bold.stories.tsx
+++ b/packages/react-sdk/src/components/bold.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Bold as BoldPrimitive } from "./bold";
 import argTypes from "./bold.props.json";

--- a/packages/react-sdk/src/components/bold.tsx
+++ b/packages/react-sdk/src/components/bold.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 const defaultTag = "b";
 

--- a/packages/react-sdk/src/components/box.stories.tsx
+++ b/packages/react-sdk/src/components/box.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Box as BoxPrimitive } from "./box";
 import argTypes from "./box.props.json";

--- a/packages/react-sdk/src/components/button.stories.tsx
+++ b/packages/react-sdk/src/components/button.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Button as ButtonPrimitive } from "./button";
 import argTypes from "./button.props.json";

--- a/packages/react-sdk/src/components/button.tsx
+++ b/packages/react-sdk/src/components/button.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 const defaultTag = "button";
 

--- a/packages/react-sdk/src/components/form.stories.tsx
+++ b/packages/react-sdk/src/components/form.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Form as FormPrimitive } from "./form";
 import argTypes from "./form.props.json";

--- a/packages/react-sdk/src/components/form.tsx
+++ b/packages/react-sdk/src/components/form.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 const defaultTag = "form";
 

--- a/packages/react-sdk/src/components/heading.stories.tsx
+++ b/packages/react-sdk/src/components/heading.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Heading as HeadingPrimitive } from "./heading";
 import argTypes from "./heading.props.json";

--- a/packages/react-sdk/src/components/image.stories.tsx
+++ b/packages/react-sdk/src/components/image.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Image as ImagePrimitive } from "./image";
 import argTypes from "./image.props.json";

--- a/packages/react-sdk/src/components/image.tsx
+++ b/packages/react-sdk/src/components/image.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 import { getImageAttributes, type ImageLoader } from "../component-utils/image";
 
 const defaultTag = "img";

--- a/packages/react-sdk/src/components/input.stories.tsx
+++ b/packages/react-sdk/src/components/input.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Input as InputPrimitive } from "./input";
 import argTypes from "./input.props.json";

--- a/packages/react-sdk/src/components/input.tsx
+++ b/packages/react-sdk/src/components/input.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 const defaultTag = "input";
 

--- a/packages/react-sdk/src/components/italic.stories.tsx
+++ b/packages/react-sdk/src/components/italic.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Italic as ItalicPrimitive } from "./italic";
 import argTypes from "./italic.props.json";

--- a/packages/react-sdk/src/components/italic.tsx
+++ b/packages/react-sdk/src/components/italic.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 const defaultTag = "i";
 

--- a/packages/react-sdk/src/components/link.stories.tsx
+++ b/packages/react-sdk/src/components/link.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Link as LinkPrimitive } from "./link";
 import argTypes from "./link.props.json";

--- a/packages/react-sdk/src/components/link.tsx
+++ b/packages/react-sdk/src/components/link.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 const defaultTag = "a";
 

--- a/packages/react-sdk/src/components/paragraph.stories.tsx
+++ b/packages/react-sdk/src/components/paragraph.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Paragraph as ParagraphPrimitive } from "./paragraph";
 import argTypes from "./paragraph.props.json";

--- a/packages/react-sdk/src/components/paragraph.tsx
+++ b/packages/react-sdk/src/components/paragraph.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 const defaultTag = "p";
 

--- a/packages/react-sdk/src/components/subscript.stories.tsx
+++ b/packages/react-sdk/src/components/subscript.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Bold as BoldPrimitive } from "./bold";
 import argTypes from "./bold.props.json";

--- a/packages/react-sdk/src/components/text-block.stories.tsx
+++ b/packages/react-sdk/src/components/text-block.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { ComponentStory, ComponentMeta } from "@storybook/react";
 import { TextBlock as TextBlockPrimitive } from "./text-block";
 import argTypes from "./text-block.props.json";

--- a/packages/react-sdk/src/components/text-block.tsx
+++ b/packages/react-sdk/src/components/text-block.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
 
 const defaultTag = "div";
 

--- a/packages/react-sdk/src/tree/wrapper-component.tsx
+++ b/packages/react-sdk/src/tree/wrapper-component.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import { Fragment } from "react";
 import type { Instance } from "../db";
 import * as components from "../components";
 import { useUserProps } from "../user-props/use-user-props";

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -10,7 +10,7 @@
     "inlineSources": false,
     "isolatedModules": true,
     "moduleResolution": "node",
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "noUnusedParameters": false,
     "preserveWatchOutput": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Eslint always had issues finding unused variables. And it's usually required two more plugins beside builtin functionality to handle this case.

Typescript has this builtin and handles all cases out of the box. Also it works faster and more responsive in ide than eslint.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [x] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
