### PR TITLE
Hide outline when window is resizing

### DIFF
--- a/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
+++ b/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
@@ -2,7 +2,10 @@ import { useEffect } from "react";
 import type { Instance, InstanceProps } from "@webstudio-is/react-sdk";
 import { getBrowserStyle } from "@webstudio-is/react-sdk";
 import { publish, subscribe, subscribeAll } from "~/shared/pubsub";
-import { subscribeScrollState } from "~/shared/dom-hooks";
+import {
+  subscribeScrollState,
+  subscribeWindowResize,
+} from "~/shared/dom-hooks";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -112,6 +115,15 @@ export const SelectedInstanceConnector = ({
       },
     });
 
+    const unsubscribeWindowResize = subscribeWindowResize({
+      onResizeStart() {
+        hideOutline();
+      },
+      onResizeEnd() {
+        showOutline(element);
+      },
+    });
+
     // trigger style recomputing every time instance styles are changed
     publish({
       type: "selectInstance",
@@ -130,6 +142,7 @@ export const SelectedInstanceConnector = ({
       unsubscribeTreeChange?.();
       unsubscribePreviewStyle();
       unsubscribeScrollState();
+      unsubscribeWindowResize();
     };
 
     // instance props may change dom element

--- a/apps/designer/app/shared/dom-hooks/use-window-resize.ts
+++ b/apps/designer/app/shared/dom-hooks/use-window-resize.ts
@@ -27,6 +27,7 @@ if (typeof window === "object") {
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
 type UseWindowResize = {

--- a/apps/designer/app/shared/dom-hooks/use-window-resize.ts
+++ b/apps/designer/app/shared/dom-hooks/use-window-resize.ts
@@ -4,14 +4,52 @@ import mitt from "mitt";
 const emitter = mitt();
 
 if (typeof window === "object") {
+  let timeoutId = 0;
+  let isResizing = false;
   window.addEventListener(
     "resize",
     () => {
+      if (isResizing === false) {
+        emitter.emit("resizeStart");
+      }
       emitter.emit("resize");
+      isResizing = true;
+      clearTimeout(timeoutId);
+      timeoutId = window.setTimeout(() => {
+        if (isResizing === false) {
+          return;
+        }
+        isResizing = false;
+        emitter.emit("resizeEnd");
+      }, 150);
     },
     false
   );
 }
+
+const noop = () => {};
+
+type UseWindowResize = {
+  onResizeStart?: () => void;
+  onResize?: () => void;
+  onResizeEnd?: () => void;
+};
+
+export const subscribeWindowResize = ({
+  onResizeStart = noop,
+  onResize = noop,
+  onResizeEnd = noop,
+}: UseWindowResize) => {
+  emitter.on("resizeStart", onResizeStart);
+  emitter.on("resize", onResize);
+  emitter.on("resizeEnd", onResizeEnd);
+
+  return () => {
+    emitter.off("resizeStart", onResizeStart);
+    emitter.off("resize", onResize);
+    emitter.off("resizeEnd", onResizeEnd);
+  };
+};
 
 /**
  * Subscribe to DOM resize event only once and then notify all listeners over js only.


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/446 https://github.com/webstudio-is/webstudio-designer/issues/638

Here I solved 2 issues.

Outline is hidden while canvas is resizing.
And after resizing outline rect is recomputed.

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. select an instance
2. click on breakpoints menu
3. use slider to change the canvas width or choose one of preset breakpoints

## Code Review

- [ ] hi @kof, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
