### PR TITLE
Add delay to spacing tooltip

### DIFF
--- a/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
@@ -56,12 +56,9 @@ const Cell = ({
         onChange={onChange}
         onClose={onPopoverClose}
       />
-      <SpacingTooltip
-        property={property}
-        isOpen={
-          isActive && isPopoverOpen === false && scrubStatus.isActive === false
-        }
-      />
+      {isActive && isPopoverOpen === false && scrubStatus.isActive === false ? (
+        <SpacingTooltip property={property} />
+      ) : null}
       <ValueText
         css={{
           // We want value to have `default` cursor to indicate that it's clickable,

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/tooltip.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/tooltip.tsx
@@ -1,5 +1,10 @@
-import { styled, Tooltip } from "@webstudio-is/design-system";
+import {
+  styled,
+  Tooltip,
+  useEnhancedTooltipProps,
+} from "@webstudio-is/design-system";
 import { SpacingStyleProperty } from "./types";
+import { useDebounce } from "use-debounce";
 
 // trigger is used only for positioning
 const Trigger = styled("div", {
@@ -39,13 +44,18 @@ export const SpacingTooltip = ({
 }: {
   property: SpacingStyleProperty;
   isOpen: boolean;
-}) => (
-  <Tooltip
-    open={isOpen}
-    content={labels[property]}
-    side={sides[property]}
-    disableHoverableContent
-  >
-    <Trigger />
-  </Tooltip>
-);
+}) => {
+  const { delayDuration } = useEnhancedTooltipProps();
+  const [open] = useDebounce(isOpen, delayDuration ?? 0);
+
+  return isOpen ? (
+    <Tooltip
+      open={open}
+      content={labels[property]}
+      side={sides[property]}
+      disableHoverableContent
+    >
+      <Trigger />
+    </Tooltip>
+  ) : null;
+};

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/tooltip.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/tooltip.tsx
@@ -5,6 +5,7 @@ import {
 } from "@webstudio-is/design-system";
 import { SpacingStyleProperty } from "./types";
 import { useDebounce } from "use-debounce";
+import { useState } from "react";
 
 // trigger is used only for positioning
 const Trigger = styled("div", {
@@ -40,15 +41,18 @@ const sides = {
 
 export const SpacingTooltip = ({
   property,
-  isOpen,
 }: {
   property: SpacingStyleProperty;
-  isOpen: boolean;
 }) => {
   const { delayDuration } = useEnhancedTooltipProps();
-  const [open] = useDebounce(isOpen, delayDuration ?? 0);
+  const [initialOpen, setInitialOpen] = useState(false);
+  const [open] = useDebounce(initialOpen, delayDuration ?? 0);
 
-  return isOpen ? (
+  if (initialOpen === false) {
+    setInitialOpen(true);
+  }
+
+  return (
     <Tooltip
       open={open}
       content={labels[property]}
@@ -57,5 +61,5 @@ export const SpacingTooltip = ({
     >
       <Trigger />
     </Tooltip>
-  ) : null;
+  );
 };

--- a/packages/design-system/src/components/enhanced-tooltip.tsx
+++ b/packages/design-system/src/components/enhanced-tooltip.tsx
@@ -45,6 +45,8 @@ export const EnhancedTooltipProvider = ({
   );
 };
 
+export const useEnhancedTooltipProps = () => useContext(EnhancedTooltipContext);
+
 /**
  * EnhancedTooltip has the following differences from the radix-ui
  * 1. Don't show the tooltip if any click or key-down was made inside Tooltip.Trigger

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -27,6 +27,7 @@ export { Tooltip, InputErrorsTooltip } from "./components/tooltip";
 export {
   EnhancedTooltip,
   EnhancedTooltipProvider,
+  useEnhancedTooltipProps,
 } from "./components/enhanced-tooltip";
 export { Button } from "./components/button";
 export { DeprecatedIconButton } from "./components/__DEPRECATED__/icon-button";


### PR DESCRIPTION
## Description

Add delay to spacing control tooltip.

## Steps for reproduction

1. Hover spacing controls, see tooltip delayed

## Code Review

- [ ] hi @kof, I need you to do
  - test it on preview
- [ ] hi @rpominov just your code changed a little, FYI

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
