### PR TITLE
Added aspect ratio property to sizes

### DIFF
--- a/packages/react-sdk/src/css/categories.ts
+++ b/packages/react-sdk/src/css/categories.ts
@@ -60,6 +60,7 @@ const size = [
   "maxHeight",
   "overflow",
   "objectFit",
+  "aspectRatio",
 ] as const;
 
 const position = [


### PR DESCRIPTION
We need this so that user can decide when they don't want it and we can set it by default based on image size for the image and this way we remove layout shift for users automatically.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
