### PR TITLE
Apply the first available weight when current weight isn't supported 

### DIFF
--- a/apps/designer/app/designer/features/style-panel/controls/font-weight/font-weight-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/font-weight/font-weight-control.tsx
@@ -56,9 +56,11 @@ const useLabels = (
   );
 
   const selectedLabel = useMemo(() => {
-    const selectedOption = availableFontWeights.find(
-      (option) => option.weight === currentWeight
-    );
+    const selectedOption =
+      availableFontWeights.find((option) => option.weight === currentWeight) ??
+      // In case available weights a custom font supports does not include the current weight,
+      // we show the first available weight.
+      availableFontWeights[0];
     return selectedOption?.label;
   }, [currentWeight, availableFontWeights]);
 


### PR DESCRIPTION
Fixes https://github.com/webstudio-is/webstudio-designer/issues/677

## Description

When we select a custom font, the previously selected font weight might be not supported, so we need to set the first supported weight.

## Steps for reproduction

1. select instance
2. open font-family selector
3. upload custom font
4. select custom font
5. see font is applied
6. font-weight will be empty if the custom font doesn't support the previous weight

## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [x] added tests
- [x] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
