### PR TITLE
Move `@webstudio-is/design-tokens` to `@webstudio-is/react-sdk` prod deps

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -35,7 +35,6 @@
     "@webstudio-is/generate-arg-types": "*",
     "@webstudio-is/jest-config": "*",
     "@webstudio-is/scripts": "*",
-    "@webstudio-is/design-tokens": "*",
     "babel-loader": "^8.2.5",
     "esbuild": "^0.14.25",
     "esbuild-node-externals": "^1.4.1",
@@ -58,6 +57,7 @@
   "dependencies": {
     "@webstudio-is/asset-uploader": "^*",
     "@webstudio-is/css-data": "*",
+    "@webstudio-is/design-tokens": "*",
     "@webstudio-is/icons": "*",
     "@webstudio-is/image": "*",
     "@webstudio-is/prisma-client": "*",


### PR DESCRIPTION
This should fix the problem reported on this line: https://github.com/webstudio-is/webstudio-saas/actions/runs/3657427162/jobs/6181006430#step:6:52 , cc @andrasbacsai 

Even though [you only reach for a type](https://github.com/webstudio-is/webstudio-designer/blob/1a66acb79c8c560b3a54b55512c2779991a68eff/packages/react-sdk/src/tree/root.ts#L11), you still should declare this package among your dependencies - otherwise, it won't be installed by your consumers and thus the TS compilation will fail for them. 