### PR TITLE
Fix property reset glitches

### DIFF
--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -194,24 +194,27 @@ export const usePublishSelectedInstanceData = (treeId: Tree["id"]) => {
   const [allUserProps] = useAllUserProps();
 
   useEffect(() => {
-    // Unselects the instance by `undefined`
-    let payload;
-    if (instance !== undefined) {
-      const props =
-        allUserProps[instance.id] ??
-        utils.props.createInstanceProps({ instanceId: instance.id, treeId });
-      const browserStyle = getBrowserStyle(selectedElement);
-      payload = {
-        id: instance.id,
-        component: instance.component,
-        cssRules: instance.cssRules,
-        browserStyle,
-        props,
-      };
-    }
-    publish({
-      type: "selectInstance",
-      payload,
+    // some styles require nexxxt frame to provide new value
+    requestAnimationFrame(() => {
+      // Unselects the instance by `undefined`
+      let payload;
+      if (instance !== undefined) {
+        const props =
+          allUserProps[instance.id] ??
+          utils.props.createInstanceProps({ instanceId: instance.id, treeId });
+        const browserStyle = getBrowserStyle(selectedElement);
+        payload = {
+          id: instance.id,
+          component: instance.component,
+          cssRules: instance.cssRules,
+          browserStyle,
+          props,
+        };
+      }
+      publish({
+        type: "selectInstance",
+        payload,
+      });
     });
   }, [instance, allUserProps, treeId, selectedElement]);
 };

--- a/apps/designer/app/designer/features/style-panel/controls/color/color-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/color/color-control.tsx
@@ -15,11 +15,15 @@ export const ColorControl = ({
     currentStyle,
     inheritedStyle,
     property: styleConfig.property,
-  });
-
-  if (value === undefined) {
-    return null;
-  }
+  }) ?? {
+    // provide default value to avoid control hiding
+    // when value is recomputed
+    type: "rgb" as const,
+    r: 0,
+    g: 0,
+    b: 0,
+    alpha: 0,
+  };
 
   const setValue = setProperty(styleConfig.property);
 

--- a/apps/designer/app/designer/features/style-panel/controls/select/select-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/select/select-control.tsx
@@ -16,14 +16,13 @@ export const SelectControl = ({
     property: styleConfig.property,
   });
 
-  if (value === undefined) {
-    return null;
-  }
-
   const setValue = setProperty(styleConfig.property);
 
   return (
     <Select
+      // show empty field instead of radix placeholder
+      // like css value input does
+      placeholder=""
       options={styleConfig.items.map(({ label }) => label)}
       value={toValue(value)}
       onChange={setValue}


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/600 https://github.com/webstudio-is/webstudio-designer/issues/608

- wrapped getComputedStyle with requestAnimationFrame to recompute some styles correctly
- added default to color picker to avoid hiding while styles are recomputed
- added placeholder to select to avoid hiding while styles are recomputed

These issues comes from the fact we compute default styles from dom instead of data.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [x] detailed
  - [x] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
