### PR TITLE
Handle loader errors in error boundary

### DIFF
--- a/apps/designer/app/root.tsx
+++ b/apps/designer/app/root.tsx
@@ -7,7 +7,6 @@ import { OutletProps } from "react-router-dom";
 import { PersistentFetcherProvider } from "./shared/fetcher";
 
 const RootWithErrorBoundary = (props: OutletProps) => (
-  // @ts-expect-error 'ErrorBoundary' cannot be used as a JSX component.
   <ErrorBoundary>
     <TooltipProvider>
       <PersistentFetcherProvider>

--- a/apps/designer/app/routes/$.tsx
+++ b/apps/designer/app/routes/$.tsx
@@ -1,8 +1,8 @@
-import {
-  redirect,
-  json,
-  type LoaderFunction,
-  type MetaFunction,
+import { redirect, json } from "@remix-run/node";
+import type {
+  MetaFunction,
+  LoaderFunction,
+  ErrorBoundaryComponent,
 } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { InstanceRoot, Root } from "@webstudio-is/react-sdk";
@@ -20,9 +20,7 @@ import { db } from "@webstudio-is/project/server";
 import type { DynamicLinksFunction } from "remix-utils";
 import type { CanvasData } from "@webstudio-is/project";
 
-type Data =
-  | (CanvasData & { env: Env; mode: BuildMode })
-  | { errors: string; env: Env };
+type Data = CanvasData & { env: Env; mode: BuildMode };
 
 export const dynamicLinks: DynamicLinksFunction<CanvasData> = ({
   data,
@@ -42,63 +40,46 @@ export const dynamicLinks: DynamicLinksFunction<CanvasData> = ({
 export const handle = { dynamicLinks };
 
 export const meta: MetaFunction = ({ data }: { data: Data }) => {
-  if ("errors" in data) {
-    return { title: "Error" };
-  }
   const { page } = data;
   return { title: page.title, ...page.meta };
 };
 
-export const loader: LoaderFunction = async ({
-  request,
-}): Promise<Data | Response> => {
-  try {
-    const buildParams = getBuildParams(request);
+export const loader: LoaderFunction = async ({ request }): Promise<Data> => {
+  const buildParams = getBuildParams(request);
 
-    if (buildParams === undefined) {
-      return redirect(dashboardPath());
-    }
-
-    const { mode, pathname } = buildParams;
-
-    const project = await db.project.loadByParams(buildParams);
-
-    if (project === null) {
-      throw json("Project not found", { status: 404 });
-    }
-
-    const canvasData = await loadCanvasData(
-      project,
-      mode === "published" ? "prod" : "dev",
-      pathname
-    );
-
-    if (canvasData === undefined) {
-      throw json("Page not found", { status: 404 });
-    }
-
-    return { ...canvasData, env, mode };
-  } catch (error) {
-    // If a Response is thrown, we're rethrowing it for Remix to handle.
-    // https://remix.run/docs/en/v1/api/conventions#throwing-responses-in-loaders
-    if (error instanceof Response) {
-      throw error;
-    }
-
-    sentryException({ error });
-    return {
-      errors: error instanceof Error ? error.message : String(error),
-      env,
-    };
+  if (buildParams === undefined) {
+    throw redirect(dashboardPath());
   }
+
+  const { mode, pathname } = buildParams;
+
+  const project = await db.project.loadByParams(buildParams);
+
+  if (project === null) {
+    throw json("Project not found", { status: 404 });
+  }
+
+  const canvasData = await loadCanvasData(
+    project,
+    mode === "published" ? "prod" : "dev",
+    pathname
+  );
+
+  if (canvasData === undefined) {
+    throw json("Page not found", { status: 404 });
+  }
+
+  return { ...canvasData, env, mode };
+};
+
+export const ErrorBoundary: ErrorBoundaryComponent = ({ error }) => {
+  sentryException({ error });
+  const message = error instanceof Error ? error.message : String(error);
+  return <ErrorMessage message={message} />;
 };
 
 const Content = () => {
   const data = useLoaderData<Data>();
-
-  if ("errors" in data) {
-    return <ErrorMessage message={data.errors} />;
-  }
 
   const Outlet =
     data.mode === "edit"

--- a/apps/designer/app/routes/designer/$projectId.tsx
+++ b/apps/designer/app/routes/designer/$projectId.tsx
@@ -1,5 +1,5 @@
 import { useLoaderData } from "@remix-run/react";
-import { LoaderFunction } from "@remix-run/node";
+import type { ErrorBoundaryComponent, LoaderFunction } from "@remix-run/node";
 import { type DesignerProps, Designer, links } from "~/designer";
 import { db } from "@webstudio-is/project/server";
 import { ErrorMessage } from "~/shared/error";
@@ -11,45 +11,38 @@ export { links };
 export const loader: LoaderFunction = async ({
   params,
   request,
-}): Promise<DesignerProps | Error> => {
-  try {
-    if (params.projectId === undefined) {
-      throw new Error("Project id undefined");
-    }
-
-    const url = new URL(request.url);
-    const pageIdParam = url.searchParams.get("pageId");
-
-    const project = await db.project.loadById(params.projectId);
-
-    if (project === null) {
-      throw new Error(`Project "${params.projectId}" not found`);
-    }
-
-    const devBuild = await db.build.loadByProjectId(project.id, "dev");
-
-    return {
-      project,
-      pages: devBuild.pages,
-      pageId: pageIdParam || devBuild.pages.homePage.id,
-      buildOrigin: getBuildOrigin(request),
-    };
-  } catch (error) {
-    sentryException({ error });
-    return { errors: error instanceof Error ? error.message : String(error) };
+}): Promise<DesignerProps> => {
+  if (params.projectId === undefined) {
+    throw new Error("Project id undefined");
   }
+
+  const url = new URL(request.url);
+  const pageIdParam = url.searchParams.get("pageId");
+
+  const project = await db.project.loadById(params.projectId);
+
+  if (project === null) {
+    throw new Error(`Project "${params.projectId}" not found`);
+  }
+
+  const devBuild = await db.build.loadByProjectId(project.id, "dev");
+
+  return {
+    project,
+    pages: devBuild.pages,
+    pageId: pageIdParam || devBuild.pages.homePage.id,
+    buildOrigin: getBuildOrigin(request),
+  };
 };
 
-type Error = {
-  errors: string;
+export const ErrorBoundary: ErrorBoundaryComponent = ({ error }) => {
+  sentryException({ error });
+  const message = error instanceof Error ? error.message : String(error);
+  return <ErrorMessage message={message} />;
 };
 
 export const DesignerRoute = () => {
-  const data = useLoaderData<DesignerProps | Error>();
-
-  if ("errors" in data) {
-    return <ErrorMessage message={data.errors} />;
-  }
+  const data = useLoaderData<DesignerProps>();
 
   return <Designer {...data} />;
 };

--- a/apps/designer/app/routes/index.tsx
+++ b/apps/designer/app/routes/index.tsx
@@ -3,11 +3,16 @@
 // see https://github.com/remix-run/remix/issues/2098#issuecomment-1049262218 .
 // To solve this, we're re-exporting the $.tsx route API in index.tsx
 
-import type { LoaderFunction, MetaFunction } from "@remix-run/node";
+import type {
+  ErrorBoundaryComponent,
+  LoaderFunction,
+  MetaFunction,
+} from "@remix-run/node";
 import CatchAllContnet, {
   loader as catchAllloader,
   meta as catchAllmeta,
   handle as catchAllHandle,
+  ErrorBoundary as CatchAllErrorBoundary,
 } from "./$";
 
 // We're wrapping functions in order for them to be distinct from the ones in $.tsx.
@@ -16,5 +21,9 @@ import CatchAllContnet, {
 export const meta: MetaFunction = (args) => catchAllmeta(args);
 export const loader: LoaderFunction = (args) => catchAllloader(args);
 export const handle = catchAllHandle;
+export const ErrorBoundary: ErrorBoundaryComponent = ({ error }) => (
+  // @ts-ignore for some reason cannot be invoked according to types
+  <CatchAllErrorBoundary error={error} />
+);
 const Content = () => <CatchAllContnet />;
 export default Content;

--- a/apps/designer/app/routes/index.tsx
+++ b/apps/designer/app/routes/index.tsx
@@ -22,7 +22,6 @@ export const meta: MetaFunction = (args) => catchAllmeta(args);
 export const loader: LoaderFunction = (args) => catchAllloader(args);
 export const handle = catchAllHandle;
 export const ErrorBoundary: ErrorBoundaryComponent = ({ error }) => (
-  // @ts-ignore for some reason cannot be invoked according to types
   <CatchAllErrorBoundary error={error} />
 );
 const Content = () => <CatchAllContnet />;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5553,16 +5553,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "18.0.15"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.15.tgz#d355644c26832dc27f3e6cbf0c4f4603fc4ab7fe"
-  integrity sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17", "@types/react@^17.0.24":
+"@types/react@*", "@types/react@^17", "@types/react@^17.0.24":
   version "17.0.47"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.47.tgz#4ee71aaf4c5a9e290e03aa4d0d313c5d666b3b78"
   integrity sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==


### PR DESCRIPTION
This will allow to infer loader data instead of writing type for it as recommended in https://github.com/remix-run/remix/releases/tag/remix%401.6.5.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [x] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
