### PR TITLE
Enter has no effect if menu is open and no value selected

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -261,6 +261,7 @@ export const CssValueInput = ({
     getMenuProps,
     getItemProps,
     isOpen,
+    highlightedIndex,
   } = useCombobox<CssValueInputValue>({
     items: keywords,
     value,
@@ -333,8 +334,9 @@ export const CssValueInput = ({
   };
 
   const handleKeyDown = useHandleKeyDown({
-    // In case of menu is really open do not prevent default downshift Enter key behaviour
-    ignoreEnter: isOpen && !menuProps.empty,
+    // In case of the menu is really open and the selection is inside it
+    // we do not prevent the default downshift Enter key behavior
+    ignoreEnter: isOpen && !menuProps.empty && highlightedIndex !== -1,
     onChangeComplete,
     value,
     onChange: props.onChange,


### PR DESCRIPTION
Fixes Enter non-working part of #603, but not fixes Check mark showing logic.
The wrong value is used to compare the selected field, https://github.com/webstudio-is/webstudio-designer/blob/26d0d0c2a6b3fe21c2298e451ffea5adc350290e/packages/design-system/src/components/combobox.tsx#L203 as its compares with current item but not with already selected