### PR TITLE
Split Link and RichTextLink components

### DIFF
--- a/apps/designer/app/canvas/features/text-editor/interop.ts
+++ b/apps/designer/app/canvas/features/text-editor/interop.ts
@@ -41,7 +41,11 @@ const $writeUpdates = (
       const id = refs.get(child.getKey());
       const childrenUpdates: ChildrenUpdates = [];
       $writeUpdates(child, childrenUpdates, refs);
-      updates.push({ id, component: "Link", children: childrenUpdates });
+      updates.push({
+        id,
+        component: "RichTextLink",
+        children: childrenUpdates,
+      });
     }
     if ($isTextNode(child)) {
       // support nesting bold into italic and vice versa
@@ -109,7 +113,7 @@ const $writeLexical = (
     }
 
     // convert instances
-    if (child.component === "Link" && $isElementNode(parent)) {
+    if (child.component === "RichTextLink" && $isElementNode(parent)) {
       const linkNode = $createLinkNode("");
       refs.set(linkNode.getKey(), child.id);
       parent.append(linkNode);

--- a/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
@@ -80,7 +80,10 @@ export const WrapperComponentDev = ({
     "data-ws-component": instance.component,
     [idAttribute]: instance.id,
     onClick: (event: MouseEvent) => {
-      if (instance.component === "Link") {
+      if (
+        instance.component === "Link" ||
+        instance.component === "RichTextLink"
+      ) {
         event.preventDefault();
       }
     },

--- a/packages/react-sdk/src/components/__generated__/rich-text-link.props.json
+++ b/packages/react-sdk/src/components/__generated__/rich-text-link.props.json
@@ -1,0 +1,547 @@
+{
+  "slot": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "style": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "title": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "download": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "href": {
+    "defaultValue": "",
+    "required": false,
+    "type": "text"
+  },
+  "hrefLang": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "media": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "ping": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "rel": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "target": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "type": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "referrerPolicy": {
+    "defaultValue": null,
+    "options": [
+      "\"\"",
+      "no-referrer",
+      "no-referrer-when-downgrade",
+      "origin",
+      "origin-when-cross-origin",
+      "same-origin",
+      "strict-origin",
+      "strict-origin-when-cross-origin",
+      "unsafe-url"
+    ],
+    "required": false,
+    "type": "select"
+  },
+  "defaultChecked": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "defaultValue": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "suppressContentEditableWarning": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "suppressHydrationWarning": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "accessKey": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "className": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "contentEditable": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "contextMenu": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "dir": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "draggable": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "hidden": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "id": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "lang": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "placeholder": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "spellCheck": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "tabIndex": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "translate": {
+    "defaultValue": null,
+    "options": ["yes", "no"],
+    "required": false,
+    "type": "radio"
+  },
+  "radioGroup": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "role": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "about": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "datatype": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "inlist": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "prefix": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "property": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "resource": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "typeof": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "vocab": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "autoCapitalize": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "autoCorrect": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "autoSave": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "color": {
+    "defaultValue": null,
+    "required": false,
+    "type": "color"
+  },
+  "itemProp": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "itemScope": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "itemType": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "itemID": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "itemRef": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "results": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "security": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "unselectable": {
+    "defaultValue": null,
+    "options": ["on", "off"],
+    "required": false,
+    "type": "radio"
+  },
+  "inputMode": {
+    "defaultValue": null,
+    "options": [
+      "text",
+      "none",
+      "search",
+      "tel",
+      "url",
+      "email",
+      "numeric",
+      "decimal"
+    ],
+    "required": false,
+    "type": "select"
+  },
+  "is": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-activedescendant": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-atomic": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-autocomplete": {
+    "defaultValue": null,
+    "options": ["list", "none", "inline", "both"],
+    "required": false,
+    "type": "radio"
+  },
+  "aria-busy": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-checked": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-colcount": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-colindex": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-colspan": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-controls": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-current": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-describedby": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-details": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-disabled": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-dropeffect": {
+    "defaultValue": null,
+    "options": ["link", "none", "copy", "execute", "move", "popup"],
+    "required": false,
+    "type": "select"
+  },
+  "aria-errormessage": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-expanded": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-flowto": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-grabbed": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-haspopup": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-hidden": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-invalid": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-keyshortcuts": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-label": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-labelledby": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-level": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-live": {
+    "defaultValue": null,
+    "options": ["off", "assertive", "polite"],
+    "required": false,
+    "type": "radio"
+  },
+  "aria-modal": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-multiline": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-multiselectable": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-orientation": {
+    "defaultValue": null,
+    "options": ["horizontal", "vertical"],
+    "required": false,
+    "type": "radio"
+  },
+  "aria-owns": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-placeholder": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-posinset": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-pressed": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-readonly": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-relevant": {
+    "defaultValue": null,
+    "options": [
+      "text",
+      "additions",
+      "additions removals",
+      "additions text",
+      "all",
+      "removals",
+      "removals additions",
+      "removals text",
+      "text additions",
+      "text removals"
+    ],
+    "required": false,
+    "type": "select"
+  },
+  "aria-required": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-roledescription": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  },
+  "aria-rowcount": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-rowindex": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-rowspan": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-selected": {
+    "defaultValue": null,
+    "required": false,
+    "type": "boolean"
+  },
+  "aria-setsize": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-sort": {
+    "defaultValue": null,
+    "options": ["none", "ascending", "descending", "other"],
+    "required": false,
+    "type": "radio"
+  },
+  "aria-valuemax": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-valuemin": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-valuenow": {
+    "defaultValue": null,
+    "required": false,
+    "type": "number"
+  },
+  "aria-valuetext": {
+    "defaultValue": null,
+    "required": false,
+    "type": "text"
+  }
+}

