### PR TITLE
Use serialized loader types

### DIFF
--- a/apps/designer/app/dashboard/components/header.tsx
+++ b/apps/designer/app/dashboard/components/header.tsx
@@ -9,9 +9,13 @@ import {
   Text,
   Flex,
 } from "@webstudio-is/design-system";
-import { User } from "@webstudio-is/prisma-client";
+import { User as DbUser } from "@webstudio-is/prisma-client";
 import { useNavigate } from "react-router-dom";
 import { logoutPath } from "~/shared/router-utils";
+
+type User = Omit<DbUser, "createdAt"> & {
+  createdAt: string;
+};
 
 export const DashboardHeader = ({ user }: { user: User }) => {
   const navigate = useNavigate();

--- a/apps/designer/app/dashboard/dashboard.tsx
+++ b/apps/designer/app/dashboard/dashboard.tsx
@@ -3,9 +3,10 @@ import { useActionData } from "@remix-run/react";
 import { Flex } from "@webstudio-is/design-system";
 import interStyles from "~/shared/font-faces/inter.css";
 import dashboardStyles from "./dashboard.css";
-import { User } from "@webstudio-is/prisma-client";
+import { User as DbUser } from "@webstudio-is/prisma-client";
 import { DashboardHeader } from "./components/header";
 import { SelectProjectCard } from "./components/card";
+
 export const links = () => {
   return [
     {
@@ -17,6 +18,10 @@ export const links = () => {
       href: dashboardStyles,
     },
   ];
+};
+
+type User = Omit<DbUser, "createdAt"> & {
+  createdAt: string;
 };
 
 type DashboardProps = {

--- a/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
@@ -350,7 +350,7 @@ describe("usePropsLogic", () => {
         name: "string",
         description: "string",
         location: "REMOTE",
-        createdAt: new Date("1995-12-17T03:24:00Z"),
+        createdAt: new Date("1995-12-17T03:24:00Z").toISOString(),
         meta: { width: 101, height: 202 },
         path: "string",
         status: "uploaded",
@@ -361,7 +361,7 @@ describe("usePropsLogic", () => {
       [
         {
           "asset": {
-            "createdAt": 1995-12-17T03:24:00.000Z,
+            "createdAt": "1995-12-17T03:24:00.000Z",
             "description": "string",
             "format": "string",
             "id": "string",

--- a/apps/designer/app/routes/dashboard/index.tsx
+++ b/apps/designer/app/routes/dashboard/index.tsx
@@ -10,8 +10,12 @@ import { db } from "@webstudio-is/project/server";
 import { ensureUserCookie } from "~/shared/session";
 import { authenticator } from "~/services/auth.server";
 import { zfd } from "zod-form-data";
-import { type Project, User } from "@webstudio-is/prisma-client";
+import { type Project, User as DbUser } from "@webstudio-is/prisma-client";
 import { designerPath, loginPath } from "~/shared/router-utils";
+
+type User = Omit<DbUser, "createdAt"> & {
+  createdAt: string;
+};
 
 export { links };
 const schema = zfd.formData({

--- a/packages/asset-uploader/src/types.ts
+++ b/packages/asset-uploader/src/types.ts
@@ -3,9 +3,10 @@ import type { FontMeta } from "@webstudio-is/fonts/server";
 import { Asset as DbAsset } from "@webstudio-is/prisma-client";
 import type { ImageMeta } from "./utils/format-asset";
 
-type BaseAsset = Omit<DbAsset, "meta"> & {
+type BaseAsset = Omit<DbAsset, "meta" | "createdAt"> & {
   path: string;
   status?: "uploaded";
+  createdAt: string;
 };
 
 export type FontAsset = Omit<BaseAsset, "format"> & {

--- a/packages/asset-uploader/src/utils/format-asset.ts
+++ b/packages/asset-uploader/src/utils/format-asset.ts
@@ -19,6 +19,7 @@ export const formatAsset = (asset: DbAsset): Asset => {
   if (isFont) {
     return {
       ...base,
+      createdAt: base.createdAt.toISOString(),
       format: asset.format as FontFormat,
       meta: FontMeta.parse(JSON.parse(asset.meta)),
     };
@@ -26,6 +27,7 @@ export const formatAsset = (asset: DbAsset): Asset => {
 
   return {
     ...base,
+    createdAt: base.createdAt.toISOString(),
     meta: ImageMeta.parse(JSON.parse(asset.meta)),
   };
 };


### PR DESCRIPTION
New remix enforces types to be serialized.
Prisma output dates as Date instance and this is not customizable. Had to fix only 2 cases.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [x] conceptual
  - [x] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
