### PR TITLE
Hide deleting assets immediately on delete

### DIFF
--- a/apps/designer/app/designer/shared/assets/types.ts
+++ b/apps/designer/app/designer/shared/assets/types.ts
@@ -17,6 +17,9 @@ export type UploadingClientAsset = {
   preview: PreviewAsset;
 };
 
+/**
+ * Used for optimistic UI only
+ **/
 export type DeletingClientAsset = {
   status: "deleting";
   asset: Asset;
@@ -24,12 +27,17 @@ export type DeletingClientAsset = {
 };
 
 /**
- * Client side we need more information about the asset than the server provides.
+ * On the client side, we need more information about the asset than the server provides.
  */
 export type ClientAsset =
   | UploadedClientAsset
   | UploadingClientAsset
   | DeletingClientAsset;
+
+/**
+ * Assets that can be shown in the UI
+ */
+export type ActiveAsset = UploadedClientAsset | UploadingClientAsset;
 
 export type ActionData = {
   uploadedAssets?: Array<Asset>;

--- a/apps/designer/app/designer/shared/assets/types.ts
+++ b/apps/designer/app/designer/shared/assets/types.ts
@@ -37,7 +37,7 @@ export type ClientAsset =
 /**
  * Assets that can be shown in the UI
  */
-export type ActiveAsset = UploadedClientAsset | UploadingClientAsset;
+export type RenderableAsset = UploadedClientAsset | UploadingClientAsset;
 
 export type ActionData = {
   uploadedAssets?: Array<Asset>;

--- a/apps/designer/app/designer/shared/assets/use-assets.tsx
+++ b/apps/designer/app/designer/shared/assets/use-assets.tsx
@@ -18,7 +18,11 @@ import { toast } from "@webstudio-is/design-system";
 import { restAssetsPath } from "~/shared/router-utils";
 import { useClientAssets, useProject } from "../nano-states";
 import { sanitizeS3Key } from "@webstudio-is/asset-uploader";
-import type { ActiveAsset, ClientAsset, UploadingClientAsset } from "./types";
+import type {
+  RenderableAsset,
+  ClientAsset,
+  UploadingClientAsset,
+} from "./types";
 import { usePersistentFetcher } from "~/shared/fetcher";
 import type { ActionData } from "~/designer/shared/assets";
 import {
@@ -308,7 +312,7 @@ export const AssetsProvider = ({ children }: { children: ReactNode }) => {
   );
 };
 
-const filterByType = (clientAssets: ActiveAsset[], type: AssetType) => {
+const filterByType = (clientAssets: RenderableAsset[], type: AssetType) => {
   return clientAssets.filter((clientAsset) => {
     const format = clientAsset.asset?.format ?? clientAsset.preview?.format;
 
@@ -330,7 +334,7 @@ export const useAssets = (type: AssetType) => {
   const assetsByType = useMemo(() => {
     // In no case we need to have access to deleting assets
     // But we need them for optiistic updates, filter out here
-    const activeAssets: ActiveAsset[] = [];
+    const activeAssets: RenderableAsset[] = [];
 
     for (const asset of assetsContext.assets) {
       if (asset.status !== "deleting") {

--- a/apps/designer/app/designer/shared/assets/use-assets.tsx
+++ b/apps/designer/app/designer/shared/assets/use-assets.tsx
@@ -78,7 +78,7 @@ const toUploadingAssetsAndFormData = (
           // should be removed after fix
           const formData = new FormData();
           formData.append(type, file, sanitizeS3Key(file.name));
-          formData.append(idsFormDataFieldName, crypto.randomUUID());
+          formData.append(idsFormDataFieldName, id);
 
           resolve([
             {

--- a/apps/designer/app/designer/shared/fonts-manager/item-utils.ts
+++ b/apps/designer/app/designer/shared/fonts-manager/item-utils.ts
@@ -1,13 +1,13 @@
 import { SYSTEM_FONTS } from "@webstudio-is/fonts";
 import { matchSorter } from "match-sorter";
-import { ClientAsset } from "../assets";
+import { ActiveAsset } from "../assets";
 
 export type Item = {
   label: string;
   type: "uploaded" | "system";
 };
 
-export const toItems = (clientAssets: Array<ClientAsset>): Array<Item> => {
+export const toItems = (clientAssets: Array<ActiveAsset>): Array<Item> => {
   const system = Array.from(SYSTEM_FONTS.keys()).map((label) => ({
     label,
     type: "system",
@@ -33,7 +33,7 @@ export const toItems = (clientAssets: Array<ClientAsset>): Array<Item> => {
 
 export const filterIdsByFamily = (
   family: string,
-  clientAssets: Array<ClientAsset>
+  clientAssets: Array<ActiveAsset>
 ) => {
   // One family may have multiple assets for different formats, so we need to find them all.
   return (

--- a/apps/designer/app/designer/shared/fonts-manager/item-utils.ts
+++ b/apps/designer/app/designer/shared/fonts-manager/item-utils.ts
@@ -1,13 +1,13 @@
 import { SYSTEM_FONTS } from "@webstudio-is/fonts";
 import { matchSorter } from "match-sorter";
-import { ActiveAsset } from "../assets";
+import { RenderableAsset } from "../assets";
 
 export type Item = {
   label: string;
   type: "uploaded" | "system";
 };
 
-export const toItems = (clientAssets: Array<ActiveAsset>): Array<Item> => {
+export const toItems = (clientAssets: Array<RenderableAsset>): Array<Item> => {
   const system = Array.from(SYSTEM_FONTS.keys()).map((label) => ({
     label,
     type: "system",
@@ -33,7 +33,7 @@ export const toItems = (clientAssets: Array<ActiveAsset>): Array<Item> => {
 
 export const filterIdsByFamily = (
   family: string,
-  clientAssets: Array<ActiveAsset>
+  clientAssets: Array<RenderableAsset>
 ) => {
   // One family may have multiple assets for different formats, so we need to find them all.
   return (

--- a/apps/designer/app/designer/shared/image-manager/image-manager.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-manager.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import { findNextListIndex, Grid } from "@webstudio-is/design-system";
-import { AssetsShell, type ClientAsset, useAssets, useSearch } from "../assets";
+import { AssetsShell, type ActiveAsset, useAssets, useSearch } from "../assets";
 import { useFilter } from "../assets/use-filter";
 import { ImageThumbnail } from "./image-thumbnail";
 import { matchSorter } from "match-sorter";
 
-const filterItems = (search: string, items: Array<ClientAsset>) => {
+const filterItems = (search: string, items: ActiveAsset[]) => {
   return matchSorter(items, search, {
     keys: [
       (item) =>
@@ -17,7 +17,7 @@ const filterItems = (search: string, items: Array<ClientAsset>) => {
 const useLogic = ({
   onChange,
 }: {
-  onChange?: (asset: ClientAsset) => void;
+  onChange?: (asset: ActiveAsset) => void;
 }) => {
   const { assets, handleDelete } = useAssets("image");
 
@@ -58,7 +58,7 @@ const useLogic = ({
     },
   });
 
-  const handleSelect = (clientAsset?: ClientAsset) => {
+  const handleSelect = (clientAsset?: ActiveAsset) => {
     const selectedIndex = filteredItems.findIndex(
       (item) =>
         (item.asset?.id ?? item.preview?.id) ===
@@ -77,7 +77,7 @@ const useLogic = ({
 };
 
 type ImageManagerProps = {
-  onChange?: (asset: ClientAsset) => void;
+  onChange?: (asset: ActiveAsset) => void;
 };
 
 export const ImageManager = ({ onChange }: ImageManagerProps) => {

--- a/apps/designer/app/designer/shared/image-manager/image-manager.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-manager.tsx
@@ -1,11 +1,16 @@
 import { useState } from "react";
 import { findNextListIndex, Grid } from "@webstudio-is/design-system";
-import { AssetsShell, type ActiveAsset, useAssets, useSearch } from "../assets";
+import {
+  AssetsShell,
+  type RenderableAsset,
+  useAssets,
+  useSearch,
+} from "../assets";
 import { useFilter } from "../assets/use-filter";
 import { ImageThumbnail } from "./image-thumbnail";
 import { matchSorter } from "match-sorter";
 
-const filterItems = (search: string, items: ActiveAsset[]) => {
+const filterItems = (search: string, items: RenderableAsset[]) => {
   return matchSorter(items, search, {
     keys: [
       (item) =>
@@ -17,7 +22,7 @@ const filterItems = (search: string, items: ActiveAsset[]) => {
 const useLogic = ({
   onChange,
 }: {
-  onChange?: (asset: ActiveAsset) => void;
+  onChange?: (asset: RenderableAsset) => void;
 }) => {
   const { assets, handleDelete } = useAssets("image");
 
@@ -58,7 +63,7 @@ const useLogic = ({
     },
   });
 
-  const handleSelect = (clientAsset?: ActiveAsset) => {
+  const handleSelect = (clientAsset?: RenderableAsset) => {
     const selectedIndex = filteredItems.findIndex(
       (item) =>
         (item.asset?.id ?? item.preview?.id) ===
@@ -77,7 +82,7 @@ const useLogic = ({
 };
 
 type ImageManagerProps = {
-  onChange?: (asset: ActiveAsset) => void;
+  onChange?: (asset: RenderableAsset) => void;
 };
 
 export const ImageManager = ({ onChange }: ImageManagerProps) => {

--- a/apps/designer/app/designer/shared/image-manager/image-thumbnail.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-thumbnail.tsx
@@ -9,7 +9,7 @@ import placeholderImage from "~/shared/images/image-placeholder.svg";
 import brokenImage from "~/shared/images/broken-image-placeholder.svg";
 import { UploadingAnimation } from "./uploading-animation";
 import { ImageInfoTrigger, imageInfoTriggerCssVars } from "./image-info-tigger";
-import type { ActiveAsset } from "~/designer/shared/assets";
+import type { RenderableAsset } from "~/designer/shared/assets";
 import { Filename } from "./filename";
 
 const useImageWithFallback = ({
@@ -68,10 +68,10 @@ const Thumbnail = styled(Box, {
 });
 
 type ImageThumbnailProps = {
-  asset: ActiveAsset;
+  asset: RenderableAsset;
   onDelete: (ids: Array<string>) => void;
-  onSelect: (asset?: ActiveAsset) => void;
-  onChange?: (asset: ActiveAsset) => void;
+  onSelect: (asset?: RenderableAsset) => void;
+  onChange?: (asset: RenderableAsset) => void;
   state?: "selected";
 };
 

--- a/apps/designer/app/designer/shared/image-manager/image-thumbnail.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-thumbnail.tsx
@@ -9,7 +9,7 @@ import placeholderImage from "~/shared/images/image-placeholder.svg";
 import brokenImage from "~/shared/images/broken-image-placeholder.svg";
 import { UploadingAnimation } from "./uploading-animation";
 import { ImageInfoTrigger, imageInfoTriggerCssVars } from "./image-info-tigger";
-import type { ClientAsset } from "~/designer/shared/assets";
+import type { ActiveAsset } from "~/designer/shared/assets";
 import { Filename } from "./filename";
 
 const useImageWithFallback = ({
@@ -68,10 +68,10 @@ const Thumbnail = styled(Box, {
 });
 
 type ImageThumbnailProps = {
-  asset: ClientAsset;
+  asset: ActiveAsset;
   onDelete: (ids: Array<string>) => void;
-  onSelect: (asset?: ClientAsset) => void;
-  onChange?: (asset: ClientAsset) => void;
+  onSelect: (asset?: ActiveAsset) => void;
+  onChange?: (asset: ActiveAsset) => void;
   state?: "selected";
 };
 
@@ -97,7 +97,6 @@ export const ImageThumbnail = ({
       : name;
 
   const isUploading = status === "uploading";
-  const isDeleting = status === "deleting";
 
   const src = useImageWithFallback({ path });
 
@@ -108,9 +107,7 @@ export const ImageThumbnail = ({
       status={status}
       state={state}
       onFocus={() => {
-        if (clientAsset.status !== "deleting") {
-          onSelect?.(clientAsset);
-        }
+        onSelect?.(clientAsset);
       }}
       onBlur={(event: FocusEvent) => {
         const isFocusWithin = event.currentTarget.contains(event.relatedTarget);
@@ -149,7 +146,7 @@ export const ImageThumbnail = ({
           }}
         />
       )}
-      {(isUploading || isDeleting) && <UploadingAnimation />}
+      {isUploading && <UploadingAnimation />}
     </ThumbnailContainer>
   );
 };


### PR DESCRIPTION
Now image delete is shown immediately on delete.
PR_1 of #546  (simplifies logic and types for image thumbnail)

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [x] conceptual
  - [ ] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
