### PR TITLE
Fix hover outline

### DIFF
--- a/apps/designer/app/canvas/hovered-instance-connector.ts
+++ b/apps/designer/app/canvas/hovered-instance-connector.ts
@@ -35,12 +35,14 @@ const startHoveredInstanceConnection = (rootInstance: Instance) => {
   let mouseOutTimeoutId: undefined | ReturnType<typeof setTimeout> = undefined;
 
   const handleMouseOver = (event: MouseEvent) => {
-    const element = event.target;
-    if (element instanceof Element) {
-      clearTimeout(mouseOutTimeoutId);
-      // store hovered element locally to update outline when scroll ends
-      hoveredElement = element;
-      publishHover(element);
+    if (event.target instanceof Element) {
+      const element = event.target.closest(`[${idAttribute}]`) ?? undefined;
+      if (element !== undefined) {
+        clearTimeout(mouseOutTimeoutId);
+        // store hovered element locally to update outline when scroll ends
+        hoveredElement = element;
+        publishHover(element);
+      }
     }
   };
 
@@ -95,6 +97,7 @@ const startHoveredInstanceConnection = (rootInstance: Instance) => {
     window.removeEventListener("mouseout", handleMouseOut);
     unsubscribeNavigatorHoveredInstance();
     unsubscribeScrollState();
+    clearTimeout(mouseOutTimeoutId);
   };
 };
 

--- a/apps/designer/app/canvas/hovered-instance-connector.ts
+++ b/apps/designer/app/canvas/hovered-instance-connector.ts
@@ -32,9 +32,12 @@ const startHoveredInstanceConnection = (rootInstance: Instance) => {
     });
   }, 50);
 
+  let mouseOutTimeoutId: undefined | ReturnType<typeof setTimeout> = undefined;
+
   const handleMouseOver = (event: MouseEvent) => {
     const element = event.target;
     if (element instanceof Element) {
+      clearTimeout(mouseOutTimeoutId);
       // store hovered element locally to update outline when scroll ends
       hoveredElement = element;
       publishHover(element);
@@ -42,11 +45,13 @@ const startHoveredInstanceConnection = (rootInstance: Instance) => {
   };
 
   const handleMouseOut = () => {
-    hoveredElement = undefined;
-    publish({
-      type: "hoverInstance",
-      payload: undefined,
-    });
+    mouseOutTimeoutId = setTimeout(() => {
+      hoveredElement = undefined;
+      publish({
+        type: "hoverInstance",
+        payload: undefined,
+      });
+    }, 100);
   };
 
   const eventOptions = { passive: true };


### PR DESCRIPTION
Found an issue when hover a few elements fast and then move cursor out of iframe hover gets stuck on some element. This is because we use combination of mouseover and mouseout events.

So when we move out of one instance to another it looks like this

over
out
over
out

Which may lead to race conditions. So here out is canceled by every hover and delayed a little to always emit last.

## Code Review

- [ ] hi @kof, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
