### PR TITLE
Don't populate an instance on paste, because its already populated

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -123,7 +123,10 @@ const useCopyPaste = () => {
       publish({ type: "deleteInstance", payload: { id: instance.id } });
     },
     onPaste: (instance, props) => {
-      publish({ type: "insertInstance", payload: { instance, props } });
+      publish({
+        type: "insertInstance",
+        payload: { instance, props, isPopulated: true },
+      });
     },
   });
 };

--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -36,6 +36,7 @@ declare module "~/shared/pubsub" {
       instance: Instance;
       dropTarget?: { parentId: Instance["id"]; position: number };
       props?: Array<UserProp>;
+      isPopulated?: boolean;
     };
     unselectInstance: undefined;
   }
@@ -81,35 +82,37 @@ export const useInsertInstance = ({ treeId }: { treeId: string }) => {
   const [selectedInstance, setSelectedInstance] = useSelectedInstance();
   const [breakpoints] = useBreakpoints();
 
-  useSubscribe("insertInstance", ({ instance, dropTarget, props }) => {
-    store.createTransaction(
-      [rootInstanceContainer, allUserPropsContainer],
-      (rootInstance, allUserProps) => {
-        if (rootInstance === undefined) {
-          return;
+  useSubscribe(
+    "insertInstance",
+    ({ instance, dropTarget, props, isPopulated }) => {
+      store.createTransaction(
+        [rootInstanceContainer, allUserPropsContainer],
+        (rootInstance, allUserProps) => {
+          if (rootInstance === undefined) {
+            return;
+          }
+          const populatedInstance = isPopulated
+            ? instance
+            : utils.tree.populateInstance(instance, breakpoints[0].id);
+          const hasInserted = utils.tree.insertInstanceMutable(
+            rootInstance,
+            populatedInstance,
+            dropTarget ?? findInsertLocation(rootInstance, selectedInstance?.id)
+          );
+          if (hasInserted) {
+            setSelectedInstance(instance);
+          }
+          if (props !== undefined) {
+            allUserProps[instance.id] = utils.props.createInstanceProps({
+              instanceId: instance.id,
+              treeId,
+              props,
+            });
+          }
         }
-        const populatedInstance = utils.tree.populateInstance(
-          instance,
-          breakpoints[0].id
-        );
-        const hasInserted = utils.tree.insertInstanceMutable(
-          rootInstance,
-          populatedInstance,
-          dropTarget ?? findInsertLocation(rootInstance, selectedInstance?.id)
-        );
-        if (hasInserted) {
-          setSelectedInstance(instance);
-        }
-        if (props !== undefined) {
-          allUserProps[instance.id] = utils.props.createInstanceProps({
-            instanceId: instance.id,
-            treeId,
-            props,
-          });
-        }
-      }
-    );
-  });
+      );
+    }
+  );
 };
 
 export const useReparentInstance = () => {

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -128,7 +128,10 @@ const useCopyPaste = (publish: Publish) => {
       publish({ type: "deleteInstance", payload: { id: instance.id } });
     },
     onPaste: (instance, props) => {
-      publish({ type: "insertInstance", payload: { instance, props } });
+      publish({
+        type: "insertInstance",
+        payload: { instance, props, isPopulated: true },
+      });
     },
   });
 };


### PR DESCRIPTION
## Description

Can't change width of a copied box 

## Steps for reproduction

1. Add a Box
2. Select the Box and copy it (cmd+c)
3. Select Body
4. Paste (cmd+v)
5. Select the copy you've just pasted
6. Try to change its width
7. Observe that even though the number in input changes the actual width of the Box on canvas stays the same

https://user-images.githubusercontent.com/825702/207803118-5b6fedd8-ded4-4a03-97b9-d4d6cff6710a.mov


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
