### PR TITLE
Fix switch display

### DIFF
--- a/@types/css-tree.d.ts
+++ b/@types/css-tree.d.ts
@@ -10,6 +10,10 @@ declare module "css-tree" {
         match: Match[];
       }
     | {
+        syntax: { type: "Type"; name: string };
+        match: Match[];
+      }
+    | {
         syntax: { type: "Keyword"; name: string };
         token: string;
       }

--- a/apps/designer/app/designer/features/style-panel/shared/parse-css-value.test.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/parse-css-value.test.ts
@@ -36,6 +36,13 @@ describe("Parse CSS value", () => {
       });
     });
 
+    test("keyword display block", () => {
+      expect(parseCssValue("display", "block")).toEqual({
+        type: "keyword",
+        value: "block",
+      });
+    });
+
     test("keyword with unit", () => {
       expect(parseCssValue("width", "autopx")).toEqual({
         type: "invalid",

--- a/apps/designer/app/designer/features/style-panel/shared/parse-css-value.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/parse-css-value.ts
@@ -107,15 +107,32 @@ export const parseCssValue = (
     const match =
       "match" in matchResult.matched ? matchResult.matched.match : undefined;
 
-    if (
-      match != null &&
-      match.length === 1 &&
-      match[0].syntax?.type === "Keyword"
-    ) {
-      return {
-        type: "keyword",
-        value: input,
-      } as const;
+    if (match != null && match.length === 1) {
+      const singleMatch = match[0];
+
+      if (singleMatch.syntax?.type === "Keyword") {
+        return {
+          type: "keyword",
+          value: input,
+        } as const;
+      }
+
+      if (singleMatch.syntax?.type === "Type") {
+        if (
+          "match" in singleMatch &&
+          singleMatch.match != null &&
+          singleMatch.match.length === 1
+        ) {
+          const singleMatchMatch = singleMatch.match[0];
+
+          if (singleMatchMatch.syntax?.type === "Keyword") {
+            return {
+              type: "keyword",
+              value: input,
+            } as const;
+          }
+        }
+      }
     }
   }
 

--- a/apps/designer/app/designer/features/style-panel/shared/parse-css-value.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/parse-css-value.ts
@@ -107,7 +107,7 @@ export const parseCssValue = (
     const match =
       "match" in matchResult.matched ? matchResult.matched.match : undefined;
 
-    if (match != null && match.length === 1) {
+    if (match?.length === 1) {
       const singleMatch = match[0];
 
       if (singleMatch.syntax?.type === "Keyword") {
@@ -118,11 +118,7 @@ export const parseCssValue = (
       }
 
       if (singleMatch.syntax?.type === "Type") {
-        if (
-          "match" in singleMatch &&
-          singleMatch.match != null &&
-          singleMatch.match.length === 1
-        ) {
+        if ("match" in singleMatch && singleMatch.match.length === 1) {
           const singleMatchMatch = singleMatch.match[0];
 
           if (singleMatchMatch.syntax?.type === "Keyword") {


### PR DESCRIPTION
Switching display from flex on block caused error in input field

We were not able to parse display block etc

As this is not fixed for display props.
```
setProperty should be called with a style object, string is deprecated
```

So we got that "parsed not valid behavior" which we decided to be invalid.

