### PR TITLE
Fix esm in prisma migrations

### DIFF
--- a/packages/prisma-client/migrations-cli/prisma-migrations.ts
+++ b/packages/prisma-client/migrations-cli/prisma-migrations.ts
@@ -5,9 +5,12 @@
 import { execaSync } from "execa";
 import path from "node:path";
 import fs from "node:fs";
+import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
 import { prisma } from "../src";
 import { UserError } from "./errors";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const prismaDir = path.resolve(__dirname, "..", "prisma");
 export const schemaFilePath = path.join(prismaDir, "schema.prisma");


### PR DESCRIPTION
Missed __dirname while migrating to esm. Works locally.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
