### PR TITLE
Fix span component type

### DIFF
--- a/packages/react-sdk/src/components/span.ws.tsx
+++ b/packages/react-sdk/src/components/span.ws.tsx
@@ -3,7 +3,7 @@ import type { WsComponentMeta, MetaProps } from "./component-type";
 import props from "./__generated__/span.props.json";
 
 const meta: WsComponentMeta = {
-  type: "rich-text",
+  type: "rich-text-child",
   label: "Styled Text",
   Icon: BrushIcon,
   props: props as MetaProps,


### PR DESCRIPTION
Mistyped when added type to components.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [x] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
