### PR TITLE
Disable dark theme for now until we got it up-to-date

### DIFF
--- a/apps/designer/app/designer/features/topbar/menu/menu.tsx
+++ b/apps/designer/app/designer/features/topbar/menu/menu.tsx
@@ -27,6 +27,7 @@ import {
 } from "~/shared/theme";
 import { useClientSettings } from "~/designer/shared/client-settings";
 import { dashboardPath } from "~/shared/router-utils";
+import { isFeatureEnabled } from "~/shared/feature-flags";
 
 const menuItemCss = {
   display: "flex",
@@ -37,6 +38,9 @@ const menuItemCss = {
 };
 
 const ThemeMenuItem = () => {
+  if (isFeatureEnabled("dark") === false) {
+    return null;
+  }
   const currentSetting = getThemeSetting();
   const labels: Record<ThemeSetting, string> = {
     light: "Light",

--- a/apps/designer/app/shared/feature-flags/flags.ts
+++ b/apps/designer/app/shared/feature-flags/flags.ts
@@ -1,2 +1,3 @@
 export const designTokens = false;
 export const example = false;
+export const dark = false;

--- a/apps/designer/app/shared/theme/theme.ts
+++ b/apps/designer/app/shared/theme/theme.ts
@@ -1,10 +1,11 @@
 import { useLoaderData } from "@remix-run/react";
 import { darkTheme } from "@webstudio-is/design-system";
 import { restThemePath } from "~/shared/router-utils";
+import { isFeatureEnabled } from "../feature-flags";
 import type { ColorScheme, ThemeSetting } from "./types";
 
 // User selected theme setting.
-let setting: ThemeSetting = "system";
+let setting: ThemeSetting = isFeatureEnabled("dark") ? "system" : "light";
 // Current systeme theme.
 let system: ColorScheme;
 


### PR DESCRIPTION
It will keep working if you enable feature flag "dark"

closes https://github.com/webstudio-is/webstudio-designer/issues/547

We are disabling it because our process for defining colors for both modes didn't work well and we don't have resources to properly test in both modes all components.

We will reenable it once we have redone the colors in the theme and got a process for designers to test each component in both modes.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
