### PR TITLE
Fix performance issue with scrub when used inside popover

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -79,8 +79,9 @@ const useScrub = ({
 
   // make sure caret doesn't jump around as you scrub
   useLayoutEffect(() => {
-    if (isInputActive) {
-      inputRef.current?.select();
+    const input = inputRef.current;
+    if (isInputActive && input) {
+      input.selectionStart = input.selectionEnd = input.value.length;
     }
   });
 

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -26,8 +26,6 @@ import {
   useCallback,
   useEffect,
   useRef,
-  useState,
-  useLayoutEffect,
 } from "react";
 import { useIsFromCurrentBreakpoint } from "../use-is-from-current-breakpoint";
 import { useUnitSelect } from "./unit-select";
@@ -63,7 +61,6 @@ const useScrub = ({
 ] => {
   const scrubRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const [isInputActive, setIsInputActive] = useState(false);
 
   const onChangeRef = useRef(onChange);
   const onChangeCompleteRef = useRef(onChangeComplete);
@@ -76,14 +73,6 @@ const useScrub = ({
 
   const type = valueRef.current.type;
   const unit = type === "unit" ? valueRef.current.unit : undefined;
-
-  // make sure caret doesn't jump around as you scrub
-  useLayoutEffect(() => {
-    const input = inputRef.current;
-    if (isInputActive && input) {
-      input.selectionStart = input.selectionEnd = input.value.length;
-    }
-  });
 
   // Since scrub is going to call onChange and onChangeComplete callbacks, it will result in a new value and potentially new callback refs.
   // We need this effect to ONLY run when type or unit changes, but not when callbacks or value.value changes.
@@ -115,7 +104,9 @@ const useScrub = ({
         }
       },
       onValueInput(event) {
-        setIsInputActive(true);
+        // Moving focus to container of the input to hide the caret
+        // (it makes text harder to read and may jump around as you scrub)
+        scrubRef.current?.focus();
 
         onChangeRef.current({
           type,
@@ -134,7 +125,9 @@ const useScrub = ({
           });
         });
 
-        setIsInputActive(false);
+        // Returning focus that we've moved above
+        inputRef.current?.focus();
+        inputRef.current?.select();
       },
       shouldHandleEvent: shouldHandleEvent,
     });

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -27,6 +27,7 @@ import {
   useEffect,
   useRef,
   useState,
+  useLayoutEffect,
 } from "react";
 import { useIsFromCurrentBreakpoint } from "../use-is-from-current-breakpoint";
 import { useUnitSelect } from "./unit-select";
@@ -77,6 +78,13 @@ const useScrub = ({
   const type = valueRef.current.type;
   const unit = type === "unit" ? valueRef.current.unit : undefined;
 
+  // make sure caret doesn't jump around as you scrub
+  useLayoutEffect(() => {
+    if (isInputActive) {
+      inputRef.current?.select();
+    }
+  });
+
   // Since scrub is going to call onChange and onChangeComplete callbacks, it will result in a new value and potentially new callback refs.
   // We need this effect to ONLY run when type or unit changes, but not when callbacks or value.value changes.
   useEffect(() => {
@@ -108,7 +116,6 @@ const useScrub = ({
       },
       onValueInput(event) {
         setIsInputActive(true);
-        inputRefCurrent.blur();
 
         onChangeRef.current({
           type,
@@ -128,8 +135,6 @@ const useScrub = ({
         });
 
         setIsInputActive(false);
-        inputRefCurrent.focus();
-        inputRefCurrent.select();
       },
       shouldHandleEvent: shouldHandleEvent,
     });
@@ -308,6 +313,7 @@ export const CssValueInput = ({
   const shouldHandleEvent = useCallback((node) => {
     return suffixRef.current?.contains?.(node) === false;
   }, []);
+
   const [scrubRef, inputRef, isInputActive] = useScrub({
     value,
     onChange: props.onChange,

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -59,8 +59,7 @@ const useScrub = ({
   shouldHandleEvent?: (node: EventTarget) => boolean;
 }): [
   React.MutableRefObject<HTMLDivElement | null>,
-  React.MutableRefObject<HTMLInputElement | null>,
-  boolean
+  React.MutableRefObject<HTMLInputElement | null>
 ] => {
   const scrubRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -142,7 +141,7 @@ const useScrub = ({
     return scrub.disconnectedCallback;
   }, [type, unit, shouldHandleEvent]);
 
-  return [scrubRef, inputRef, isInputActive];
+  return [scrubRef, inputRef];
 };
 
 const useHandleKeyDown =
@@ -314,7 +313,7 @@ export const CssValueInput = ({
     return suffixRef.current?.contains?.(node) === false;
   }, []);
 
-  const [scrubRef, inputRef, isInputActive] = useScrub({
+  const [scrubRef, inputRef] = useScrub({
     value,
     onChange: props.onChange,
     onChangeComplete,
@@ -398,13 +397,7 @@ export const CssValueInput = ({
             baseRef={scrubRef}
             inputRef={inputRef}
             name={property}
-            state={
-              value.type === "invalid"
-                ? "invalid"
-                : isInputActive
-                ? "active"
-                : undefined
-            }
+            state={value.type === "invalid" ? "invalid" : undefined}
             prefix={prefix}
             suffix={suffix}
             css={{ cursor: "default" }}

--- a/packages/design-system/src/components/primitives/numeric-gesture-control.ts
+++ b/packages/design-system/src/components/primitives/numeric-gesture-control.ts
@@ -37,7 +37,6 @@ export type NumericScrubOptions = {
 type NumericScrubState = {
   value: number;
   cursor?: SVGElement;
-  velocity: number;
   direction: string;
   timerId?: ReturnType<typeof window.setTimeout>;
 };
@@ -59,7 +58,6 @@ export const numericScrubControl = (
     // We will read value lazyly in a moment it will be used to avoid having outdated value
     value: -1,
     cursor: undefined,
-    velocity: direction === "horizontal" ? 1 : -1,
     direction: direction,
     timerId: undefined,
   };

--- a/packages/design-system/src/components/text-field.tsx
+++ b/packages/design-system/src/components/text-field.tsx
@@ -314,6 +314,11 @@ export const TextField = React.forwardRef<HTMLDivElement, TextFieldProps>(
         withPrefix={Boolean(prefix)}
         withSuffix={Boolean(suffix)}
         onClickCapture={focusInnerInput}
+        // Setting tabIndex to -1 to allow this element to be focused via JavaScript.
+        // This is used when we need to hide the caret but want to:
+        //   1. keep the visual focused state of the component
+        //   2. keep focus somewhere insisde the component to not trigger some focus-trap logic
+        tabIndex={-1}
       >
         {/* We want input to be the first element in DOM so it receives the focus first */}
         <InputBase


### PR DESCRIPTION
https://discord.com/channels/955905230107738152/1052545317922406440

> so the problem is useScrub wants to remove focus from input: https://github.com/webstudio-is/webstudio-designer/blob/c70d9ff21a64da12a0562d046246a5e359d556e9/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx#L111

> but popover wants to keep focus inside content while it's open (not configurable): https://github.com/radix-ui/primitives/blob/81b25f4b40c54f72aeb106ca0e64e1e09655153e/packages/react/popover/src/Popover.tsx#L261-L263

> and they fight

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [x] detailed
  - [x] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
