### PR TITLE
Fix media query specificity

### DIFF
--- a/packages/css-engine/src/core/css-engine.test.ts
+++ b/packages/css-engine/src/core/css-engine.test.ts
@@ -5,7 +5,14 @@ const style0 = {
 } as const;
 
 const mediaRuleOptions0 = { minWidth: 0 } as const;
-const mediaId = "0";
+const mediaId0 = "0";
+
+const style1 = {
+  display: { type: "keyword", value: "flex" },
+} as const;
+
+const mediaRuleOptions1 = { minWidth: 300 } as const;
+const mediaId1 = "1";
 
 describe("CssEngine", () => {
   let engine: CssEngine;
@@ -14,7 +21,7 @@ describe("CssEngine", () => {
     engine = new CssEngine();
   });
 
-  test("use default media rule when there is no matching one registrered", () => {
+  test("use default media rule when there is no matching one registered", () => {
     engine.addStyleRule(".c", {
       style: style0,
       breakpoint: "x",
@@ -35,25 +42,57 @@ describe("CssEngine", () => {
       }"
     `);
 
-    engine.addMediaRule(mediaId, mediaRuleOptions0);
+    engine.addMediaRule(mediaId0, mediaRuleOptions0);
     engine.addStyleRule(".c1", {
       style: { color: { type: "keyword", value: "blue" } },
-      breakpoint: mediaId,
+      breakpoint: mediaId0,
     });
     // Default media query should allways be the first to have the lowest source order specificity
     expect(engine.cssText).toMatchInlineSnapshot(`
-      "@media all {
+      "@media all and (min-width: 0px) {
+        .c1 { color: blue }
+      }
+      @media all {
         .c { display: block }
         .c1 { color: red }
+      }"
+    `);
+  });
+
+  test("sort media queries based on min-width", () => {
+    engine.addMediaRule(mediaId1, mediaRuleOptions1);
+    engine.addStyleRule(".c2", {
+      style: style1,
+      breakpoint: mediaId1,
+    });
+
+    engine.addMediaRule(mediaId0, mediaRuleOptions0);
+    engine.addStyleRule(".c1", {
+      style: style0,
+      breakpoint: mediaId0,
+    });
+
+    engine.addStyleRule(".c3", {
+      style: style0,
+      breakpoint: "x",
+    });
+
+    // Default media query should allways be the first to have the lowest source order specificity
+    expect(engine.cssText).toMatchInlineSnapshot(`
+      "@media all {
+        .c3 { display: block }
       }
       @media all and (min-width: 0px) {
-        .c1 { color: blue }
+        .c1 { display: block }
+      }
+      @media all and (min-width: 300px) {
+        .c2 { display: flex }
       }"
     `);
   });
 
   test("rule with multiple properties", () => {
-    engine.addMediaRule(mediaId, mediaRuleOptions0);
+    engine.addMediaRule(mediaId0, mediaRuleOptions0);
     engine.addStyleRule(".c", {
       style: {
         ...style0,
@@ -69,7 +108,7 @@ describe("CssEngine", () => {
   });
 
   test("hyphenate property", () => {
-    engine.addMediaRule(mediaId, mediaRuleOptions0);
+    engine.addMediaRule(mediaId0, mediaRuleOptions0);
     engine.addStyleRule(".c", {
       style: {
         backgroundColor: { type: "keyword", value: "red" },
@@ -84,7 +123,7 @@ describe("CssEngine", () => {
   });
 
   test("add rule", () => {
-    engine.addMediaRule(mediaId, mediaRuleOptions0);
+    engine.addMediaRule(mediaId0, mediaRuleOptions0);
     const rule1 = engine.addStyleRule(".c", {
       style: {
         ...style0,
@@ -116,7 +155,7 @@ describe("CssEngine", () => {
   });
 
   test("update rule", () => {
-    engine.addMediaRule(mediaId, mediaRuleOptions0);
+    engine.addMediaRule(mediaId0, mediaRuleOptions0);
     const rule = engine.addStyleRule(".c", {
       style: {
         ...style0,
@@ -147,7 +186,7 @@ describe("CssEngine", () => {
   });
 
   test("don't override media queries", () => {
-    engine.addMediaRule(mediaId, mediaRuleOptions0);
+    engine.addMediaRule(mediaId0, mediaRuleOptions0);
     engine.addStyleRule(".c", {
       style: style0,
       breakpoint: "0",
@@ -157,7 +196,7 @@ describe("CssEngine", () => {
         .c { display: block }
       }"
     `);
-    engine.addMediaRule(mediaId, mediaRuleOptions0);
+    engine.addMediaRule(mediaId0, mediaRuleOptions0);
     expect(engine.cssText).toMatchInlineSnapshot(`
       "@media all and (min-width: 0px) {
         .c { display: block }

--- a/packages/css-engine/src/core/css-engine.test.ts
+++ b/packages/css-engine/src/core/css-engine.test.ts
@@ -17,9 +17,11 @@ const mediaId1 = "1";
 describe("CssEngine", () => {
   let engine: CssEngine;
 
-  beforeEach(() => {
+  const reset = () => {
     engine = new CssEngine();
-  });
+  };
+
+  beforeEach(reset);
 
   test("use default media rule when there is no matching one registered", () => {
     engine.addStyleRule(".c", {
@@ -49,17 +51,17 @@ describe("CssEngine", () => {
     });
     // Default media query should allways be the first to have the lowest source order specificity
     expect(engine.cssText).toMatchInlineSnapshot(`
-      "@media all and (min-width: 0px) {
-        .c1 { color: blue }
-      }
-      @media all {
+      "@media all {
         .c { display: block }
         .c1 { color: red }
+      }
+      @media all and (min-width: 0px) {
+        .c1 { color: blue }
       }"
     `);
   });
 
-  test("sort media queries based on min-width", () => {
+  test("sort media queries based on lower min-width", () => {
     engine.addMediaRule(mediaId1, mediaRuleOptions1);
     engine.addStyleRule(".c2", {
       style: style1,
@@ -87,6 +89,40 @@ describe("CssEngine", () => {
       }
       @media all and (min-width: 300px) {
         .c2 { display: flex }
+      }"
+    `);
+  });
+
+  test("keep the sort order when minWidth is not defined", () => {
+    engine.addStyleRule(".c0", {
+      style: style0,
+      breakpoint: "x",
+    });
+    engine.addStyleRule(".c1", {
+      style: style1,
+      breakpoint: "x",
+    });
+    expect(engine.cssText).toMatchInlineSnapshot(`
+      "@media all {
+        .c0 { display: block }
+        .c1 { display: flex }
+      }"
+    `);
+
+    reset();
+
+    engine.addStyleRule(".c1", {
+      style: style1,
+      breakpoint: "x",
+    });
+    engine.addStyleRule(".c0", {
+      style: style0,
+      breakpoint: "x",
+    });
+    expect(engine.cssText).toMatchInlineSnapshot(`
+      "@media all {
+        .c1 { display: flex }
+        .c0 { display: block }
       }"
     `);
   });

--- a/packages/css-engine/src/core/css-engine.ts
+++ b/packages/css-engine/src/core/css-engine.ts
@@ -80,7 +80,7 @@ export class CssEngine {
     for (const plaintextRule of this.#plainRules.values()) {
       css.push(plaintextRule.cssText);
     }
-    for (const mediaRule of this.#mediaRules.values()) {
+    for (const mediaRule of MediaRule.sort(this.#mediaRules.values())) {
       const { cssText } = mediaRule;
       if (cssText !== "") css.push(cssText);
     }

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -71,8 +71,8 @@ export class MediaRule {
   static sort(mediaRules: Iterable<MediaRule>) {
     return Array.from(mediaRules).sort((ruleA, ruleB) => {
       return (
-        (ruleA.options.minWidth ?? -Infinity) -
-        (ruleB.options.minWidth ?? -Infinity)
+        (ruleA.options.minWidth ?? -Number.MAX_SAFE_INTEGER) -
+        (ruleB.options.minWidth ?? -Number.MAX_SAFE_INTEGER)
       );
     });
   }

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -67,14 +67,11 @@ export class MediaRule {
   // Needed to ensure that more specific media rules are inserted after less specific ones.
   // So that they get a higher specificity.
   static sort(mediaRules: Iterable<MediaRule>) {
-    return Array.from(mediaRules).sort((a, b) => {
-      if (
-        a.options.minWidth === undefined ||
-        b.options.minWidth === undefined
-      ) {
-        return -1;
-      }
-      return a.options.minWidth - b.options.minWidth;
+    return Array.from(mediaRules).sort((ruleA, ruleB) => {
+      return (
+        (ruleA.options.minWidth ?? -Infinity) -
+        (ruleB.options.minWidth ?? -Infinity)
+      );
     });
   }
   options: MediaRuleOptions;

--- a/packages/css-engine/src/core/rules.ts
+++ b/packages/css-engine/src/core/rules.ts
@@ -63,11 +63,25 @@ export type MediaRuleOptions = {
 };
 
 export class MediaRule {
-  #options: MediaRuleOptions;
+  // Sort media rules by minWidth.
+  // Needed to ensure that more specific media rules are inserted after less specific ones.
+  // So that they get a higher specificity.
+  static sort(mediaRules: Iterable<MediaRule>) {
+    return Array.from(mediaRules).sort((a, b) => {
+      if (
+        a.options.minWidth === undefined ||
+        b.options.minWidth === undefined
+      ) {
+        return -1;
+      }
+      return a.options.minWidth - b.options.minWidth;
+    });
+  }
+  options: MediaRuleOptions;
   rules: Array<StyleRule | PlaintextRule> = [];
   #mediaType;
   constructor(options: MediaRuleOptions = {}) {
-    this.#options = options;
+    this.options = options;
     this.#mediaType = options.mediaType ?? "all";
   }
   insertRule(rule: StyleRule | PlaintextRule) {
@@ -81,7 +95,7 @@ export class MediaRule {
       rules.push(`  ${rule.cssText}`);
     }
     let conditionText = "";
-    const { minWidth, maxWidth } = this.#options;
+    const { minWidth, maxWidth } = this.options;
     if (minWidth !== undefined) conditionText = `min-width: ${minWidth}px`;
     if (maxWidth !== undefined) conditionText = `max-width: ${maxWidth}px`;
     if (conditionText) conditionText = `and (${conditionText}) `;
@@ -108,13 +122,13 @@ export type FontFaceOptions = {
 };
 
 export class FontFaceRule {
-  #options: FontFaceOptions;
+  options: FontFaceOptions;
   constructor(options: FontFaceOptions) {
-    this.#options = options;
+    this.options = options;
   }
   get cssText() {
     const { fontFamily, fontStyle, fontWeight, fontDisplay, src } =
-      this.#options;
+      this.options;
     return `@font-face {\n  font-family: ${fontFamily}; font-style: ${fontStyle}; font-weight: ${fontWeight}; font-display: ${fontDisplay}; src: ${src};\n}`;
   }
 }


### PR DESCRIPTION
We haven't been sorting the media queries correctly

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
