### PR TITLE
Fix onComplete event lost if was tab during opened menu and nothing selected

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -31,6 +31,7 @@ import { useUnitSelect } from "./unit-select";
 import { unstable_batchedUpdates as unstableBatchedUpdates } from "react-dom";
 import { parseIntermediateOrInvalidValue } from "./parse-intermediate-or-invalid-value";
 import { toValue } from "@webstudio-is/css-engine";
+import { useDebouncedCallback } from "use-debounce";
 
 // We increment by 10 when shift is pressed, by 0.1 when alt/option is pressed and by 1 by default.
 const calcNumberChange = (
@@ -363,6 +364,12 @@ export const CssValueInput = ({
 
   const menuProps = getMenuProps();
 
+  const callOnCompleteIfIntermediateValueExists = useDebouncedCallback(() => {
+    if (props.intermediateValue !== undefined) {
+      onChangeComplete(value, "blur");
+    }
+  });
+
   const handleOnBlur: KeyboardEventHandler = (event) => {
     inputProps.onBlur(event);
     // When unit select is open, onBlur is triggered,though we don't want a change event in this case.
@@ -372,7 +379,10 @@ export const CssValueInput = ({
 
     // If the menu is open and visible we don't want to trigger onChangeComplete
     // as it will be done by Downshift
+    // There is situation that Downshift will not call omCompleted if nothing is selected in menu
     if (isOpen && !menuProps.empty) {
+      // There is a situation that Downshift will not call onChangeComplete if nothing is selected in the menu
+      callOnCompleteIfIntermediateValueExists();
       return;
     }
 

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -364,6 +364,10 @@ export const CssValueInput = ({
 
   const menuProps = getMenuProps();
 
+  /**
+   * useDebouncedCallback without wait param uses Request Animation Frame
+   * here we wait for 1 tick until the "blur" event will be completed by Downshift
+   **/
   const callOnCompleteIfIntermediateValueExists = useDebouncedCallback(() => {
     if (props.intermediateValue !== undefined) {
       onChangeComplete(value, "blur");

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -384,7 +384,7 @@ export const CssValueInput = ({
     // If the menu is open and visible we don't want to trigger onChangeComplete
     // as it will be done by Downshift
     // There is situation that Downshift will not call omCompleted if nothing is selected in menu
-    if (isOpen && !menuProps.empty) {
+    if (isOpen && menuProps.empty === false) {
       // There is a situation that Downshift will not call onChangeComplete if nothing is selected in the menu
       callOnCompleteIfIntermediateValueExists();
       return;


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

Click into css-input, delete everything -  menu occured
Click tab - must show red rectangle instead of just tabbing into new control

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
