### PR TITLE
fix: missing dependency (detect-font) + github action

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -5,6 +5,8 @@ on:
       - "packages/**/*"
       - ".github/workflows/package-tests.yml"
       - ".github/actions/publish-test/action.yaml"
+    branches-ignore:
+      - "main"
 jobs:
   publish-test:
     runs-on: ubuntu-latest

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webstudio-is/react-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Webstudio JavaScript / TypeScript API",
   "author": "Webstudio <github@webstudio.is>",
   "homepage": "https://webstudio.is",
@@ -56,6 +56,7 @@
     "zod": "^3.19.1"
   },
   "dependencies": {
+    "detect-font": "^0.1.5",
     "@webstudio-is/asset-uploader": "^*",
     "@webstudio-is/fonts": "*",
     "@webstudio-is/icons": "*",


### PR DESCRIPTION
- Added `detect-font` to `react-sdk` as a dependency.
- Do not run `package-tests` GitHub action on the main push, only on other branches.