### PR TITLE
Deprecate legacy icon button in design system

### DIFF
--- a/apps/designer/app/designer/features/props-panel/props-panel.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.tsx
@@ -20,7 +20,7 @@ import {
   ComboboxPopperAnchor,
   ComboboxListbox,
   ComboboxListboxItem,
-  IconButton,
+  IconButton_deprecated,
 } from "@webstudio-is/design-system";
 import {
   PlusIcon,
@@ -84,9 +84,9 @@ const Combobox = ({
             readOnly={isReadonly}
             state={isInvalid ? "invalid" : undefined}
             suffix={
-              <IconButton {...getToggleButtonProps()}>
+              <IconButton_deprecated {...getToggleButtonProps()}>
                 <ChevronDownIcon />
-              </IconButton>
+              </IconButton_deprecated>
             }
           />
         </ComboboxPopperAnchor>

--- a/apps/designer/app/designer/features/sidebar-left/lib/header.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/lib/header.tsx
@@ -1,4 +1,9 @@
-import { Flex, IconButton, Text, Tooltip } from "@webstudio-is/design-system";
+import {
+  Flex,
+  IconButton_deprecated,
+  Text,
+  Tooltip,
+} from "@webstudio-is/design-system";
 import { Separator } from "@webstudio-is/design-system";
 import { CrossIcon } from "@webstudio-is/icons";
 
@@ -25,8 +30,8 @@ export const Header = ({ title, suffix }: HeaderProps) => {
 
 export const CloseButton = ({ onClick }: { onClick: () => void }) => (
   <Tooltip content="Close panel" side="bottom">
-    <IconButton onClick={onClick} size="2" aria-label="Close panel">
+    <IconButton_deprecated onClick={onClick} size="2" aria-label="Close panel">
       <CrossIcon />
-    </IconButton>
+    </IconButton_deprecated>
   </Tooltip>
 );

--- a/apps/designer/app/designer/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/panels/pages/pages.tsx
@@ -1,5 +1,5 @@
 import {
-  IconButton,
+  IconButton_deprecated,
   TreeItemLabel,
   TreeItemBody,
   TreeNode,
@@ -72,7 +72,7 @@ const staticTreeProps = {
   },
 };
 
-const MenuButton = styled(IconButton, {
+const MenuButton = styled(IconButton_deprecated, {
   color: "$hint",
   "&:hover, &:focus-visible": { color: "$hiContrast" },
   variants: {
@@ -203,13 +203,13 @@ const PagesPanel = ({
           <>
             {onCreateNewPage && (
               <Tooltip content="New page" side="bottom">
-                <IconButton
+                <IconButton_deprecated
                   size="2"
                   onClick={() => onCreateNewPage()}
                   aria-label="New page"
                 >
                   <NewPageIcon />
-                </IconButton>
+                </IconButton_deprecated>
               </Tooltip>
             )}
             {onClose && <CloseButton onClick={onClose} />}

--- a/apps/designer/app/designer/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/panels/pages/settings.tsx
@@ -1,5 +1,5 @@
 import {
-  IconButton,
+  IconButton_deprecated,
   Button,
   Box,
   Label,
@@ -276,7 +276,7 @@ const NewPageSettingsView = ({
           <>
             {onClose && (
               <Tooltip content="Cancel" side="bottom">
-                <IconButton
+                <IconButton_deprecated
                   size="2"
                   onClick={onClose}
                   aria-label="Cancel"
@@ -285,7 +285,7 @@ const NewPageSettingsView = ({
                   tabIndex={3}
                 >
                   <ChevronDoubleLeftIcon />
-                </IconButton>
+                </IconButton_deprecated>
               </Tooltip>
             )}
             <ButtonContainer>
@@ -460,26 +460,26 @@ const PageSettingsView = ({
           <>
             {isHomePage === false && (
               <Tooltip content="Delete page" side="bottom">
-                <IconButton
+                <IconButton_deprecated
                   size="2"
                   onClick={onDelete}
                   aria-label="Delete page"
                   tabIndex={2}
                 >
                   <TrashIcon />
-                </IconButton>
+                </IconButton_deprecated>
               </Tooltip>
             )}
             {onClose && (
               <Tooltip content="Close page settings" side="bottom">
-                <IconButton
+                <IconButton_deprecated
                   size="2"
                   onClick={onClose}
                   aria-label="Close page settings"
                   tabIndex={2}
                 >
                   <ChevronDoubleLeftIcon />
-                </IconButton>
+                </IconButton_deprecated>
               </Tooltip>
             )}
           </>

--- a/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.tsx
@@ -1,4 +1,4 @@
-import { Flex, Grid, IconButton } from "@webstudio-is/design-system";
+import { Flex, Grid, IconButton_deprecated } from "@webstudio-is/design-system";
 import { DotFilledIcon } from "@webstudio-is/icons";
 import { useIsFromCurrentBreakpoint } from "../../../shared/use-is-from-current-breakpoint";
 import type { Style } from "@webstudio-is/css-data";
@@ -87,7 +87,7 @@ export const FlexGrid = ({
             height: "100%",
           }}
         >
-          <IconButton
+          <IconButton_deprecated
             css={{
               width: "100%",
               height: "100%",
@@ -112,7 +112,7 @@ export const FlexGrid = ({
             }}
           >
             <DotFilledIcon />
-          </IconButton>
+          </IconButton_deprecated>
         </Flex>
       ))}
       <Flex

--- a/apps/designer/app/designer/features/style-panel/sections/layout/shared/lock.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/shared/lock.tsx
@@ -1,5 +1,9 @@
 import { useState, useEffect } from "react";
-import { Flex, IconButton, Tooltip } from "@webstudio-is/design-system";
+import {
+  Flex,
+  IconButton_deprecated,
+  Tooltip,
+} from "@webstudio-is/design-system";
 import { LockOpenIcon, LockCloseIcon } from "@webstudio-is/icons";
 import type { Style } from "@webstudio-is/css-data";
 import type { CreateBatchUpdate } from "../../../shared/use-style-data";
@@ -43,9 +47,9 @@ export const Lock = ({
           justifyContent: "center",
         }}
       >
-        <IconButton onClick={() => setIsPaired((value) => !value)}>
+        <IconButton_deprecated onClick={() => setIsPaired((value) => !value)}>
           {isPaired ? <LockCloseIcon /> : <LockOpenIcon />}
-        </IconButton>
+        </IconButton_deprecated>
       </Flex>
     </Tooltip>
   );

--- a/apps/designer/app/designer/features/style-panel/sections/typography/typography.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/typography/typography.tsx
@@ -1,5 +1,10 @@
 import type { RenderCategoryProps } from "../../style-sections";
-import { Flex, Grid, IconButton, Tooltip } from "@webstudio-is/design-system";
+import {
+  Flex,
+  Grid,
+  IconButton_deprecated,
+  Tooltip,
+} from "@webstudio-is/design-system";
 import { PropertyName } from "../../shared/property-name";
 import {
   ColorControl,
@@ -297,9 +302,9 @@ export const TypographySectionAdvancedPopover = (
     >
       <Flex>
         <Tooltip content="More typography options" delayDuration={0}>
-          <IconButton>
+          <IconButton_deprecated>
             <EllipsesIcon />
-          </IconButton>
+          </IconButton_deprecated>
         </Tooltip>
       </Flex>
     </ValuePickerPopover>

--- a/apps/designer/app/designer/features/topbar/menu/menu.tsx
+++ b/apps/designer/app/designer/features/topbar/menu/menu.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuSeparator,
   DropdownMenuPortal,
-  IconButton,
+  IconButton_deprecated,
   Box,
 } from "@webstudio-is/design-system";
 import { HamburgerMenuIcon, ChevronRightIcon } from "@webstudio-is/icons";
@@ -127,9 +127,9 @@ export const Menu = ({ publish }: MenuProps) => {
             },
           }}
         >
-          <IconButton aria-label="Menu Button">
+          <IconButton_deprecated aria-label="Menu Button">
             <HamburgerMenuIcon />
-          </IconButton>
+          </IconButton_deprecated>
         </Box>
       </DropdownMenuTrigger>
       <DropdownMenuPortal>

--- a/apps/designer/app/designer/features/topbar/share.tsx
+++ b/apps/designer/app/designer/features/topbar/share.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
   Flex,
-  IconButton,
+  IconButton_deprecated,
   Popover,
   PopoverContent,
   PopoverPortal,
@@ -57,9 +57,9 @@ export const ShareButton = (props: ShareButtonProps) => {
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild aria-label="Share project">
-        <IconButton>
+        <IconButton_deprecated>
           <Share1Icon />
-        </IconButton>
+        </IconButton_deprecated>
       </PopoverTrigger>
       <PopoverPortal>
         <Content {...props} />

--- a/apps/designer/app/designer/shared/design-tokens-manager/item-menu.tsx
+++ b/apps/designer/app/designer/shared/design-tokens-manager/item-menu.tsx
@@ -1,7 +1,7 @@
 import {
   DropdownMenu,
   DropdownMenuTrigger,
-  IconButton,
+  IconButton_deprecated,
   DropdownMenuContent,
   DropdownMenuItem,
   Text,
@@ -22,7 +22,7 @@ const stopPropagation: MouseEventHandler = (event) => {
   event.stopPropagation();
 };
 
-const MenuButton = styled(IconButton, {
+const MenuButton = styled(IconButton_deprecated, {
   color: "$hint",
   "&:hover, &:focus-visible": {
     color: "$hiContrast",

--- a/apps/designer/app/designer/shared/fonts-manager/item-menu.tsx
+++ b/apps/designer/app/designer/shared/fonts-manager/item-menu.tsx
@@ -1,7 +1,7 @@
 import {
   DropdownMenu,
   DropdownMenuTrigger,
-  IconButton,
+  IconButton_deprecated,
   DropdownMenuContent,
   DropdownMenuItem,
   Text,
@@ -11,7 +11,7 @@ import {
 import { MenuIcon } from "@webstudio-is/icons";
 import { type FocusEventHandler, useState, useRef, useEffect } from "react";
 
-const MenuButton = styled(IconButton, {
+const MenuButton = styled(IconButton_deprecated, {
   color: "$hint",
   "&:hover, &:focus-visible": {
     color: "$hiContrast",

--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -17,7 +17,7 @@ import {
 } from "downshift";
 import { matchSorter } from "match-sorter";
 import { styled } from "../stitches.config";
-import { IconButton } from "./icon-button";
+import { IconButton_deprecated } from "./icon-button-deprecated";
 import { itemCss } from "./menu";
 import { panelStyles } from "./panel";
 import { TextField } from "./text-field";
@@ -268,9 +268,9 @@ export const Combobox = <Item,>({
               placeholder,
             })}
             suffix={
-              <IconButton {...getToggleButtonProps()}>
+              <IconButton_deprecated {...getToggleButtonProps()}>
                 <ChevronDownIcon />
-              </IconButton>
+              </IconButton_deprecated>
             }
           />
         </PopperAnchor>

--- a/packages/design-system/src/components/dialog.tsx
+++ b/packages/design-system/src/components/dialog.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import * as React from "react";
 import { styled, CSS } from "../stitches.config";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { CrossIcon } from "@webstudio-is/icons";
 import { overlayStyles } from "./overlay";
 import { panelStyles } from "./panel";
-import { IconButton } from "./icon-button";
+import { IconButton_deprecated } from "./icon-button-deprecated";
 
 type DialogProps = React.ComponentProps<typeof DialogPrimitive.Root> & {
   children: React.ReactNode;
@@ -67,9 +67,9 @@ export const DialogContent = React.forwardRef<
   <StyledContent {...props} ref={forwardedRef}>
     {children}
     <StyledCloseButton asChild>
-      <IconButton>
+      <IconButton_deprecated>
         <CrossIcon />
-      </IconButton>
+      </IconButton_deprecated>
     </StyledCloseButton>
   </StyledContent>
 ));

--- a/packages/design-system/src/components/icon-button-deprecated.tsx
+++ b/packages/design-system/src/components/icon-button-deprecated.tsx
@@ -1,6 +1,6 @@
 import { styled } from "../stitches.config";
 
-export const IconButton = styled("button", {
+export const IconButton_deprecated = styled("button", {
   // Reset
   alignItems: "center",
   appearance: "none",

--- a/packages/design-system/src/components/icon-button-with-menu.tsx
+++ b/packages/design-system/src/components/icon-button-with-menu.tsx
@@ -2,7 +2,7 @@ import { CheckIcon, IconComponent } from "@webstudio-is/icons";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { styled } from "../stitches.config";
 import { Tooltip } from "./tooltip";
-import { IconButton } from "./icon-button";
+import { IconButton_deprecated } from "./icon-button-deprecated";
 
 const StyledContent = styled(DropdownMenuPrimitive.Content, {
   width: 192,
@@ -114,14 +114,14 @@ export const IconButtonWithMenu = ({
         disableHoverableContent={true}
       >
         <DropdownMenuPrimitive.Trigger asChild>
-          <IconButton
+          <IconButton_deprecated
             css={{
               ...iconButtonStyle,
               ...(isActive && iconButtonActiveStyle),
             }}
           >
             {Icon}
-          </IconButton>
+          </IconButton_deprecated>
         </DropdownMenuPrimitive.Trigger>
       </Tooltip>
       <DropdownMenuPrimitive.Portal>

--- a/packages/design-system/src/components/popover.tsx
+++ b/packages/design-system/src/components/popover.tsx
@@ -4,7 +4,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { Box } from "./box";
 import { panelStyles } from "./panel";
 import { Flex } from "./flex";
-import { IconButton } from "./icon-button";
+import { IconButton_deprecated } from "./icon-button-deprecated";
 import { Text } from "./text";
 import { Separator } from "./separator";
 import { styled, CSS } from "../stitches.config";
@@ -77,7 +77,7 @@ export const PopoverHeader = ({ title }: PopoverHeaderProps) => {
       >
         <Text variant="title">{title}</Text>
         <PopoverClose asChild>
-          <IconButton
+          <IconButton_deprecated
             size="2"
             css={{
               marginRight: "$spacing$5",
@@ -85,7 +85,7 @@ export const PopoverHeader = ({ title }: PopoverHeaderProps) => {
             aria-label="Close"
           >
             <CrossLargeIcon />
-          </IconButton>
+          </IconButton_deprecated>
         </PopoverClose>
       </Flex>
       <Separator />

--- a/packages/design-system/src/components/search-field.tsx
+++ b/packages/design-system/src/components/search-field.tsx
@@ -11,7 +11,7 @@ import {
   MagnifyingGlassIcon,
 } from "@webstudio-is/icons";
 import { TextField } from "./text-field";
-import { IconButton } from "./icon-button";
+import { IconButton_deprecated } from "./icon-button-deprecated";
 import { styled } from "../stitches.config";
 
 const SearchIcon = styled(MagnifyingGlassIcon, {
@@ -19,7 +19,7 @@ const SearchIcon = styled(MagnifyingGlassIcon, {
   padding: "$spacing$3",
 });
 
-const AbortButton = styled(IconButton, {
+const AbortButton = styled(IconButton_deprecated, {
   marginRight: "$spacing$3",
 });
 

--- a/packages/design-system/src/components/sheet.tsx
+++ b/packages/design-system/src/components/sheet.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import * as React from "react";
 import { styled, keyframes, VariantProps, CSS } from "../stitches.config";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { CrossIcon } from "@webstudio-is/icons";
 import { overlayStyles } from "./overlay";
-import { IconButton } from "./icon-button";
+import { IconButton_deprecated } from "./icon-button-deprecated";
 
 const fadeIn = keyframes({
   from: { opacity: "0" },
@@ -128,9 +128,9 @@ export const SheetContent = React.forwardRef<
   <StyledContent {...props} ref={forwardedRef}>
     {children}
     <StyledCloseButton asChild>
-      <IconButton>
+      <IconButton_deprecated>
         <CrossIcon />
-      </IconButton>
+      </IconButton_deprecated>
     </StyledCloseButton>
   </StyledContent>
 ));

--- a/packages/design-system/src/components/text-field.stories.tsx
+++ b/packages/design-system/src/components/text-field.stories.tsx
@@ -1,11 +1,11 @@
 import { expect } from "@storybook/jest";
 import { userEvent, waitFor, within } from "@storybook/testing-library";
-import React from "react";
+import * as React from "react";
 import { ComponentStory } from "@storybook/react";
 import { RowGapIcon, ChevronDownIcon } from "@webstudio-is/icons";
 import { Button } from "./button";
 import { Flex } from "./flex";
-import { IconButton } from "./icon-button";
+import { IconButton_deprecated } from "./icon-button-deprecated";
 import { TextField } from "./text-field";
 import { Box } from "./box";
 import { Grid } from "./grid";
@@ -64,27 +64,27 @@ export const PrefixSuffix: ComponentStory<typeof TextField> = () => {
       <TextField
         prefix={<RowGapIcon />}
         suffix={
-          <IconButton>
+          <IconButton_deprecated>
             <ChevronDownIcon />
-          </IconButton>
+          </IconButton_deprecated>
         }
       />
       <TextField
         state="invalid"
         prefix={<RowGapIcon />}
         suffix={
-          <IconButton>
+          <IconButton_deprecated>
             <ChevronDownIcon />
-          </IconButton>
+          </IconButton_deprecated>
         }
       />
       <TextField
         disabled
         prefix={<RowGapIcon />}
         suffix={
-          <IconButton>
+          <IconButton_deprecated>
             <ChevronDownIcon />
-          </IconButton>
+          </IconButton_deprecated>
         }
       />
     </Flex>
@@ -99,9 +99,9 @@ export const Layout: ComponentStory<typeof TextField> = () => {
           value="Long content comes here and it doesn't wrap"
           prefix={<RowGapIcon />}
           suffix={
-            <IconButton>
+            <IconButton_deprecated>
               <ChevronDownIcon />
-            </IconButton>
+            </IconButton_deprecated>
           }
           css={{
             flexGrow: 1,
@@ -211,9 +211,9 @@ export const ClickCapture: ComponentStory<typeof TextField> = (args) => {
         </Flex>
       }
       suffix={
-        <IconButton>
+        <IconButton_deprecated>
           <ChevronDownIcon />
-        </IconButton>
+        </IconButton_deprecated>
       }
       {...args}
     />

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -28,7 +28,7 @@ export { SimpleToggle } from "./components/simple-toggle";
 export { ScrollArea } from "./components/scrollbar";
 export { Tooltip, InputErrorsTooltip } from "./components/tooltip";
 export { Button } from "./components/button";
-export { IconButton } from "./components/icon-button";
+export { IconButton_deprecated } from "./components/icon-button-deprecated";
 export { Box } from "./components/box";
 export { ProgressBar } from "./components/progress-bar";
 export * from "./components/popover";


### PR DESCRIPTION
We are implementing new design with different variants so first deprecate old implemention and then step by step migrate to new version.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [x] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
