### PR TITLE
Make left sidebar grow full height

### DIFF
--- a/apps/designer/app/designer/features/inspector/inspector.tsx
+++ b/apps/designer/app/designer/features/inspector/inspector.tsx
@@ -8,6 +8,7 @@ import {
   Card,
   Paragraph,
   Box,
+  Flex,
 } from "@webstudio-is/design-system";
 import { StylePanel } from "~/designer/features/style-panel";
 import { PropsPanel } from "~/designer/features/props-panel";
@@ -42,14 +43,7 @@ export const Inspector = ({ publish }: InspectorProps) => {
 
   return (
     <FloatingPanelProvider container={tabsRef}>
-      <Tabs
-        defaultValue="style"
-        ref={tabsRef}
-        css={{
-          // minHeight is required to get flex item height apply to this container
-          minHeight: 1,
-        }}
-      >
+      <Flex as={Tabs} defaultValue="style" ref={tabsRef}>
         <TabsList>
           <TabsTrigger value="style">
             <Text>Style</Text>
@@ -75,7 +69,7 @@ export const Inspector = ({ publish }: InspectorProps) => {
             selectedInstanceData={selectedInstanceData}
           />
         </TabsContent>
-      </Tabs>
+      </Flex>
     </FloatingPanelProvider>
   );
 };

--- a/apps/designer/app/designer/features/sidebar-left/sidebar-left.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/sidebar-left.tsx
@@ -45,7 +45,7 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
   );
 
   return (
-    <Flex>
+    <Flex css={{ flexGrow: 1 }}>
       <SidebarTabs activationMode="manual" value={activeTab}>
         <SidebarTabsList>
           {enabledPanels.map((tabName: TabName) => (

--- a/apps/designer/app/designer/features/sidebar-left/sidebar-left.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/sidebar-left.tsx
@@ -45,7 +45,7 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
   );
 
   return (
-    <Flex css={{ flexGrow: 1 }}>
+    <Flex grow>
       <SidebarTabs activationMode="manual" value={activeTab}>
         <SidebarTabsList>
           {enabledPanels.map((tabName: TabName) => (

--- a/apps/designer/app/designer/shared/assets/assets-shell.tsx
+++ b/apps/designer/app/designer/shared/assets/assets-shell.tsx
@@ -30,6 +30,7 @@ export const AssetsShell = ({
         css={{ py: "$spacing$5", px: "$spacing$9" }}
         gap="2"
         direction="column"
+        shrink={false}
       >
         <AssetUpload type={type} />
         <SearchField {...searchProps} autoFocus placeholder="Search" />

--- a/packages/design-system/src/components/flex.tsx
+++ b/packages/design-system/src/components/flex.tsx
@@ -3,7 +3,9 @@ import { styled } from "../stitches.config";
 export const Flex = styled("div", {
   boxSizing: "border-box",
   display: "flex",
-
+  // Fixes a bug where container doesn't want to grow.
+  minHeight: 0,
+  minWidth: 0,
   variants: {
     direction: {
       row: {
@@ -88,6 +90,22 @@ export const Flex = styled("div", {
       },
       9: {
         gap: "$spacing$20",
+      },
+    },
+    shrink: {
+      true: {
+        flexShrink: 1,
+      },
+      false: {
+        flexShrink: 0,
+      },
+    },
+    grow: {
+      true: {
+        flexGrow: 1,
+      },
+      false: {
+        flexGrow: 0,
       },
     },
   },


### PR DESCRIPTION
## Description
<img width="295" alt="Screenshot 2022-12-21 at 14 16 24" src="https://user-images.githubusercontent.com/52824/208926168-dbf9bc9e-4ee5-4c88-aaf9-519edff6d032.png">

Previous changes with flex-direction: column broke the left sidebar height

## Steps for reproduction

1. click + button
2. see all components without scrollbars

## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [x] added tests
- [x] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
