### PR TITLE
Close selects with escape

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/unit-select.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/unit-select.tsx
@@ -142,7 +142,10 @@ const UnitSelect = ({
         </StyledTrigger>
       </SelectPrimitive.SelectTrigger>
       <SelectPrimitive.Portal>
-        <SelectContent onCloseAutoFocus={onCloseAutoFocus}>
+        <SelectContent
+          onCloseAutoFocus={onCloseAutoFocus}
+          onEscapeKeyDown={() => onOpenChange(false)}
+        >
           <SelectScrollUpButton>
             <ChevronUpIcon />
           </SelectScrollUpButton>

--- a/packages/design-system/src/components/select.tsx
+++ b/packages/design-system/src/components/select.tsx
@@ -1,8 +1,9 @@
+import type { ReactNode, Ref, ComponentProps } from "react";
+import { forwardRef, useState } from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
-import React, { ReactNode, Ref } from "react";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "@webstudio-is/icons";
 import { Grid } from "./grid";
 import { Box } from "./box";
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "@webstudio-is/icons";
 import { styled } from "../stitches.config";
 
 const StyledTrigger = styled(SelectPrimitive.SelectTrigger, {
@@ -135,20 +136,18 @@ const SelectItemBase = (
 type SelectItemProps = SelectPrimitive.SelectItemProps & {
   children: ReactNode;
 };
-export const SelectItem = React.forwardRef(SelectItemBase);
+export const SelectItem = forwardRef(SelectItemBase);
 
 export type SelectOption = string;
 
 export type SelectProps<Option = SelectOption> = Omit<
-  React.ComponentProps<typeof StyledTrigger>,
+  ComponentProps<typeof StyledTrigger>,
   "onChange" | "value" | "defaultValue"
 > & {
   options: Option[];
   defaultValue?: Option;
   value?: Option;
   onChange?: (option: Option) => void;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
   placeholder?: string;
   getLabel?: (option: Option) => string | undefined;
   getValue?: (option: Option) => string | undefined;
@@ -161,8 +160,6 @@ const SelectBase = (
     defaultValue,
     placeholder = "Select an option",
     onChange,
-    onOpenChange,
-    open,
     getLabel = (option) => option,
     getValue = (option) => option,
     name,
@@ -170,6 +167,7 @@ const SelectBase = (
   }: SelectProps,
   forwardedRef: Ref<HTMLButtonElement>
 ) => {
+  const [open, setOpen] = useState(false);
   return (
     <SelectPrimitive.Root
       name={name}
@@ -177,7 +175,7 @@ const SelectBase = (
       defaultValue={defaultValue}
       onValueChange={onChange}
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={setOpen}
     >
       <StyledTrigger ref={forwardedRef} {...props}>
         <SelectPrimitive.Value asChild>
@@ -188,7 +186,7 @@ const SelectBase = (
         </StyledIcon>
       </StyledTrigger>
       <SelectPrimitive.Portal>
-        <SelectContent>
+        <SelectContent onEscapeKeyDown={() => setOpen(false)}>
           <SelectScrollUpButton>
             <ChevronUpIcon />
           </SelectScrollUpButton>
@@ -212,5 +210,5 @@ const SelectBase = (
   );
 };
 
-export const Select = React.forwardRef(SelectBase);
+export const Select = forwardRef(SelectBase);
 Select.displayName = "Select";


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/579

Looks like current version of radix-ui select do not handle escape press but gives us event. Hard to say if this is fixed as they have poor versioning and no way to see previous version.

So in the fix I removed open and onOpenChange props from select in design system and used them to react on escape keydown event.

On unit select there is already external open state which I used the same way.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [x] detailed
  - [x] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