--- a/packages/react-sdk/src/components/index.ts
+++ b/packages/react-sdk/src/components/index.ts
@@ -4,6 +4,7 @@ import TextBlock from "./text-block.ws";
 import Heading from "./heading.ws";
 import Paragraph from "./paragraph.ws";
 import Link from "./link.ws";
+import RichTextLink from "./rich-text-link.ws";
 import Span from "./span.ws";
 import Bold from "./bold.ws";
 import Italic from "./italic.ws";
@@ -21,6 +22,7 @@ const components = {
   Heading,
   Paragraph,
   Link,
+  RichTextLink,
   Span,
   Bold,
   Italic,

--- a/packages/react-sdk/src/components/meta.ts
+++ b/packages/react-sdk/src/components/meta.ts
@@ -8,6 +8,7 @@ import Input from "./__generated__/input.props.json";
 import Italic from "./__generated__/italic.props.json";
 import Superscript from "./__generated__/superscript.props.json";
 import Subscript from "./__generated__/subscript.props.json";
+import RichTextLink from "./__generated__/rich-text-link.props.json";
 import Link from "./__generated__/link.props.json";
 import Paragraph from "./__generated__/paragraph.props.json";
 import Span from "./__generated__/span.props.json";
@@ -25,6 +26,7 @@ const meta = {
   Italic,
   Superscript,
   Subscript,
+  RichTextLink,
   Link,
   Paragraph,
   Span,

--- a/packages/react-sdk/src/components/rich-text-link.stories.tsx
+++ b/packages/react-sdk/src/components/rich-text-link.stories.tsx
@@ -1,0 +1,16 @@
+import type { ComponentStory, ComponentMeta } from "@storybook/react";
+import { RichTextLink as LinkPrimitive } from "./rich-text-link";
+
+export default {
+  title: "Components/RichTextLink",
+  component: LinkPrimitive,
+} as ComponentMeta<typeof LinkPrimitive>;
+
+const Template: ComponentStory<typeof LinkPrimitive> = (args) => (
+  <LinkPrimitive {...args} />
+);
+
+export const RichTextLink = Template.bind({});
+RichTextLink.args = {
+  children: "RichTextLink",
+};

--- a/packages/react-sdk/src/components/rich-text-link.tsx
+++ b/packages/react-sdk/src/components/rich-text-link.tsx
@@ -1,0 +1,14 @@
+import { forwardRef, type ElementRef, type ComponentProps } from "react";
+
+const defaultTag = "a";
+
+type RichTextLinkProps = Omit<ComponentProps<typeof defaultTag>, "href"> & {
+  href?: string;
+};
+
+export const RichTextLink = forwardRef<
+  ElementRef<typeof defaultTag>,
+  RichTextLinkProps
+>(({ href = "", ...props }, ref) => <a {...props} href={href} ref={ref} />);
+
+RichTextLink.displayName = "RichTextLink";

--- a/packages/react-sdk/src/components/rich-text-link.ws.tsx
+++ b/packages/react-sdk/src/components/rich-text-link.ws.tsx
@@ -1,0 +1,15 @@
+import { Link2Icon } from "@webstudio-is/icons";
+import { RichTextLink } from "./rich-text-link";
+import type { WsComponentMeta } from "./component-type";
+
+const meta: WsComponentMeta<typeof RichTextLink> = {
+  Icon: Link2Icon,
+  Component: RichTextLink,
+  canAcceptChildren: false,
+  isContentEditable: false,
+  isInlineOnly: true,
+  isListed: false,
+  label: "Link",
+};
+
+export default meta;


### PR DESCRIPTION
Droppable link an link created in text editor have different requirements. We should split them. In the next PR they will get different types so we will avoid similar issues in the future.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [x] conceptual
  - [x] detailed
  - [x] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
