### PR TITLE
Use +- keys for zoom without cmd

### DIFF
--- a/apps/designer/app/designer/features/breakpoints/use-subscribe-shortcuts.ts
+++ b/apps/designer/app/designer/features/breakpoints/use-subscribe-shortcuts.ts
@@ -3,8 +3,6 @@ import { useBreakpoints } from "~/shared/nano-states";
 import { useZoom, useSelectedBreakpoint } from "../../shared/nano-states";
 import { minZoom } from "./zoom-setting";
 import { utils } from "@webstudio-is/project";
-import { shortcuts } from "~/shared/shortcuts";
-import { useHotkeys } from "react-hotkeys-hook";
 
 export const useSubscribeSelectBreakpointFromShortcut = () => {
   const [breakpoints] = useBreakpoints();
@@ -21,16 +19,6 @@ const zoomStep = 20;
 
 export const useSubscribeZoomFromShortcut = () => {
   const [zoom, setZoom] = useZoom();
-
-  // We need to prevent browser default behavior for zooming in/out
-  // Maybe we should use shift modifier and keep the default behaivor functional?
-  useHotkeys(
-    shortcuts.zoom,
-    (event) => {
-      event.preventDefault();
-    },
-    []
-  );
 
   useSubscribe("zoom", (direction) => {
     if (direction === "zoomIn") {

--- a/apps/designer/app/designer/features/topbar/menu/menu.tsx
+++ b/apps/designer/app/designer/features/topbar/menu/menu.tsx
@@ -226,7 +226,7 @@ export const Menu = ({ publish }: MenuProps) => {
             }}
           >
             Zoom in
-            <ShortcutHint value={["cmd", "+"]} />
+            <ShortcutHint value={["+"]} />
           </DropdownMenuItem>
           <DropdownMenuItem
             css={menuItemCss}
@@ -238,7 +238,7 @@ export const Menu = ({ publish }: MenuProps) => {
             }}
           >
             Zoom out
-            <ShortcutHint value={["cmd", "-"]} />
+            <ShortcutHint value={["-"]} />
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <ThemeMenuItem />

--- a/apps/designer/app/shared/shortcuts/index.ts
+++ b/apps/designer/app/shared/shortcuts/index.ts
@@ -1,14 +1,1 @@
-export const shortcuts = {
-  esc: "esc",
-  undo: "cmd+z, ctrl+z",
-  redo: "cmd+shift+z, ctrl+shift+z",
-  preview: "cmd+shift+p, ctrl+shift+p",
-  delete: "backspace, delete",
-  breakpointsMenu: "cmd+b, ctrl+b",
-  breakpoint: Array.from(new Array(9))
-    .map((_, index) => `cmd+${index + 1}, ctrl+${index + 1}`)
-    .join(", "),
-  zoom: "cmd+=, ctrl+=, cmd+-, ctrl+-",
-} as const;
-
-export const options = { splitKey: "+", keydown: true };
+export * from "./shortcuts";

--- a/apps/designer/app/shared/shortcuts/shortcuts.ts
+++ b/apps/designer/app/shared/shortcuts/shortcuts.ts
@@ -1,0 +1,14 @@
+export const shortcuts = {
+  esc: "esc",
+  undo: "cmd+z, ctrl+z",
+  redo: "cmd+shift+z, ctrl+shift+z",
+  preview: "cmd+shift+p, ctrl+shift+p",
+  delete: "backspace, delete",
+  breakpointsMenu: "cmd+b, ctrl+b",
+  breakpoint: Array.from(new Array(9))
+    .map((_, index) => `cmd+${index + 1}, ctrl+${index + 1}`)
+    .join(", "),
+  zoom: "=, -",
+} as const;
+
+export const options = { splitKey: "+", keydown: true };


### PR DESCRIPTION
## Description

This enables to keep browser zoom behavior for accessibility and zooming on canvas happens using +- keys without modifiers.

Closes https://github.com/webstudio-is/webstudio-designer/issues/658

## Steps for reproduction

1. press - on canvas and in designer for zoom out
2. press + for zoom in

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [x] added tests
- [x] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
