### PR TITLE
Fix dependency mapping for blockLevelElements

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/dependencies.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/dependencies.ts
@@ -75,7 +75,7 @@ export const dependencies: Dependencies = {
     notValues: ["none"],
   },
   blockLevelElements: {
-    property: "clear",
+    property: "display",
     values: ["block", "flex", "grid", "table"],
   },
   allElementsExceptTableDisplayTypes: {

--- a/apps/designer/app/designer/features/style-panel/style-settings.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-settings.tsx
@@ -51,10 +51,12 @@ const appliesTo = (styleConfig: StyleConfig, currentStyle: Style): boolean => {
     if (dependency === undefined) return false;
     const currentValue = currentStyle[dependency.property]?.value;
     if (currentValue === undefined) return false;
-    if (Array.isArray(dependency.values))
+    if (Array.isArray(dependency.values)) {
       return dependency.values.includes(String(currentValue));
-    if (Array.isArray(dependency.notValues))
+    }
+    if (Array.isArray(dependency.notValues)) {
       return dependency.notValues.includes(String(currentValue)) === false;
+    }
   }
 
   return true;


### PR DESCRIPTION
For example property "clear"  was  not showing up in position section because of that. It is supposed to show when display is any block-level value

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
