### PR TITLE
Fix inspector layout when style panel sections are collapsed

### DIFF
--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -155,6 +155,7 @@ const SidePanel = ({
       css={{
         gridArea,
         display: "flex",
+        flexDirection: "column",
         px: 0,
         fg: 0,
         // Left sidebar tabs won't be able to pop out to the right if we set overflowX to auto.

--- a/apps/designer/app/designer/features/inspector/inspector.tsx
+++ b/apps/designer/app/designer/features/inspector/inspector.tsx
@@ -42,7 +42,14 @@ export const Inspector = ({ publish }: InspectorProps) => {
 
   return (
     <FloatingPanelProvider container={tabsRef}>
-      <Tabs defaultValue="style" ref={tabsRef}>
+      <Tabs
+        defaultValue="style"
+        ref={tabsRef}
+        css={{
+          // minHeight is required to get flex item height apply to this container
+          minHeight: 1,
+        }}
+      >
         <TabsList>
           <TabsTrigger value="style">
             <Text>Style</Text>


### PR DESCRIPTION
## Description

Closes https://github.com/webstudio-is/webstudio-designer/issues/662

It was using flex-direction raw by default which led to that space, no idea though, why it worked when opened.

## Steps for reproduction

1. select any instance
2. style panel sections are all collapsed
3. see an additional  empty column visible in style panel

## Code Review

- [ ] hi @rpominov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [x] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
