### PR TITLE
don't display empty unitless dropdown

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -61,17 +61,12 @@ const useHandleOnChange = (
     }
 
     // We want to switch to unit mode if entire input is a number.
-    if (isNumericString(input)) {
+    if (isNumericString(input) && isValid(property, input + "px")) {
       if (value.type === "unit" && String(Number(input)) !== input) return;
       onChange?.({
         type: "unit",
         // Use previously known unit or fallback to px.
-        unit:
-          valueRef.current.type === "unit"
-            ? valueRef.current.unit
-            : isValid(property, input + "px")
-            ? "px"
-            : "number",
+        unit: valueRef.current.type === "unit" ? valueRef.current.unit : "px",
         value: Number(input),
       });
       return;
@@ -131,11 +126,7 @@ const useScrub = ({
     const scrub = numericScrubControl(scrubRef.current, {
       initialValue: valueRef.current.value,
       onValueInput(event) {
-        onChangeRef.current({
-          type,
-          unit,
-          value: event.value,
-        });
+        if (inputRef.current) inputRef.current.value = String(event.value);
         setIsInputActive(true);
         inputRef.current?.blur();
       },

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -29,12 +29,9 @@ import {
 } from "react";
 import { useIsFromCurrentBreakpoint } from "../use-is-from-current-breakpoint";
 import { useUnitSelect } from "./unit-select";
-import { isValid } from "../parse-css-value";
+import { isValid, isNumericString } from "../parse-css-value";
 
 const unsetValue: UnsetValue = { type: "unset", value: "" };
-
-const isNumericString = (input: string) =>
-  String(input).trim().length !== 0 && isNaN(Number(input)) === false;
 
 // We increment by 10 when shift is pressed, by 0.1 when alt/option is pressed and by 1 by default.
 const calcNumberChange = (

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -61,12 +61,17 @@ const useHandleOnChange = (
     }
 
     // We want to switch to unit mode if entire input is a number.
-    if (isNumericString(input) && isValid(property, input + "px")) {
+    if (isNumericString(input)) {
       if (value.type === "unit" && String(Number(input)) !== input) return;
       onChange?.({
         type: "unit",
         // Use previously known unit or fallback to px.
-        unit: valueRef.current.type === "unit" ? valueRef.current.unit : "px",
+        unit:
+          valueRef.current.type === "unit"
+            ? valueRef.current.unit
+            : isValid(property, input + "px")
+            ? "px"
+            : "number",
         value: Number(input),
       });
       return;

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -76,7 +76,7 @@ const useHandleOnChange = (
       type: "keyword",
       value: input,
     });
-  }, [input, value.type, onChange]);
+  }, [property, input, value.type, onChange]);
 
   useEffect(() => {
     valueRef.current = value;
@@ -305,24 +305,27 @@ export const CssValueInput = ({
     </CssValueInputIconButton>
   );
 
-  const isKeywordValue = value.type === "keyword";
+  const keywordButtonElement = (
+    <TextFieldIconButton
+      {...getToggleButtonProps()}
+      state={isOpen ? "active" : undefined}
+    >
+      <ChevronDownIcon />
+    </TextFieldIconButton>
+  );
+  const hasItems = items.length !== 0;
   const isUnitValue = value.type === "unit";
+  const isKeywordValue = value.type === "keyword" && hasItems;
   const suffixRef = useRef<HTMLDivElement | null>(null);
-  const suffix =
-    items.length === 0 && isKeywordValue ? null : (
-      <Box ref={suffixRef}>
-        {isKeywordValue ? (
-          <TextFieldIconButton
-            {...getToggleButtonProps()}
-            state={isOpen ? "active" : undefined}
-          >
-            <ChevronDownIcon />
-          </TextFieldIconButton>
-        ) : isUnitValue ? (
-          unitSelectElement
-        ) : null}
-      </Box>
-    );
+  const suffix = (
+    <Box ref={suffixRef}>
+      {isUnitValue
+        ? unitSelectElement
+        : isKeywordValue
+        ? keywordButtonElement
+        : null}
+    </Box>
+  );
 
   return (
     <ComboboxPopper>

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -29,6 +29,7 @@ import {
 } from "react";
 import { useIsFromCurrentBreakpoint } from "../use-is-from-current-breakpoint";
 import { useUnitSelect } from "./unit-select";
+import { isValid } from "../parse-css-value";
 
 const unsetValue: UnsetValue = { type: "unset", value: "" };
 
@@ -46,6 +47,7 @@ const calcNumberChange = (
 };
 
 const useHandleOnChange = (
+  property: StyleProperty,
   value: StyleValue,
   input: string,
   onChange: (value: StyleValue) => void
@@ -59,7 +61,7 @@ const useHandleOnChange = (
     }
 
     // We want to switch to unit mode if entire input is a number.
-    if (isNumericString(input)) {
+    if (isNumericString(input) && isValid(property, input + "px")) {
       if (value.type === "unit" && String(Number(input)) !== input) return;
       onChange?.({
         type: "unit",
@@ -254,7 +256,7 @@ export const CssValueInput = ({
 
   const inputProps = getInputProps();
 
-  useHandleOnChange(value, inputProps.value, onChange);
+  useHandleOnChange(property, value, inputProps.value, onChange);
 
   const [isUnitsOpen, unitSelectElement] = useUnitSelect({
     property,

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -303,21 +303,24 @@ export const CssValueInput = ({
     </CssValueInputIconButton>
   );
 
+  const isKeywordValue = value.type === "keyword";
+  const isUnitValue = value.type === "unit";
   const suffixRef = useRef<HTMLDivElement | null>(null);
-  const suffix = (
-    <Box ref={suffixRef}>
-      {value.type === "keyword" ? (
-        <TextFieldIconButton
-          {...getToggleButtonProps()}
-          state={isOpen ? "active" : undefined}
-        >
-          <ChevronDownIcon />
-        </TextFieldIconButton>
-      ) : value.type === "unit" ? (
-        unitSelectElement
-      ) : null}
-    </Box>
-  );
+  const suffix =
+    items.length === 0 && isKeywordValue ? null : (
+      <Box ref={suffixRef}>
+        {isKeywordValue ? (
+          <TextFieldIconButton
+            {...getToggleButtonProps()}
+            state={isOpen ? "active" : undefined}
+          >
+            <ChevronDownIcon />
+          </TextFieldIconButton>
+        ) : isUnitValue ? (
+          unitSelectElement
+        ) : null}
+      </Box>
+    );
 
   return (
     <ComboboxPopper>

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/unit-select.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/unit-select.tsx
@@ -65,7 +65,8 @@ export const useUnitSelect = ({
   if (
     value === undefined ||
     renderUnits == undefined ||
-    renderValue === undefined
+    renderValue === undefined ||
+    renderUnits.length < 2
   ) {
     return [isOpen, null];
   }

--- a/apps/designer/app/designer/features/style-panel/shared/get-final-value.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/get-final-value.ts
@@ -1,7 +1,7 @@
 import type { Style, StyleValue, StyleProperty } from "@webstudio-is/css-data";
 import { toValue } from "@webstudio-is/css-engine";
 import type { InheritedStyle } from "./get-inherited-style";
-import { isValid } from "./parse-css-value";
+import { isValid, isNumericString } from "./parse-css-value";
 
 // @todo expose which instance we inherited the value from
 export const getFinalValue = ({
@@ -18,6 +18,12 @@ export const getFinalValue = ({
     property in inheritedStyle ? inheritedStyle[property].value : undefined;
   if (currentValue?.value === "inherit" && inheritedValue !== undefined) {
     return inheritedValue;
+  }
+  if (
+    currentValue?.type !== "unit" &&
+    isNumericString(String(currentValue?.value))
+  ) {
+    return { value: Number(currentValue?.value), type: "unit", unit: "number" };
   }
   if (
     currentValue &&

--- a/apps/designer/app/designer/features/style-panel/shared/parse-css-value.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/parse-css-value.ts
@@ -4,6 +4,9 @@ import { units } from "@webstudio-is/css-data";
 
 const unitRegex = new RegExp(`${[...units, "number"].join("|")}`);
 
+export const isNumericString = (input: string) =>
+  String(input).trim().length !== 0 && isNaN(Number(input)) === false;
+
 export const isValid = (property: string, value: string): boolean => {
   // Only browsers with houdini api will provide validation for now
   // @todo add a polyfill maybe

--- a/packages/design-system/src/components/text-field.tsx
+++ b/packages/design-system/src/components/text-field.tsx
@@ -36,6 +36,7 @@ const textFieldIconBaseStyle = css({
 export const TextFieldIconButton = styled(
   "button",
   {
+    background: "none",
     border: "none",
     boxSizing: "border-box",
     fontFamily: "inherit",


### PR DESCRIPTION
don't display chevron if there are no items to display in the dropdown and fix the bg on chevron's/unit text-field suffix button.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
