### PR TITLE
Publish css-vars package to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "golden-fleece": "^1.0.9"
   },
-  "packageManager": "yarn@1.22.19",
   "lint-staged": {
     "*.{ts,tsx,js,json,css,md}": "prettier --write"
   },

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -11,7 +11,8 @@
     "dev": "tsup --watch",
     "build:cjs": "tsc --module commonjs --outDir lib/cjs && find lib/cjs -name '*.js' | while read NAME; do mv $NAME ${NAME%.js}.cjs; done",
     "build": "rm -fr lib tsconfig.tsbuildinfo && tsc && yarn build:cjs",
-    "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
+    "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0",
+    "publish-to-npm": "bash ../../bin/publish-to-npm.sh"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
This one is missing when upgrade packages in webstudio-saas

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [x] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
