### PR TITLE
Resolve tsconfig package

### DIFF
--- a/apps/designer/tsconfig.json
+++ b/apps/designer/tsconfig.json
@@ -1,6 +1,6 @@
 {
   // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/remix.json",
+  "extends": "../../packages/tsconfig/remix.json",
   "include": [
     "remix.env.d.ts",
     "**/*.ts",

--- a/packages/asset-uploader/package.json
+++ b/packages/asset-uploader/package.json
@@ -28,6 +28,7 @@
     "@types/sharp": "^0.30.4",
     "@webstudio-is/jest-config": "*",
     "@webstudio-is/scripts": "*",
+    "@webstudio-is/tsconfig": "*",
     "typescript": "4.7.4",
     "zod": "^3.19.1"
   },

--- a/packages/asset-uploader/tsconfig.json
+++ b/packages/asset-uploader/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/css-tree": "^2.0.0",
     "@webstudio-is/scripts": "*",
+    "@webstudio-is/tsconfig": "*",
     "camelcase": "^6.3.0",
     "css-tree": "^2.3.0",
     "mdn-data": "2.0.23",

--- a/packages/css-data/tsconfig.json
+++ b/packages/css-data/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"

--- a/packages/css-engine/package.json
+++ b/packages/css-engine/package.json
@@ -35,6 +35,7 @@
     "@webstudio-is/jest-config": "*",
     "@webstudio-is/css-data": "*",
     "@webstudio-is/scripts": "*",
+    "@webstudio-is/tsconfig": "*",
     "typescript": "4.7.4",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9"

--- a/packages/css-engine/tsconfig.json
+++ b/packages/css-engine/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"

--- a/packages/css-vars/package.json
+++ b/packages/css-vars/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@webstudio-is/jest-config": "*",
     "@webstudio-is/scripts": "*",
+    "@webstudio-is/tsconfig": "*",
     "typescript": "4.7.4"
   },
   "module": "./lib/index.js",

--- a/packages/css-vars/tsconfig.json
+++ b/packages/css-vars/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -28,6 +28,7 @@
     "@storybook/testing-library": "^0.0.13",
     "@webstudio-is/scripts": "*",
     "@webstudio-is/jest-config": "*",
+    "@webstudio-is/tsconfig": "*",
     "typescript": "4.7.4"
   },
   "peerDependencies": {

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -1,13 +1,10 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "module": "ES2020",
-    "jsx": "react-jsx",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./lib"

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@webstudio-is/scripts": "*",
+    "@webstudio-is/tsconfig": "*",
     "typescript": "4.7.4"
   },
   "exports": {

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src", "../../@types/**/*.d.ts"],
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -22,6 +22,7 @@
     "@webstudio-is/design-system": "*",
     "@webstudio-is/jest-config": "*",
     "@webstudio-is/scripts": "*",
+    "@webstudio-is/tsconfig": "*",
     "typescript": "4.7.4",
     "zod": "^3.19.1"
   },

--- a/packages/fonts/tsconfig.json
+++ b/packages/fonts/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./lib"

--- a/packages/generate-arg-types/package.json
+++ b/packages/generate-arg-types/package.json
@@ -18,6 +18,7 @@
     "zod": "^3.19.1"
   },
   "devDependencies": {
+    "@webstudio-is/tsconfig": "*",
     "typescript": "4.7.4",
     "esbuild": "^0.14.25"
   },

--- a/packages/generate-arg-types/tsconfig.json
+++ b/packages/generate-arg-types/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./.bin"

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -18,6 +18,7 @@
     "@webstudio-is/jest-config": "*",
     "@webstudio-is/prisma-client": "*",
     "@webstudio-is/project": "*",
+    "@webstudio-is/tsconfig": "*",
     "tsup": "^6.1.3",
     "typescript": "4.7.4"
   },

--- a/packages/http-client/tsconfig.json
+++ b/packages/http-client/tsconfig.json
@@ -1,13 +1,10 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src", "../../@types/**/*.d.ts"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "module": "commonjs",
-    "jsx": "react-jsx",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "paths": { "~/*": ["./src/*"] },
     "outDir": "./lib",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -28,6 +28,7 @@
     "@storybook/testing-library": "^0.0.13",
     "@svgo/jsx": "^0.4.2",
     "@webstudio-is/scripts": "*",
+    "@webstudio-is/tsconfig": "*",
     "tsx": "^3.9.0",
     "typescript": "4.7.4"
   },

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,13 +1,10 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "module": "es2020",
-    "jsx": "react-jsx",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -32,6 +32,7 @@
     "@webstudio-is/generate-arg-types": "*",
     "@webstudio-is/jest-config": "*",
     "@webstudio-is/scripts": "*",
+    "@webstudio-is/tsconfig": "*",
     "typescript": "4.7.4"
   },
   "peerDependencies": {

--- a/packages/image/tsconfig.json
+++ b/packages/image/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src", "./src/**/__generated__/*.json"],
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./lib"

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@types/uuid": "^8.3.4",
     "@webstudio-is/scripts": "*",
+    "@webstudio-is/tsconfig": "*",
     "concurrently": "^7.6.0",
     "prisma": "^4.3.1",
     "typescript": "4.7.4",

--- a/packages/prisma-client/tsconfig.json
+++ b/packages/prisma-client/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src"],
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2019",
-    "strict": true,
     "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./lib"

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@webstudio-is/scripts": "*",
+    "@webstudio-is/tsconfig": "*",
     "typescript": "4.7.4"
   },
   "exports": {

--- a/packages/project/tsconfig.json
+++ b/packages/project/tsconfig.json
@@ -1,11 +1,9 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": ["src", "../../@types/**/*.d.ts"],
   "compilerOptions": {
     "module": "ES2020",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -35,6 +35,7 @@
     "@webstudio-is/generate-arg-types": "*",
     "@webstudio-is/jest-config": "*",
     "@webstudio-is/scripts": "*",
+    "@webstudio-is/tsconfig": "*",
     "babel-loader": "^8.2.5",
     "esbuild": "^0.14.25",
     "esbuild-node-externals": "^1.4.1",

--- a/packages/react-sdk/tsconfig.json
+++ b/packages/react-sdk/tsconfig.json
@@ -1,6 +1,5 @@
 {
-  // Extends can't use node's resolution rn https://github.com/dividab/tsconfig-paths/issues/209#issuecomment-1177261091
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "include": [
     "./src",
     "./src/**/__generated__/*.json",
@@ -9,9 +8,7 @@
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "module": "ES2020",
-    "jsx": "react-jsx",
     "target": "ES2020",
-    "strict": true,
     "baseUrl": ".",
     "outDir": "./lib",
     "rootDir": "./src"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -19,6 +19,7 @@
     "tsx": "^3.12.1"
   },
   "devDependencies": {
+    "@webstudio-is/tsconfig": "*",
     "typescript": "4.7.4"
   }
 }

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../node_modules/@webstudio-is/tsconfig/base.json",
+  "extends": "@webstudio-is/tsconfig/base.json",
   "compilerOptions": {
     "module": "ES2022",
     "target": "ES2022"


### PR DESCRIPTION
While migrating to pnpm I got an issue with our extends relying on node_modules. pnpm have only symlinks and do not have hoisted node_modules in the root.

Here I switched extends to package name as all tools can resolve it and tweaked remix tsconfig to extend from packages folder instead of node_modules.

## Before requesting a review

- [ ] if the PR is WIP - use draft mode
- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")
- [ ] what kind of review is needed?
  - [ ] conceptual
  - [x] detailed
  - [ ] with testing

## Test cases

- [ ] step by step interaction description and what is expected to happen

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
