### PR TITLE
Fix scrub uses other instance value

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -91,6 +91,14 @@ const useScrub = ({
     }
 
     const scrub = numericScrubControl(scrubRefCurrent, {
+      // @todo: after this https://github.com/webstudio-is/webstudio-designer/issues/564
+      // we can switch back on using just initial value
+      //
+      // For now we are reusing controls for different selectedInstanceData,
+      // and the best here is to call useEffect every time selectedInstanceData changes
+      // and recreate numericScrubControl.
+      // Until we have decision do we use key properties for this or not,
+      // on of the solution to get value inside scrub is to use ref and lazy getter.
       // Getter to avoid recreating scrub on every value change
       getValue: () => {
         if (valueRef.current.type === "unit") {

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -96,8 +96,6 @@ const useScrub = ({
         if (valueRef.current.type === "unit") {
           return valueRef.current.value;
         }
-
-        return;
       },
       onValueInput(event) {
         setIsInputActive(true);

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -90,9 +90,15 @@ const useScrub = ({
       return;
     }
 
-    const value = valueRef.current.value;
     const scrub = numericScrubControl(scrubRefCurrent, {
-      initialValue: value,
+      // Getter to avoid recreating scrub on every value change
+      getValue: () => {
+        if (valueRef.current.type === "unit") {
+          return valueRef.current.value;
+        }
+
+        return;
+      },
       onValueInput(event) {
         setIsInputActive(true);
         inputRefCurrent.blur();

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.stories.tsx
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.stories.tsx
@@ -18,7 +18,7 @@ const useNumericScrubControl = ({
     if (ref.current === null) return;
     ref.current.value = String(value);
     const { disconnectedCallback } = numericScrubControl(ref.current, {
-      initialValue: value,
+      getValue: () => value,
       direction: direction,
       onValueChange: (event) => {
         event.preventDefault();

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -98,6 +98,8 @@ export const numericScrubControl = (
         const value = getValue();
 
         // We don't support scrub on non unit values
+        // Its highly unlikely that the value here will be undefined, as useScrub tries to not create scrub on non unit values
+        // but having that we use lazy getValue() and vanilla js events it's possible.
         if (value === undefined) return;
 
         state.value = value;

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -27,7 +27,7 @@ export type NumericScrubCallback = (event: {
 export type NumericScrubOptions = {
   minValue?: NumericScrubValue;
   maxValue?: NumericScrubValue;
-  initialValue?: NumericScrubValue;
+  getValue: () => number | undefined;
   direction?: NumericScrubDirection;
   onValueInput?: NumericScrubCallback;
   onValueChange?: NumericScrubCallback;
@@ -48,7 +48,7 @@ export const numericScrubControl = (
   {
     minValue = Number.MIN_SAFE_INTEGER,
     maxValue = Number.MAX_SAFE_INTEGER,
-    initialValue = 0,
+    getValue,
     direction = "horizontal",
     onValueInput,
     onValueChange,
@@ -57,7 +57,8 @@ export const numericScrubControl = (
 ) => {
   const eventNames = ["pointerup", "pointerdown"] as const;
   const state: NumericScrubState = {
-    value: initialValue,
+    // We will read value lazyly in a moment it will be used to avoid having outdated value
+    value: -1,
     cursor: undefined,
     offset: 0,
     velocity: direction === "horizontal" ? 1 : -1,
@@ -94,6 +95,13 @@ export const numericScrubControl = (
         if (event.target && shouldHandleEvent?.(event.target) === false) return;
         // light touches don't register corresponding pointerup
         if (event.pressure === 0 || event.button !== 0) break;
+        const value = getValue();
+
+        // We don't support scrub on non unit values
+        if (value === undefined) return;
+
+        state.value = value;
+
         state.offset = offset;
         state.timerId = setTimeout(() => {
           exitPointerLock?.();
@@ -108,10 +116,14 @@ export const numericScrubControl = (
         if (state.offset) {
           if (state.offset < 0) state.offset = globalThis.innerWidth + 1;
           else if (state.offset > globalThis.innerWidth) state.offset = 1;
+
           state.value += movement;
+
           if (state.value < minValue) state.value = minValue;
           else if (state.value > maxValue) state.value = maxValue;
+
           state.offset += movement * state.velocity;
+
           onValueInput?.({
             target: targetNode,
             value: state.value,


### PR DESCRIPTION
The issue is if we select on canvas instance of one Box for example, and then other box, scrub had in the state value of first selected Box.


https://user-images.githubusercontent.com/5077042/206211694-19124e0b-5b90-4aef-8848-7ebe7f1d7bae.mov


