### PR TITLE
Fixes ESC behavior in CssValueInput

### DIFF
--- a/apps/designer/app/designer/features/style-panel/controls/text/text-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/text/text-control.tsx
@@ -8,6 +8,8 @@ import type { StyleValue } from "@webstudio-is/css-data";
 import { useState } from "react";
 import { Box, Tooltip } from "@webstudio-is/design-system";
 
+const emptyValue: StyleValue = { type: "string", value: "" };
+
 export const TextControl = ({
   currentStyle,
   inheritedStyle,
@@ -37,7 +39,7 @@ export const TextControl = ({
         <CssValueInput
           icon={icon}
           property={styleConfig.property}
-          value={value}
+          value={value ?? emptyValue}
           intermediateValue={intermediateValue}
           keywords={styleConfig.items.map((item) => ({
             type: "keyword",

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -276,18 +276,18 @@ export const CssValueInput = ({
         ? String(item.value)
         : toValue(item),
     onInputChange: (inputValue) => {
-      onChange(inputValue ?? unsetValue.value);
+      onChange(inputValue ?? toValue(props.value));
     },
     onItemSelect: (value) => {
-      onChangeComplete(value ?? unsetValue);
+      onChangeComplete(value ?? props.value ?? unsetValue);
     },
     onItemHighlight: (value) => {
       if (value == null) {
-        onHighlight(unsetValue);
+        onHighlight(props.value ?? unsetValue);
         return;
       }
       if (value.type !== "intermediate") {
-        onHighlight(value ?? unsetValue);
+        onHighlight(value ?? props.value ?? unsetValue);
       }
     },
   });

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -16,7 +16,6 @@ import { ChevronDownIcon } from "@webstudio-is/icons";
 import type {
   KeywordValue,
   StyleProperty,
-  UnsetValue,
   StyleValue,
   Unit,
 } from "@webstudio-is/css-data";
@@ -32,8 +31,6 @@ import { useUnitSelect } from "./unit-select";
 import { unstable_batchedUpdates as unstableBatchedUpdates } from "react-dom";
 import { parseIntermediateOrInvalidValue } from "./parse-intermediate-or-invalid-value";
 import { toValue } from "@webstudio-is/css-engine";
-
-const unsetValue: UnsetValue = { type: "unset", value: "" };
 
 // We increment by 10 when shift is pressed, by 0.1 when alt/option is pressed and by 1 by default.
 const calcNumberChange = (
@@ -186,7 +183,7 @@ type CssValueInputValue = StyleValue | IntermediateStyleValue;
 
 type CssValueInputProps = {
   property: StyleProperty;
-  value: StyleValue | undefined;
+  value: StyleValue;
   intermediateValue: CssValueInputValue | undefined;
   /**
    * Selected item in the dropdown
@@ -235,7 +232,7 @@ export const CssValueInput = ({
   onHighlight,
   ...props
 }: CssValueInputProps & { icon?: JSX.Element }) => {
-  const value = props.intermediateValue ?? props.value ?? unsetValue;
+  const value = props.intermediateValue ?? props.value;
 
   const onChange = (input: string) => {
     // We don't know what's inside the input,
@@ -279,15 +276,15 @@ export const CssValueInput = ({
       onChange(inputValue ?? toValue(props.value));
     },
     onItemSelect: (value) => {
-      onChangeComplete(value ?? props.value ?? unsetValue);
+      onChangeComplete(value ?? props.value);
     },
     onItemHighlight: (value) => {
       if (value == null) {
-        onHighlight(props.value ?? unsetValue);
+        onHighlight(props.value);
         return;
       }
       if (value.type !== "intermediate") {
-        onHighlight(value ?? props.value ?? unsetValue);
+        onHighlight(value ?? props.value);
       }
     },
   });

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -58,24 +58,26 @@ const InvalidValue = z.object({
 });
 export type InvalidValue = z.infer<typeof InvalidValue>;
 
-const UnsetValue = z.object({
-  type: z.literal("unset"),
-  value: z.literal(""),
-});
-export type UnsetValue = z.infer<typeof UnsetValue>;
-
 export const validStaticValueTypes = [
   "unit",
   "keyword",
   "fontFamily",
   "rgb",
+  "string",
 ] as const;
+
+const StringValue = z.object({
+  type: z.literal("string"),
+  value: z.string(),
+});
+export type StringValue = z.infer<typeof StringValue>;
 
 const ValidStaticStyleValue = z.union([
   UnitValue,
   KeywordValue,
   FontFamilyValue,
   RgbValue,
+  StringValue,
 ]);
 export type ValidStaticStyleValue = z.infer<typeof ValidStaticStyleValue>;
 
@@ -86,13 +88,7 @@ const VarValue = z.object({
 });
 export type VarValue = z.infer<typeof VarValue>;
 
-const StyleValue = z.union([
-  ValidStaticStyleValue,
-  InvalidValue,
-  UnsetValue,
-  VarValue,
-  RgbValue,
-]);
+const StyleValue = z.union([ValidStaticStyleValue, InvalidValue, VarValue]);
 export type StyleValue = z.infer<typeof StyleValue>;
 
 const Style = z.record(z.string(), StyleValue);

--- a/packages/css-engine/src/core/to-value.test.ts
+++ b/packages/css-engine/src/core/to-value.test.ts
@@ -17,14 +17,14 @@ describe("Convert WS CSS Values to native CSS strings", () => {
     expect(value).toBe("bad");
   });
 
-  test("unset", () => {
-    const value = toValue({ type: "unset", value: "" });
-    expect(value).toBe("");
-  });
-
   test("var", () => {
     const value = toValue({ type: "var", value: "namespace", fallbacks: [] });
     expect(value).toBe("var(--namespace)");
+  });
+
+  test("string", () => {
+    const value = toValue({ type: "string", value: "test" });
+    expect(value).toBe("test");
   });
 
   test("var with fallbacks", () => {

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -53,7 +53,7 @@ export const toValue = (
     return value.value;
   }
 
-  if (value.type === "unset") {
+  if (value.type === "string") {
     return value.value;
   }
 

--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -159,6 +159,8 @@ export const useCombobox = <Item,>({
   match,
   ...rest
 }: UseComboboxProps<Item>) => {
+  const [isOpen, setIsOpen] = useState(false);
+
   const { filteredItems, filter, resetFilter } = useFilter<Item>({
     items,
     itemToString,
@@ -168,6 +170,14 @@ export const useCombobox = <Item,>({
   const downshiftProps = useDownshiftCombobox({
     ...rest,
     items: filteredItems,
+    isOpen,
+    onIsOpenChange(value) {
+      // Don't set isOpen to true if there are no items to show
+      // because otherwise first ESC press will try to close it and only next ESC
+      // will reset the value. When list is empty, first ESC should reset the value.
+      const nextIsOpen = value.isOpen === true && filteredItems.length !== 0;
+      setIsOpen(nextIsOpen);
+    },
     defaultHighlightedIndex: -1,
     selectedItem: selectedItem ?? null, // Prevent downshift warning about switching controlled mode
     stateReducer,
@@ -189,8 +199,7 @@ export const useCombobox = <Item,>({
     },
   });
 
-  const { isOpen, getItemProps, highlightedIndex, getMenuProps } =
-    downshiftProps;
+  const { getItemProps, highlightedIndex, getMenuProps } = downshiftProps;
 
   useEffect(() => {
     if (isOpen === false) {


### PR DESCRIPTION
## Description

Closes https://github.com/webstudio-is/webstudio-designer/issues/656

1. When ESC is pressed without dropdowns open - it should reset the value to the last known permanent value
2. When any drop down is open - first ESC press should close the dropdown, second - reset the value (as described in point 1)

## Steps for reproduction

Case 1

1. find a numeric CSS value input
2. change the value with some number
3. press ESC
4. number resets to the initial value

Case 2

1. find a keyword CSS value input
2. start typing
3. autocomplete list is shown
4. press ESC
5. list is closed
6. press ESC
7. value resets to initial value

Case 3

1. find a numeric CSS value input
2. type some number
3. click on unit button - list shows
4. press ESC - list closes
5. press ESC - value resets to initial value

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [x] added tests
- [x] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
