### PR TITLE
Remove treeId from props updates

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -139,8 +139,8 @@ const DesignMode = ({ treeId, buildId }: DesignModeProps) => {
   useManageBreakpoints();
   usePublishDesignTokens();
   useManageDesignModeStyles();
-  useManageProps();
-  usePublishSelectedInstanceData(treeId);
+  useManageProps({ treeId });
+  usePublishSelectedInstanceData();
   useInsertInstance({ treeId });
   useReparentInstance();
   useDeleteInstance();

--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -188,7 +188,7 @@ export const useDeleteInstance = () => {
   });
 };
 
-export const usePublishSelectedInstanceData = (treeId: Tree["id"]) => {
+export const usePublishSelectedInstanceData = () => {
   const [instance] = useSelectedInstance();
   const [selectedElement] = useSelectedElement();
   const [allUserProps] = useAllUserProps();
@@ -204,11 +204,9 @@ export const usePublishSelectedInstanceData = (treeId: Tree["id"]) => {
 
   useEffect(() => {
     // Unselects the instance by `undefined`
-    let payload;
+    let payload: undefined | SelectedInstanceData;
     if (instance !== undefined) {
-      const props =
-        allUserProps[instance.id] ??
-        utils.props.createInstanceProps({ instanceId: instance.id, treeId });
+      const props = allUserProps[instance.id];
       const browserStyle = getBrowserStyle(selectedElement);
       payload = {
         id: instance.id,
@@ -222,7 +220,7 @@ export const usePublishSelectedInstanceData = (treeId: Tree["id"]) => {
       type: "selectInstance",
       payload,
     });
-  }, [instance, allUserProps, treeId, selectedElement, styleKey]);
+  }, [instance, allUserProps, selectedElement, styleKey]);
 };
 
 export const usePublishHoveredInstanceData = () => {

--- a/apps/designer/app/canvas/shared/props.ts
+++ b/apps/designer/app/canvas/shared/props.ts
@@ -6,10 +6,10 @@ import {
   deletePropMutable,
 } from "~/shared/props-utils";
 
-export const useManageProps = () => {
+export const useManageProps = ({ treeId }: { treeId: string }) => {
   useSubscribe("updateProps", (userPropsUpdates) => {
     store.createTransaction([allUserPropsContainer], (allUserProps) => {
-      updateAllUserPropsMutable(allUserProps, userPropsUpdates);
+      updateAllUserPropsMutable(treeId, allUserProps, userPropsUpdates);
     });
   });
 

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -114,7 +114,9 @@ const useCopyPaste = (publish: Publish) => {
         rootInstance,
         selectedInstance.id
       );
-      return instance && { instance, props: selectedInstance.props.props };
+      return (
+        instance && { instance, props: selectedInstance.props?.props ?? [] }
+      );
     }
   }, [rootInstance, selectedInstance]);
 

--- a/apps/designer/app/designer/features/props-panel/use-props-logic.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.ts
@@ -204,8 +204,7 @@ export const usePropsLogic = ({
     publish({
       type: "updateProps",
       payload: {
-        treeId: selectedInstanceData.props.treeId,
-        propsId: selectedInstanceData.props.id,
+        propsId: selectedInstanceData.props?.id,
         instanceId: selectedInstanceData.id,
         updates,
       },

--- a/apps/designer/app/shared/props-utils/update-props.test.ts
+++ b/apps/designer/app/shared/props-utils/update-props.test.ts
@@ -18,10 +18,9 @@ describe("Update props", () => {
     const update: UserPropsUpdates = {
       propsId: "id",
       instanceId: "instanceId",
-      treeId: "treeId",
       updates: [],
     };
-    updateAllUserPropsMutable(propsMap, update);
+    updateAllUserPropsMutable("treeId", propsMap, update);
     expect(propsMap).toMatchSnapshot();
   });
 
@@ -37,10 +36,9 @@ describe("Update props", () => {
     const update: UserPropsUpdates = {
       propsId: "id",
       instanceId: "instanceId",
-      treeId: "treeId",
       updates: [{ id: "propId", prop: "a", value: "1", type: "string" }],
     };
-    updateAllUserPropsMutable(propsMap, update);
+    updateAllUserPropsMutable("treeId", propsMap, update);
     expect(propsMap).toMatchSnapshot();
   });
 
@@ -56,10 +54,9 @@ describe("Update props", () => {
     const update: UserPropsUpdates = {
       propsId: "id",
       instanceId: "instanceId",
-      treeId: "treeId",
       updates: [{ id: "propId", prop: "a", value: "2", type: "string" }],
     };
-    updateAllUserPropsMutable(propsMap, update);
+    updateAllUserPropsMutable("treeId", propsMap, update);
     expect(propsMap).toMatchSnapshot();
   });
 
@@ -75,10 +72,9 @@ describe("Update props", () => {
     const update: UserPropsUpdates = {
       propsId: "id",
       instanceId: "instanceId",
-      treeId: "treeId",
       updates: [{ id: "propId", prop: "b", value: "1", type: "string" }],
     };
-    updateAllUserPropsMutable(propsMap, update);
+    updateAllUserPropsMutable("treeId", propsMap, update);
     expect(propsMap).toMatchSnapshot();
   });
 
@@ -94,7 +90,6 @@ describe("Update props", () => {
     const update: UserPropsUpdates = {
       propsId: "id",
       instanceId: "instanceId",
-      treeId: "treeId",
       updates: [
         {
           id: "propId",
@@ -104,7 +99,7 @@ describe("Update props", () => {
         },
       ],
     };
-    updateAllUserPropsMutable(propsMap, update);
+    updateAllUserPropsMutable("treeId", propsMap, update);
     expect(propsMap).toMatchInlineSnapshot(`
       {
         "instanceId": {

--- a/apps/designer/app/shared/props-utils/update-props.ts
+++ b/apps/designer/app/shared/props-utils/update-props.ts
@@ -4,12 +4,13 @@ import {
 } from "@webstudio-is/react-sdk";
 
 export const updateAllUserPropsMutable = (
+  treeId: string,
   allUserProps: AllUserProps,
-  { instanceId, propsId, treeId, updates }: UserPropsUpdates
+  { instanceId, propsId, updates }: UserPropsUpdates
 ) => {
   if (instanceId in allUserProps === false) {
     allUserProps[instanceId] = {
-      id: propsId,
+      id: propsId ?? crypto.randomUUID(),
       instanceId,
       treeId,
       props: [],

--- a/apps/designer/app/shared/props-utils/update-props.ts
+++ b/apps/designer/app/shared/props-utils/update-props.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from "uuid";
 import {
   type AllUserProps,
   type UserPropsUpdates,
@@ -10,7 +11,7 @@ export const updateAllUserPropsMutable = (
 ) => {
   if (instanceId in allUserProps === false) {
     allUserProps[instanceId] = {
-      id: propsId ?? crypto.randomUUID(),
+      id: propsId ?? uuid(),
       instanceId,
       treeId,
       props: [],

--- a/packages/project/src/shared/canvas-components/instance-data.ts
+++ b/packages/project/src/shared/canvas-components/instance-data.ts
@@ -12,7 +12,7 @@ export type SelectedInstanceData = {
   component: Instance["component"];
   cssRules: Array<CssRule>;
   browserStyle: Style;
-  props: InstanceProps;
+  props?: InstanceProps;
 };
 
 export type HoveredInstanceData = {

--- a/packages/react-sdk/src/user-props/types.ts
+++ b/packages/react-sdk/src/user-props/types.ts
@@ -2,9 +2,8 @@ import type { InstanceProps, Instance } from "../db";
 import { UserProp } from "./schema";
 
 export type UserPropsUpdates = {
-  treeId: InstanceProps["treeId"];
-  propsId: InstanceProps["id"];
   instanceId: Instance["id"];
+  propsId?: InstanceProps["id"];
   updates: Array<UserProp>;
 };
 


### PR DESCRIPTION
Will help with https://github.com/webstudio-is/webstudio-designer/issues/628

treeId is stored in every props update which complicates data flow and requires passing it everywhere. Here I instead pass it inside of transaction.

This allowed us pass undefined in props data when select instance so we no longer need to create empty instance props. Updates will create it lazily.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [x] detailed
  - [x] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
