### PR TITLE
Access style config by property

### DIFF
--- a/apps/designer/app/designer/features/style-panel/controls/menu/menu-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/menu/menu-control.tsx
@@ -1,15 +1,16 @@
 import { IconButtonWithMenu } from "@webstudio-is/design-system";
 import { useIsFromCurrentBreakpoint } from "../../shared/use-is-from-current-breakpoint";
 import type { ControlProps } from "../../style-sections";
-import { iconConfigs } from "../../shared/configs";
+import { iconConfigs, styleConfigByName } from "../../shared/configs";
 import { toValue } from "@webstudio-is/css-engine";
 
 export const MenuControl = ({
   property,
+  items: passedItems,
   currentStyle,
   setProperty,
-  styleConfig,
 }: ControlProps) => {
+  const { label } = styleConfigByName[property];
   const value = currentStyle[property];
   const isFromCurrentBreakpoint = useIsFromCurrentBreakpoint(property);
 
@@ -31,7 +32,7 @@ export const MenuControl = ({
               : 0
           }deg)`,
         };
-  const items = styleConfig.items
+  const items = passedItems
     .map((item) => {
       const ItemIcon = iconProps[item.name];
       return {
@@ -43,7 +44,7 @@ export const MenuControl = ({
   return (
     <IconButtonWithMenu
       icon={items.find(({ name }) => name === currentValue)?.icon}
-      label={styleConfig.label}
+      label={label}
       items={items}
       value={String(currentValue)}
       isActive={isFromCurrentBreakpoint}

--- a/apps/designer/app/designer/features/style-panel/controls/select/select-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/select/select-control.tsx
@@ -6,7 +6,7 @@ export const SelectControl = ({
   property,
   currentStyle,
   setProperty,
-  styleConfig,
+  items,
 }: ControlProps) => {
   const value = currentStyle[property];
 
@@ -17,7 +17,7 @@ export const SelectControl = ({
       // show empty field instead of radix placeholder
       // like css value input does
       placeholder=""
-      options={styleConfig.items.map(({ label }) => label)}
+      options={items.map(({ label }) => label)}
       value={toValue(value)}
       onChange={setValue}
     />

--- a/apps/designer/app/designer/features/style-panel/controls/text/text-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/text/text-control.tsx
@@ -6,15 +6,17 @@ import { ControlProps } from "../../style-sections";
 import type { StyleValue } from "@webstudio-is/css-data";
 import { useState } from "react";
 import { Box, EnhancedTooltip } from "@webstudio-is/design-system";
+import { styleConfigByName } from "../../shared/configs";
 
 export const TextControl = ({
   property,
+  items,
   currentStyle,
   setProperty,
   deleteProperty,
-  styleConfig,
   icon,
 }: ControlProps & { icon?: JSX.Element }) => {
+  const { label } = styleConfigByName[property];
   const value = currentStyle[property];
 
   const setValue = setProperty(property);
@@ -24,14 +26,14 @@ export const TextControl = ({
   >();
 
   return (
-    <EnhancedTooltip content={styleConfig.label}>
+    <EnhancedTooltip content={label}>
       <Box>
         <CssValueInput
           icon={icon}
           property={property}
           value={value}
           intermediateValue={intermediateValue}
-          keywords={styleConfig.items.map((item) => ({
+          keywords={items.map((item) => ({
             type: "keyword",
             value: item.name,
           }))}

--- a/apps/designer/app/designer/features/style-panel/sections/layout/layout.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/layout.tsx
@@ -7,6 +7,7 @@ import { renderProperty } from "../../style-sections";
 import { MenuControl, SelectControl, TextControl } from "../../controls";
 import { PropertyName } from "../../shared/property-name";
 import { ColumnGapIcon, RowGapIcon } from "@webstudio-is/icons";
+import { styleConfigByName } from "../../shared/configs";
 
 const LayoutSectionFlex = ({
   currentStyle,
@@ -63,26 +64,18 @@ const LayoutSectionFlex = ({
           <Box css={{ gridArea: "grid" }}>
             <FlexGrid currentStyle={currentStyle} batchUpdate={batchUpdate} />
           </Box>
-          {flexDirection?.styleConfig && (
-            <Box css={{ gridArea: "flexDirection" }}>
-              <MenuControl {...flexDirection} />
-            </Box>
-          )}
-          {flexWrap?.styleConfig && (
-            <Box css={{ gridArea: "flexWrap" }}>
-              <MenuControl {...flexWrap} />
-            </Box>
-          )}
-          {alignItems?.styleConfig && (
-            <Box css={{ gridArea: "alignItems" }}>
-              <MenuControl {...alignItems} />
-            </Box>
-          )}
-          {justifyContent?.styleConfig && (
-            <Box css={{ gridArea: "justifyContent" }}>
-              <MenuControl {...justifyContent} />
-            </Box>
-          )}
+          <Box css={{ gridArea: "flexDirection" }}>
+            <MenuControl {...flexDirection} />
+          </Box>
+          <Box css={{ gridArea: "flexWrap" }}>
+            <MenuControl {...flexWrap} />
+          </Box>
+          <Box css={{ gridArea: "alignItems" }}>
+            <MenuControl {...alignItems} />
+          </Box>
+          <Box css={{ gridArea: "justifyContent" }}>
+            <MenuControl {...justifyContent} />
+          </Box>
           {alignContent && showAlignContent && (
             <Box css={{ gridArea: "alignContent" }}>
               <MenuControl {...alignContent} />
@@ -101,25 +94,19 @@ const LayoutSectionFlex = ({
           alignItems: "center",
         }}
       >
-        {columnGap?.styleConfig && (
-          <Box css={{ gridArea: "columnGap" }}>
-            <TextControl icon={<ColumnGapIcon />} {...columnGap} />
-          </Box>
-        )}
-        {rowGap?.styleConfig && columnGap?.styleConfig && (
-          <Box css={{ gridArea: "lock", px: "$spacing$3" }}>
-            <Lock
-              pairedKeys={["columnGap", "rowGap"]}
-              currentStyle={currentStyle}
-              batchUpdate={batchUpdate}
-            />
-          </Box>
-        )}
-        {rowGap?.styleConfig && (
-          <Box css={{ gridArea: "rowGap" }}>
-            <TextControl icon={<RowGapIcon />} {...rowGap} />
-          </Box>
-        )}
+        <Box css={{ gridArea: "columnGap" }}>
+          <TextControl icon={<ColumnGapIcon />} {...columnGap} />
+        </Box>
+        <Box css={{ gridArea: "lock", px: "$spacing$3" }}>
+          <Lock
+            pairedKeys={["columnGap", "rowGap"]}
+            currentStyle={currentStyle}
+            batchUpdate={batchUpdate}
+          />
+        </Box>
+        <Box css={{ gridArea: "rowGap" }}>
+          <TextControl icon={<RowGapIcon />} {...rowGap} />
+        </Box>
       </Grid>
     </Flex>
   );
@@ -150,32 +137,27 @@ export const LayoutSection = ({
   const displayValue = toValue(currentStyle.display);
 
   const { display } = sectionStyle;
+  const { label, items } = styleConfigByName.display;
 
   return (
     <>
-      {display?.styleConfig && (
-        <Grid css={{ gridTemplateColumns: "4fr 6fr" }}>
-          <PropertyName
-            property="display"
-            label={display.styleConfig.label}
-            onReset={() => deleteProperty("display")}
-          />
-          <SelectControl
-            property="display"
-            category={display.category}
-            currentStyle={display.currentStyle}
-            setProperty={display.setProperty}
-            deleteProperty={display.deleteProperty}
-            // show only important values first and hide others with scroll
-            styleConfig={{
-              ...display.styleConfig,
-              items: display.styleConfig.items
-                .filter((item) => orderedDisplayValues.includes(item.name))
-                .sort(compareDisplayValues),
-            }}
-          />
-        </Grid>
-      )}
+      <Grid css={{ gridTemplateColumns: "4fr 6fr" }}>
+        <PropertyName
+          property="display"
+          label={label}
+          onReset={() => deleteProperty("display")}
+        />
+        <SelectControl
+          property="display"
+          currentStyle={display.currentStyle}
+          setProperty={display.setProperty}
+          deleteProperty={display.deleteProperty}
+          // show only important values first and hide others with scroll
+          items={items
+            .filter((item) => orderedDisplayValues.includes(item.name))
+            .sort(compareDisplayValues)}
+        />
+      </Grid>
 
       {displayValue === "flex" || displayValue === "inline-flex" ? (
         <LayoutSectionFlex
@@ -187,9 +169,7 @@ export const LayoutSection = ({
       ) : (
         styleConfigsByCategory.map((entry) =>
           // exclude display already rendered above
-          entry.styleConfig.property === "display"
-            ? null
-            : renderProperty(entry)
+          entry.property === "display" ? null : renderProperty(entry)
         )
       )}
     </>

--- a/apps/designer/app/designer/features/style-panel/shared/configs.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/configs.ts
@@ -1,5 +1,6 @@
 import { categories, type Category } from "@webstudio-is/react-sdk";
 import type { StyleProperty, AppliesTo } from "@webstudio-is/css-data";
+import { keywordValues, properties } from "@webstudio-is/css-data";
 import { humanizeString } from "~/shared/string-utils";
 import {
   IconRecords,
@@ -32,7 +33,6 @@ import {
   RowGapIcon,
   ColumnGapIcon,
 } from "@webstudio-is/icons";
-import { keywordValues, properties } from "@webstudio-is/css-data";
 import type * as Controls from "../controls";
 
 type BaseStyleConfig = {
@@ -75,7 +75,7 @@ const getControl = (property: StyleProperty): Control => {
 const createStyleConfigs = () => {
   // We have same properties in different categories: alignSelf is in grid children and flex children
   // but this list has to contain only unique props
-  const map: { [prop in Property]?: StyleConfig } = {};
+  const styleConfigByName = {} as { [prop in StyleProperty]: StyleConfig };
 
   let category: Category;
 
@@ -87,7 +87,7 @@ const createStyleConfigs = () => {
       const keywords = keywordValues[property] || [];
       const label = humanizeString(property);
 
-      map[property] = {
+      styleConfigByName[property] = {
         label,
         property,
         appliesTo: properties[property].appliesTo,
@@ -100,10 +100,10 @@ const createStyleConfigs = () => {
     }
   }
 
-  return Object.values(map);
+  return { styleConfigs: Object.values(styleConfigByName), styleConfigByName };
 };
 
-export const styleConfigs: Array<StyleConfig> = createStyleConfigs();
+export const { styleConfigs, styleConfigByName } = createStyleConfigs();
 
 export const iconConfigs: IconRecords = {
   // layout

--- a/apps/designer/app/designer/features/style-panel/style-sections.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-sections.tsx
@@ -1,6 +1,6 @@
 import { Grid } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
-import type { StyleConfig } from "./shared/configs";
+import { styleConfigByName } from "./shared/configs";
 import type { Category } from "@webstudio-is/react-sdk";
 import type { Style, StyleProperty } from "@webstudio-is/css-data";
 import type {
@@ -26,11 +26,10 @@ import { PropertyName } from "./shared/property-name";
 
 export type ControlProps = {
   property: StyleProperty;
+  items: Array<{ label: string; name: string }>;
+  currentStyle: Style;
   setProperty: SetProperty;
   deleteProperty: DeleteProperty;
-  currentStyle: Style;
-  styleConfig: StyleConfig;
-  category: Category;
 };
 
 export type RenderCategoryProps = {
@@ -48,10 +47,10 @@ export type RenderCategoryProps = {
 
 export type RenderPropertyProps = {
   property: StyleProperty;
+  items: Array<{ label: string; name: string }>;
   setProperty: SetProperty;
   deleteProperty: DeleteProperty;
   currentStyle: Style;
-  styleConfig: StyleConfig;
   category: Category;
 };
 
@@ -60,10 +59,10 @@ export const renderProperty = ({
   currentStyle,
   setProperty,
   deleteProperty,
-  styleConfig,
   category,
 }: RenderPropertyProps) => {
-  const Control = controls[styleConfig.control];
+  const { label, control, items } = styleConfigByName[property];
+  const Control = controls[control];
   if (!Control) {
     return null;
   }
@@ -72,16 +71,15 @@ export const renderProperty = ({
     <Grid key={category + property} css={{ gridTemplateColumns: "4fr 6fr" }}>
       <PropertyName
         property={property}
-        label={styleConfig.label}
+        label={label}
         onReset={() => deleteProperty(property)}
       />
       <Control
         property={property}
+        items={items}
         currentStyle={currentStyle}
         setProperty={setProperty}
         deleteProperty={deleteProperty}
-        styleConfig={styleConfig}
-        category={category}
       />
     </Grid>
   );


### PR DESCRIPTION
Since style config is hardcoded in module scope we can access it by property instead of passing style config everywhere.

## Code Review

- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
