### PR TITLE
Hide outline when preview styles

### DIFF
--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -29,7 +29,7 @@ declare module "~/shared/pubsub" {
     hoveredInstanceRect: DOMRect;
     hoverInstance?: HoveredInstanceData;
     loadRootInstance?: Instance;
-    selectedInstanceRect: DOMRect;
+    selectedInstanceRect?: DOMRect;
     selectInstance?: SelectedInstanceData;
     textEditingInstanceId?: Instance["id"];
     insertInstance: {

--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -29,7 +29,6 @@ declare module "~/shared/pubsub" {
     hoveredInstanceRect: DOMRect;
     hoverInstance?: HoveredInstanceData;
     loadRootInstance?: Instance;
-    selectedInstanceRect?: DOMRect;
     selectInstance?: SelectedInstanceData;
     textEditingInstanceId?: Instance["id"];
     insertInstance: {

--- a/apps/designer/app/designer/features/workspace/canvas-tools/hooks/use-subscribe-instance-rect.ts
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/hooks/use-subscribe-instance-rect.ts
@@ -1,12 +1,15 @@
 import { useSubscribe } from "~/shared/pubsub";
 import {
-  useSelectedInstanceRect,
+  useSelectedInstanceOutline,
   useHoveredInstanceRect,
 } from "~/shared/nano-states";
 
 export const useSubscribeInstanceRect = () => {
-  const [, setSelectedRect] = useSelectedInstanceRect();
-  useSubscribe("selectedInstanceRect", setSelectedRect);
+  const [selectedInstanceOutline, setSelectedInstanceOutline] =
+    useSelectedInstanceOutline();
+  useSubscribe("updateSelectedInstanceOutline", (value) => {
+    setSelectedInstanceOutline({ ...selectedInstanceOutline, ...value });
+  });
   const [, setHoveredRect] = useHoveredInstanceRect();
   useSubscribe("hoveredInstanceRect", setHoveredRect);
 };

--- a/apps/designer/app/designer/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
@@ -1,5 +1,5 @@
 import {
-  useSelectedInstanceRect,
+  useSelectedInstanceOutline,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
 import { useSelectedInstanceData } from "~/designer/shared/nano-states";
@@ -7,7 +7,7 @@ import { Outline } from "./outline";
 import { Label } from "./label";
 
 export const SelectedInstanceOutline = () => {
-  const [instanceRect] = useSelectedInstanceRect();
+  const [{ rect, visible }] = useSelectedInstanceOutline();
   const [instanceData] = useSelectedInstanceData();
   const [textEditingInstanceId] = useTextEditingInstanceId();
 
@@ -17,15 +17,16 @@ export const SelectedInstanceOutline = () => {
 
   if (
     instanceData === undefined ||
-    instanceRect === undefined ||
-    isEditingCurrentInstance
+    isEditingCurrentInstance ||
+    visible === false ||
+    rect === undefined
   ) {
     return null;
   }
 
   return (
-    <Outline rect={instanceRect}>
-      <Label component={instanceData.component} instanceRect={instanceRect} />
+    <Outline rect={rect}>
+      <Label component={instanceData.component} instanceRect={rect} />
     </Outline>
   );
 };

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -18,11 +18,15 @@ export const useBreakpoints = () => useValue(breakpointsContainer);
 const isPreviewModeContainer = createValueContainer<boolean>(false);
 export const useIsPreviewMode = () => useValue(isPreviewModeContainer);
 
-const selectedInstanceRectContainer = createValueContainer<
-  DOMRect | undefined
->();
-export const useSelectedInstanceRect = () =>
-  useValue(selectedInstanceRectContainer);
+const selectedInstanceOutlineContainer = createValueContainer<{
+  visible: boolean;
+  rect?: DOMRect;
+}>({
+  visible: false,
+  rect: undefined,
+});
+export const useSelectedInstanceOutline = () =>
+  useValue(selectedInstanceOutlineContainer);
 
 const hoveredInstanceRectContainer = createValueContainer<
   DOMRect | undefined


### PR DESCRIPTION
## Description

Ref https://github.com/webstudio-is/webstudio-designer/issues/625

Frequently changed style values with for example scrub makes outline look laggy because of latency between iframe and designer (where outline is rendered).

Here I subscribed to previewStyle and send undefined to hide rect. We do the same when scroll canvas and cannot update outline fast.

## Steps for reproduction

1. select instance
2. use scrub to change for example top

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
