### PR TITLE
Make lost-pixel request legacy backend

### DIFF
--- a/packages/design-system/lostpixel.config.ts
+++ b/packages/design-system/lostpixel.config.ts
@@ -6,6 +6,7 @@ export const config: CustomProjectConfig = {
     storybookUrl: "packages/design-system/storybook-static",
   },
   lostPixelProjectId: "cl8a8xmx714904901m9oce4vhqc",
+  lostPixelUrl: 'https://app.gitbased.lost-pixel.com/api/callback',
   s3: {
     endPoint: "ams3.digitaloceanspaces.com",
     accessKey: process.env.S3_ACCESS_KEY,


### PR DESCRIPTION
Preparation to the migration to lost-pixel platform v1. The URL introduced in this PR will point to legacy lost-pixel so that until we migrate to next version lost-pixel works undisrupted.