### PR TITLE
Fix a security issue with eval()

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/parse-css-value.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/parse-css-value.ts
@@ -22,31 +22,36 @@ export const isValid = (property: string, value: string): boolean => {
   return true;
 };
 
-// wtf?
-// eslint-disable-next-line no-useless-escape
-const mathRegex = /[\+\-\*\/]/;
+// If expression is a math expression, evaluates it.
+// Otherwise returns undefined.
+const evaluateMath = (expression: string) => {
+  if (/^\d[+\-*/0-9.]+\d$/.test(expression) === false) {
+    return undefined;
+  }
+  try {
+    // Eval is save here because of the regex above
+    const result = eval(`(${expression})`);
+    if (typeof result === "number") {
+      return result;
+    }
+  } catch (err) {
+    return undefined;
+  }
+};
 
 // - 2+2px
 // - 2*2
 const evaluate = (input: string, parsedUnit: [Unit] | null) => {
-  const parsed = parseFloat(input);
-  // If its not a number, it can't be a math expression.
-  if (isNaN(parsed)) return parsed;
+  const result = evaluateMath(
+    parsedUnit === null ? input : input.replace(parsedUnit[0], "")
+  );
 
-  // It's a math expression
-  if (mathRegex.test(input)) {
-    // Get rid of the unit
-    if (parsedUnit !== null) {
-      input = input.replace(parsedUnit[0], "");
-    }
-    try {
-      return eval(`(${input})`);
-    } catch (err) {
-      return parsed;
-    }
+  if (result !== undefined) {
+    return result;
   }
 
-  return parsed;
+  const number = parseFloat(input);
+  return isNaN(number) ? undefined : number;
 };
 
 // Helper to let user input:
@@ -73,7 +78,7 @@ export const parseCssValue = (
 
   // If we get a unit but there is no number - we assume its an accidental
   // unit match and its a keyword value.
-  if (isNaN(number) === true) {
+  if (number === undefined) {
     if (isValid(property, input)) {
       return {
         type: "keyword",


### PR DESCRIPTION
In the current main if you enter `1+1,alert("hello")` as a value into a CSS input, you'll see an alert. This PR fixes it.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
