### PR TITLE
Background image DB support

### DIFF
--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -18,6 +18,7 @@
     "@types/css-tree": "^2.0.0",
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
+    "@webstudio-is/asset-uploader": "workspace:^",
     "camelcase": "^6.3.0",
     "css-tree": "^2.3.0",
     "mdn-data": "2.0.23",

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -1,6 +1,7 @@
 import { units } from "./__generated__/units";
 import { properties } from "./__generated__/properties";
 import { z } from "zod";
+import { ImageAsset } from "@webstudio-is/asset-uploader";
 
 type Properties = typeof properties & {
   [custom: CustomProperty]: {
@@ -50,6 +51,14 @@ const RgbValue = z.object({
 });
 export type RgbValue = z.infer<typeof RgbValue>;
 
+// https://developer.mozilla.org/en-US/docs/Web/API/CSSImageValue
+const ImageValue = z.object({
+  type: z.literal("image"),
+  value: z.array(z.object({ type: z.literal("asset"), value: ImageAsset })),
+});
+
+export type ImageValue = z.infer<typeof ImageValue>;
+
 // We want to be able to render the invalid value
 // and show it is invalid visually, without saving it to the db
 const InvalidValue = z.object({
@@ -69,14 +78,22 @@ export const validStaticValueTypes = [
   "keyword",
   "fontFamily",
   "rgb",
+  "image",
 ] as const;
 
-const ValidStaticStyleValue = z.union([
+/**
+ * Shared types with DB types,
+ * ImageValue in DB has different type
+ */
+const SharedStaticStyleValue = z.union([
   UnitValue,
   KeywordValue,
   FontFamilyValue,
   RgbValue,
 ]);
+
+const ValidStaticStyleValue = z.union([ImageValue, SharedStaticStyleValue]);
+
 export type ValidStaticStyleValue = z.infer<typeof ValidStaticStyleValue>;
 
 const VarValue = z.object({
@@ -91,8 +108,18 @@ const StyleValue = z.union([
   InvalidValue,
   UnsetValue,
   VarValue,
-  RgbValue,
 ]);
+
+/**
+ * Shared types with DB types
+ */
+export const SharedStyleValue = z.union([
+  SharedStaticStyleValue,
+  InvalidValue,
+  UnsetValue,
+  VarValue,
+]);
+
 export type StyleValue = z.infer<typeof StyleValue>;
 
 const Style = z.record(z.string(), StyleValue);

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -51,7 +51,6 @@ const RgbValue = z.object({
 });
 export type RgbValue = z.infer<typeof RgbValue>;
 
-// https://developer.mozilla.org/en-US/docs/Web/API/CSSImageValue
 export const ImageValue = z.object({
   type: z.literal("image"),
   value: z.array(z.object({ type: z.literal("asset"), value: ImageAsset })),
@@ -82,8 +81,8 @@ export const validStaticValueTypes = [
 ] as const;
 
 /**
- * Shared types with DB types,
- * ImageValue in DB has different type
+ * Shared zod types with DB types.
+ * ImageValue in DB has a different type
  */
 const SharedStaticStyleValue = z.union([
   UnitValue,

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -52,7 +52,7 @@ const RgbValue = z.object({
 export type RgbValue = z.infer<typeof RgbValue>;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/CSSImageValue
-const ImageValue = z.object({
+export const ImageValue = z.object({
   type: z.literal("image"),
   value: z.array(z.object({ type: z.literal("asset"), value: ImageAsset })),
 });

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -61,6 +61,16 @@ export const toValue = (
     return `rgba(${value.r}, ${value.g}, ${value.b}, ${value.alpha})`;
   }
 
+  if (value.type === "image") {
+    // @todo image-set
+    return value.value
+      .map(
+        (imageAsset) =>
+          `url(${imageAsset.value.path}) /* id=${imageAsset.value.id} */`
+      )
+      .join(", ");
+  }
+
   // Will give ts error in case of missing type
   assertUnreachable(value, `Unknown value type`);
 

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -22,6 +22,7 @@
     "@webstudio-is/prisma-client": "workspace:^",
     "@webstudio-is/react-sdk": "workspace:^",
     "bson-objectid": "^2.0.2",
+    "dataloader": "^2.1.0",
     "immer": "^9.0.12",
     "nanoid": "^3.2.0",
     "react": "^17.0.2",

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -22,6 +22,7 @@ const assetsLoader = new DataLoader<string, Asset | undefined>(
     const assets = await prisma.asset.findMany({
       where: {
         id: {
+          // Spread to remove readonly from assetIds, otherwise ts error.
           in: [...assetIds],
         },
       },

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -119,7 +119,7 @@ export const loadById = async (
 
   return {
     ...tree,
-    root,
+    root: instance,
   };
 };
 

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -85,6 +85,7 @@ const InstanceDb = z.lazy(() =>
 const ImageValueDbIn = ImageValue.transform((imageStyle) => ({
   type: imageStyle.type,
   value: imageStyle.value.map((value) =>
+    /* Now value.type is always equal to the "asset", but in the future, it will have additional types */
     value.type === "asset" ? { type: "asset", value: value.value.id } : value
   ),
 }));

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -27,6 +27,12 @@ const assetsLoader = new DataLoader<string, Asset | undefined>(
       },
     });
 
+    /**
+     * Dataloader docs:
+     * The Array of values must be the same length as the Array of keys.
+     * Each index in the Array of values must correspond to the same index in the Array of keys.
+     * (assets returned from DB can have a different order, some could not exist)
+     */
     return assetIds.map((assetId) =>
       assets.find((asset) => asset.id === assetId)
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -721,6 +721,7 @@ importers:
       '@webstudio-is/scripts': workspace:^
       '@webstudio-is/tsconfig': workspace:^
       bson-objectid: ^2.0.2
+      dataloader: ^2.1.0
       immer: ^9.0.12
       jest: ^29.3.1
       nanoid: ^3.2.0
@@ -739,6 +740,7 @@ importers:
       '@webstudio-is/prisma-client': link:../prisma-client
       '@webstudio-is/react-sdk': link:../react-sdk
       bson-objectid: 2.0.3
+      dataloader: 2.1.0
       immer: 9.0.15
       nanoid: 3.3.4
       react: 17.0.2
@@ -12365,6 +12367,10 @@ packages:
   /data-uri-to-buffer/3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
     engines: {node: '>= 6'}
+
+  /dataloader/2.1.0:
+    resolution: {integrity: sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==}
+    dev: false
 
   /deasync/0.1.26:
     resolution: {integrity: sha512-YKw0BmJSWxkjtQsbgn6Q9CHSWB7DKMen8vKrgyC006zy0UZ6nWyGidB0IzZgqkVRkOglAeUaFtiRTeLyel72bg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,7 @@ importers:
   packages/css-data:
     specifiers:
       '@types/css-tree': ^2.0.0
+      '@webstudio-is/asset-uploader': workspace:^
       '@webstudio-is/scripts': workspace:^
       '@webstudio-is/tsconfig': workspace:^
       camelcase: ^6.3.0
@@ -307,6 +308,7 @@ importers:
       zod: ^3.19.1
     devDependencies:
       '@types/css-tree': 2.0.0
+      '@webstudio-is/asset-uploader': link:../asset-uploader
       '@webstudio-is/scripts': link:../scripts
       '@webstudio-is/tsconfig': link:../tsconfig
       camelcase: 6.3.0


### PR DESCRIPTION
## Description

ref  #534

Next PR #705

Db support for ImageValue style.
Having that ImageValue can contain assets we need to transform assets to `assetId` and back during save/load.

`zod + dataloader` is used for transform for simplicity, allows avoiding tree traversal, and highly simplifies code.

_I want to merge it to not make one huge PR, it has no breaking changes, just a new feature save/load support_

## Steps for reproduction

## Code Review

- [x] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [x] hi @TrySound, I need 
 - detailed review (read every line)

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
