### PR TITLE
Add style info with source data

### DIFF
--- a/apps/designer/app/designer/features/props-panel/control.tsx
+++ b/apps/designer/app/designer/features/props-panel/control.tsx
@@ -19,7 +19,6 @@ import { Checkbox } from "@webstudio-is/design-system";
 import { Asset } from "@webstudio-is/asset-uploader";
 import type { UserPropValue } from "./use-props-logic";
 import { type SetProperty } from "../style-panel/shared/use-style-data";
-import type { Style } from "@webstudio-is/css-data";
 
 const textControlTypes = [
   "text",
@@ -183,7 +182,6 @@ type ControlProps = {
   userProp: UserProp;
   onChangePropValue: (value: UserPropValue) => void;
   setCssProperty: SetProperty;
-  currentStyle: Style;
 };
 
 // eslint-disable-next-line func-style

--- a/apps/designer/app/designer/features/props-panel/props-panel.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.tsx
@@ -33,7 +33,6 @@ import {
   useStyleData,
   type SetProperty,
 } from "../style-panel/shared/use-style-data";
-import type { Style } from "@webstudio-is/css-data";
 
 type ComboboxProps = {
   isReadonly: boolean;
@@ -123,7 +122,6 @@ type PropertyProps = {
   onChangePropValue: (value: UserPropValue) => void;
   onDelete: (id: UserProp["id"]) => void;
   setCssProperty: SetProperty;
-  currentStyle: Style;
   required: boolean;
   existingProps: string[];
 };
@@ -135,7 +133,6 @@ const Property = ({
   onChangePropValue,
   onDelete,
   setCssProperty,
-  currentStyle,
   required,
   existingProps,
 }: PropertyProps) => {
@@ -201,7 +198,6 @@ const Property = ({
           userProp={userProp}
           onChangePropValue={onChangePropValue}
           setCssProperty={setCssProperty}
-          currentStyle={currentStyle}
         />
       )}
       {required ? (
@@ -238,7 +234,7 @@ export const PropsPanel = ({
     isRequired,
   } = usePropsLogic({ selectedInstanceData, publish });
 
-  const { setProperty: setCssProperty, currentStyle } = useStyleData({
+  const { setProperty: setCssProperty } = useStyleData({
     selectedInstanceData,
     publish,
   });
@@ -286,7 +282,6 @@ export const PropsPanel = ({
                 handleChangePropValue(userProp.id, value)
               }
               setCssProperty={setCssProperty}
-              currentStyle={currentStyle}
               onDelete={handleDeleteProp}
               required={isRequired(userProp)}
               existingProps={existingProps}

--- a/apps/designer/app/designer/features/style-panel/controls/color/color-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/color/color-control.tsx
@@ -9,7 +9,7 @@ export const ColorControl = ({
   currentStyle,
   setProperty,
 }: ControlProps) => {
-  let value = currentStyle[property] ?? {
+  let value = currentStyle[property]?.value ?? {
     // provide default value to avoid control hiding
     // when value is recomputed
     type: "rgb" as const,

--- a/apps/designer/app/designer/features/style-panel/controls/font-family/font-family-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/font-family/font-family-control.tsx
@@ -10,7 +10,7 @@ export const FontFamilyControl = ({
   currentStyle,
   setProperty,
 }: ControlProps) => {
-  const value = currentStyle[property];
+  const value = currentStyle[property]?.value;
   const [isOpen, setIsOpen] = useState(false);
 
   const setValue = setProperty(property);

--- a/apps/designer/app/designer/features/style-panel/controls/font-weight/font-weight-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/font-weight/font-weight-control.tsx
@@ -71,10 +71,10 @@ export const FontWeightControl = ({
   currentStyle,
   setProperty,
 }: ControlProps) => {
-  const fontWeight = currentStyle[property];
+  const fontWeight = currentStyle[property]?.value;
 
   // We need the font family to determine which font weights are available
-  const fontFamily = currentStyle.fontFamily;
+  const fontFamily = currentStyle.fontFamily?.value;
 
   const availableFontWeights = useAvailableFontWeights(
     toValue(fontFamily, { withFallback: false })

--- a/apps/designer/app/designer/features/style-panel/controls/image/image-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/image/image-control.tsx
@@ -9,7 +9,6 @@ export const ImageControl = ({
   setProperty,
 }: ControlProps) => {
   const styleValue = currentStyle[property]?.value;
-  const { assetContainers } = useAssets("image");
 
   if (styleValue === undefined) {
     return null;

--- a/apps/designer/app/designer/features/style-panel/controls/image/image-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/image/image-control.tsx
@@ -8,7 +8,8 @@ export const ImageControl = ({
   currentStyle,
   setProperty,
 }: ControlProps) => {
-  const styleValue = currentStyle[property];
+  const styleValue = currentStyle[property]?.value;
+  const { assetContainers } = useAssets("image");
 
   if (styleValue === undefined) {
     return null;

--- a/apps/designer/app/designer/features/style-panel/controls/menu/menu-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/menu/menu-control.tsx
@@ -11,7 +11,7 @@ export const MenuControl = ({
   setProperty,
 }: ControlProps) => {
   const { label, items: defaultItems } = styleConfigByName[property];
-  const value = currentStyle[property];
+  const value = currentStyle[property]?.value;
   const isFromCurrentBreakpoint = useIsFromCurrentBreakpoint(property);
 
   if (value === undefined) {
@@ -27,7 +27,7 @@ export const MenuControl = ({
       ? {}
       : {
           transform: `rotate(${
-            toValue(currentStyle.flexDirection) === "column"
+            toValue(currentStyle.flexDirection?.value) === "column"
               ? 90 * (property === "alignItems" ? -1 : 1)
               : 0
           }deg)`,

--- a/apps/designer/app/designer/features/style-panel/controls/select/select-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/select/select-control.tsx
@@ -10,7 +10,7 @@ export const SelectControl = ({
   items,
 }: ControlProps) => {
   const { items: defaultItems } = styleConfigByName[property];
-  const value = currentStyle[property];
+  const value = currentStyle[property]?.value;
 
   const setValue = setProperty(property);
 

--- a/apps/designer/app/designer/features/style-panel/controls/text/text-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/text/text-control.tsx
@@ -17,7 +17,7 @@ export const TextControl = ({
   icon,
 }: ControlProps & { icon?: JSX.Element }) => {
   const { label, items: defaultItems } = styleConfigByName[property];
-  const value = currentStyle[property];
+  const value = currentStyle[property]?.value;
 
   const setValue = setProperty(property);
 

--- a/apps/designer/app/designer/features/style-panel/sections/flex-child/flex-child.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/flex-child/flex-child.tsx
@@ -43,7 +43,7 @@ const FlexChildSectionAlign = (props: RenderCategoryProps) => {
       <ToggleGroupControl
         property="alignSelf"
         onValueChange={(value) => setAlignSelf(value)}
-        value={toValue(currentStyle.alignSelf)}
+        value={toValue(currentStyle.alignSelf?.value)}
         items={[
           {
             child: <CrossSmallIcon />,
@@ -121,8 +121,8 @@ const FlexChildSectionSizing = (props: RenderCategoryProps) => {
           }
         }}
         value={getSizingValue(
-          toValue(currentStyle.flexGrow),
-          toValue(currentStyle.flexShrink)
+          toValue(currentStyle.flexGrow?.value),
+          toValue(currentStyle.flexShrink?.value)
         )}
         items={[
           {
@@ -239,7 +239,7 @@ const FlexChildSectionOrder = (props: RenderCategoryProps) => {
             }
           }
         }}
-        value={toValue(currentStyle.order)}
+        value={toValue(currentStyle.order?.value)}
         items={[
           {
             child: <CrossSmallIcon />,

--- a/apps/designer/app/designer/features/style-panel/sections/layout/layout.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/layout.tsx
@@ -20,7 +20,7 @@ const LayoutSectionFlex = ({
   const batchUpdate = createBatchUpdate();
   const { setProperty, deleteProperty } = batchUpdate;
 
-  const flexWrapValue = currentStyle.flexWrap;
+  const flexWrapValue = currentStyle.flexWrap?.value;
 
   // From design: Notice that the align-content icon button is not visible by default.
   // This property only applies when flex-wrap is set to "wrap".
@@ -151,7 +151,7 @@ export const LayoutSection = ({
   createBatchUpdate,
   styleConfigsByCategory,
 }: RenderCategoryProps) => {
-  const displayValue = toValue(currentStyle.display);
+  const displayValue = toValue(currentStyle.display?.value);
 
   const { label, items } = styleConfigByName.display;
 

--- a/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.stories.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.stories.tsx
@@ -51,9 +51,18 @@ const Base = ({ flexDirection }: { flexDirection: string }) => {
             <Box key={justifyContent} css={{ width: 72, height: 72 }}>
               <FlexGrid
                 currentStyle={{
-                  flexDirection: { type: "keyword", value: flexDirection },
-                  justifyContent: { type: "keyword", value: justifyContent },
-                  alignItems: { type: "keyword", value: alignItems },
+                  flexDirection: {
+                    source: "external",
+                    value: { type: "keyword", value: flexDirection },
+                  },
+                  justifyContent: {
+                    source: "external",
+                    value: { type: "keyword", value: justifyContent },
+                  },
+                  alignItems: {
+                    source: "external",
+                    value: { type: "keyword", value: alignItems },
+                  },
                 }}
                 batchUpdate={batchUpdate}
               />

--- a/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.stories.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.stories.tsx
@@ -52,15 +52,12 @@ const Base = ({ flexDirection }: { flexDirection: string }) => {
               <FlexGrid
                 currentStyle={{
                   flexDirection: {
-                    source: "external",
                     value: { type: "keyword", value: flexDirection },
                   },
                   justifyContent: {
-                    source: "external",
                     value: { type: "keyword", value: justifyContent },
                   },
                   alignItems: {
-                    source: "external",
                     value: { type: "keyword", value: alignItems },
                   },
                 }}

--- a/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.tsx
@@ -4,17 +4,17 @@ import {
   Grid,
   DeprecatedIconButton,
 } from "@webstudio-is/design-system";
-import type { Style } from "@webstudio-is/css-data";
 import { toValue } from "@webstudio-is/css-engine";
 import { DotFilledIcon } from "@webstudio-is/icons";
 import { useIsFromCurrentBreakpoint } from "../../../shared/use-is-from-current-breakpoint";
 import type { CreateBatchUpdate } from "../../../shared/use-style-data";
+import type { StyleInfo } from "../../../shared/style-info";
 
 export const FlexGrid = ({
   currentStyle,
   batchUpdate,
 }: {
-  currentStyle: Style;
+  currentStyle: StyleInfo;
   batchUpdate: ReturnType<CreateBatchUpdate>;
 }) => {
   const isCurrentBreakpoint = useIsFromCurrentBreakpoint([
@@ -24,9 +24,9 @@ export const FlexGrid = ({
     "alignContent",
     "alignItems",
   ]);
-  const flexDirection = toValue(currentStyle.flexDirection);
-  const justifyContent = toValue(currentStyle.justifyContent);
-  const alignItems = toValue(currentStyle.alignItems);
+  const flexDirection = toValue(currentStyle.flexDirection?.value);
+  const justifyContent = toValue(currentStyle.justifyContent?.value);
+  const alignItems = toValue(currentStyle.alignItems?.value);
   const setAlignItems = batchUpdate.setProperty("alignItems");
   const setJustifyContent = batchUpdate.setProperty("justifyContent");
   const alignment = ["start", "center", "end"];

--- a/apps/designer/app/designer/features/style-panel/sections/layout/shared/lock.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/shared/lock.tsx
@@ -8,6 +8,7 @@ import { toValue } from "@webstudio-is/css-engine";
 import { LockOpenIcon, LockCloseIcon } from "@webstudio-is/icons";
 import type { Style } from "@webstudio-is/css-data";
 import type { CreateBatchUpdate } from "../../../shared/use-style-data";
+import type { StyleInfo } from "../../../shared/style-info";
 
 export const Lock = ({
   pairedKeys,
@@ -15,13 +16,13 @@ export const Lock = ({
   batchUpdate,
 }: {
   pairedKeys: Array<keyof Style>;
-  currentStyle: Style;
+  currentStyle: StyleInfo;
   batchUpdate: ReturnType<CreateBatchUpdate>;
 }) => {
   const aKey = pairedKeys[0];
   const bKey = pairedKeys[1];
-  const a = currentStyle[aKey];
-  const b = currentStyle[bKey];
+  const a = currentStyle[aKey]?.value;
+  const b = currentStyle[bKey]?.value;
   const aVal =
     toValue(a) + (a?.type === "unit" && a.unit !== "number" ? a.unit : "");
   const bVal =

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
@@ -33,7 +33,7 @@ const Cell = ({
 }) => {
   const isFromCurrentBreakpoint = useIsFromCurrentBreakpoint(property);
 
-  const styleValue = currentStyle[property];
+  const styleValue = currentStyle[property]?.value;
 
   const finalValue = scrubStatus.isActive ? scrubStatus.value : styleValue;
 
@@ -95,7 +95,7 @@ export const SpacingSection = ({
     value:
       hoverTarget === undefined
         ? undefined
-        : currentStyle[hoverTarget.property],
+        : currentStyle[hoverTarget.property]?.value,
     target: hoverTarget,
     onChange: handleChange,
   });

--- a/apps/designer/app/designer/features/style-panel/sections/typography/typography.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/typography/typography.tsx
@@ -172,7 +172,7 @@ export const TypographySectionAdvanced = (props: RenderCategoryProps) => {
         <ToggleGroupControl
           property="textAlign"
           onValueChange={(value) => setTextAlign(value)}
-          value={String(getTextAlign(toValue(currentStyle.textAlign)))}
+          value={String(getTextAlign(toValue(currentStyle.textAlign?.value)))}
           items={[
             {
               child: <TextAlignLeftIcon />,
@@ -199,7 +199,7 @@ export const TypographySectionAdvanced = (props: RenderCategoryProps) => {
         <ToggleGroupControl
           property="textDecorationLine"
           onValueChange={(value) => setTextDecorationLine(value)}
-          value={toValue(currentStyle.textDecorationLine)}
+          value={toValue(currentStyle.textDecorationLine?.value)}
           items={[
             {
               child: <CrossSmallIcon />,
@@ -229,7 +229,7 @@ export const TypographySectionAdvanced = (props: RenderCategoryProps) => {
         <ToggleGroupControl
           property="textTransform"
           onValueChange={(value) => setTextTransform(value)}
-          value={toValue(currentStyle.textTransform)}
+          value={toValue(currentStyle.textTransform?.value)}
           items={[
             {
               child: <CrossSmallIcon />,
@@ -256,7 +256,7 @@ export const TypographySectionAdvanced = (props: RenderCategoryProps) => {
         <ToggleGroupControl
           property="fontStyle"
           onValueChange={(value) => setFontStyle(value)}
-          value={toValue(currentStyle.fontStyle)}
+          value={toValue(currentStyle.fontStyle?.value)}
           items={[
             {
               child: <CrossSmallIcon />,
@@ -310,7 +310,7 @@ export const TypographySectionAdvancedPopover = (
             <ToggleGroupControl
               property="direction"
               onValueChange={(value) => setDirection(value)}
-              value={toValue(currentStyle.direction)}
+              value={toValue(currentStyle.direction?.value)}
               items={[
                 {
                   child: <TextDirectionLTRIcon />,
@@ -334,7 +334,7 @@ export const TypographySectionAdvancedPopover = (
             <ToggleGroupControl
               property="hyphens"
               onValueChange={(value) => setHyphens(value)}
-              value={toValue(currentStyle.hyphens)}
+              value={toValue(currentStyle.hyphens?.value)}
               items={[
                 {
                   child: <CrossSmallIcon />,
@@ -358,7 +358,7 @@ export const TypographySectionAdvancedPopover = (
             <ToggleGroupControl
               property="textOverflow"
               onValueChange={(value) => setTextOverflow(value)}
-              value={toValue(currentStyle.textOverflow)}
+              value={toValue(currentStyle.textOverflow?.value)}
               items={[
                 {
                   child: <CrossSmallIcon />,

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -2,8 +2,8 @@ import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
 import { useMemo } from "react";
 
 export type StylePropertyInfo = {
-  source: "local" | "external";
   value: StyleValue;
+  local?: StyleValue;
 };
 
 export type StyleInfo = {
@@ -21,14 +21,13 @@ export const useStyleInfo = ({
     const styleInfoData: StyleInfo = {};
     for (const [property, value] of Object.entries(browserStyle)) {
       styleInfoData[property as StyleProperty] = {
-        source: "external",
         value,
       };
     }
     for (const [property, value] of Object.entries(localStyle)) {
       styleInfoData[property as StyleProperty] = {
-        source: "local",
         value,
+        local: value,
       };
     }
     return styleInfoData;

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -11,10 +11,10 @@ export type StyleInfo = {
 };
 
 export const useStyleInfo = ({
-  breakpointStyle,
+  localStyle,
   browserStyle,
 }: {
-  breakpointStyle: Style;
+  localStyle: Style;
   browserStyle: Style;
 }) => {
   const styleInfoData = useMemo(() => {
@@ -25,14 +25,14 @@ export const useStyleInfo = ({
         value,
       };
     }
-    for (const [property, value] of Object.entries(breakpointStyle)) {
+    for (const [property, value] of Object.entries(localStyle)) {
       styleInfoData[property as StyleProperty] = {
         source: "local",
         value,
       };
     }
     return styleInfoData;
-  }, [browserStyle, breakpointStyle]);
+  }, [browserStyle, localStyle]);
 
   return styleInfoData;
 };

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -1,13 +1,13 @@
 import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
 import { useMemo } from "react";
 
-export type StylePropertyInfo = {
+export type StyleValueInfo = {
   value: StyleValue;
   local?: StyleValue;
 };
 
 export type StyleInfo = {
-  [property in StyleProperty]?: StylePropertyInfo;
+  [property in StyleProperty]?: StyleValueInfo;
 };
 
 export const useStyleInfo = ({

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -1,0 +1,38 @@
+import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
+import { useMemo } from "react";
+
+export type StylePropertyInfo = {
+  source: "local" | "external";
+  value: StyleValue;
+};
+
+export type StyleInfo = {
+  [property in StyleProperty]?: StylePropertyInfo;
+};
+
+export const useStyleInfo = ({
+  breakpointStyle,
+  browserStyle,
+}: {
+  breakpointStyle: Style;
+  browserStyle: Style;
+}) => {
+  const styleInfoData = useMemo(() => {
+    const styleInfoData: StyleInfo = {};
+    for (const [property, value] of Object.entries(browserStyle)) {
+      styleInfoData[property as StyleProperty] = {
+        source: "external",
+        value,
+      };
+    }
+    for (const [property, value] of Object.entries(breakpointStyle)) {
+      styleInfoData[property as StyleProperty] = {
+        source: "local",
+        value,
+      };
+    }
+    return styleInfoData;
+  }, [browserStyle, breakpointStyle]);
+
+  return styleInfoData;
+};

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -15,14 +15,17 @@ export const useStyleInfo = ({
   browserStyle,
 }: {
   localStyle: Style;
-  browserStyle: Style;
+  browserStyle?: Style;
 }) => {
   const styleInfoData = useMemo(() => {
     const styleInfoData: StyleInfo = {};
-    for (const [property, value] of Object.entries(browserStyle)) {
-      styleInfoData[property as StyleProperty] = {
-        value,
-      };
+    // temporary solution until we start computing all styles from data
+    if (browserStyle) {
+      for (const [property, value] of Object.entries(browserStyle)) {
+        styleInfoData[property as StyleProperty] = {
+          value,
+        };
+      }
     }
     for (const [property, value] of Object.entries(localStyle)) {
       styleInfoData[property as StyleProperty] = {

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -61,7 +61,7 @@ export const useStyleData = ({
 
   const currentStyle = useStyleInfo({
     localStyle: breakpointStyle,
-    browserStyle: selectedInstanceData?.browserStyle ?? {},
+    browserStyle: selectedInstanceData?.browserStyle,
   });
 
   useEffect(() => {

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -60,7 +60,7 @@ export const useStyleData = ({
   );
 
   const currentStyle = useStyleInfo({
-    breakpointStyle,
+    localStyle: breakpointStyle,
     browserStyle: selectedInstanceData?.browserStyle ?? {},
   });
 

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -7,6 +7,7 @@ import { useSelectedBreakpoint } from "~/designer/shared/nano-states";
 import { getCssRuleForBreakpoint } from "./get-css-rule-for-breakpoint";
 // @todo: must be removed, now it's only for compatibility with existing code
 import { parseCssValue } from "./parse-css-value";
+import { useStyleInfo } from "./style-info";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -58,13 +59,10 @@ export const useStyleData = ({
     () => cssRule?.style as Style
   );
 
-  const currentStyle = useMemo<Style>(
-    () => ({
-      ...selectedInstanceData?.browserStyle,
-      ...breakpointStyle,
-    }),
-    [selectedInstanceData?.browserStyle, breakpointStyle]
-  );
+  const currentStyle = useStyleInfo({
+    breakpointStyle,
+    browserStyle: selectedInstanceData?.browserStyle ?? {},
+  });
 
   useEffect(() => {
     setBreakpointStyle({ ...cssRule?.style });

--- a/apps/designer/app/designer/features/style-panel/style-sections.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-sections.tsx
@@ -2,12 +2,14 @@ import { Grid } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
 import { styleConfigByName } from "./shared/configs";
 import type { Category } from "@webstudio-is/react-sdk";
-import type { Style, StyleProperty } from "@webstudio-is/css-data";
+import type { StyleProperty } from "@webstudio-is/css-data";
 import type {
   SetProperty,
   DeleteProperty,
   CreateBatchUpdate,
 } from "./shared/use-style-data";
+import { PropertyName } from "./shared/property-name";
+import type { StyleInfo } from "./shared/style-info";
 import * as controls from "./controls";
 import {
   LayoutSection,
@@ -22,12 +24,11 @@ import {
   EffectsSection,
   OtherSection,
 } from "./sections";
-import { PropertyName } from "./shared/property-name";
 
 export type ControlProps = {
   property: StyleProperty;
   items?: Array<{ label: string; name: string }>;
-  currentStyle: Style;
+  currentStyle: StyleInfo;
   setProperty: SetProperty;
   deleteProperty: DeleteProperty;
 };
@@ -36,7 +37,7 @@ export type RenderCategoryProps = {
   setProperty: SetProperty;
   deleteProperty: DeleteProperty;
   createBatchUpdate: CreateBatchUpdate;
-  currentStyle: Style;
+  currentStyle: StyleInfo;
   category: Category;
   styleConfigsByCategory: Array<RenderPropertyProps>;
   moreStyleConfigsByCategory: Array<RenderPropertyProps>;
@@ -44,7 +45,7 @@ export type RenderCategoryProps = {
 
 export type RenderPropertyProps = {
   property: StyleProperty;
-  currentStyle: Style;
+  currentStyle: StyleInfo;
   setProperty: SetProperty;
   deleteProperty: DeleteProperty;
   category: Category;
@@ -110,9 +111,9 @@ export const shouldRenderCategory = ({
 }: RenderCategoryProps) => {
   switch (category) {
     case "flexChild":
-      return toValue(currentStyle.display).includes("flex");
+      return toValue(currentStyle.display?.value).includes("flex");
     case "gridChild":
-      return toValue(currentStyle.display).includes("grid");
+      return toValue(currentStyle.display?.value).includes("grid");
   }
 
   return true;

--- a/apps/designer/app/designer/features/style-panel/style-settings.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-settings.tsx
@@ -1,6 +1,6 @@
 import hyphenate from "hyphenate-style-name";
 import { categories, type Category } from "@webstudio-is/react-sdk";
-import type { Style, StyleProperty } from "@webstudio-is/css-data";
+import type { StyleProperty } from "@webstudio-is/css-data";
 import { toValue } from "@webstudio-is/css-engine";
 
 import {
@@ -15,6 +15,7 @@ import {
   type SetProperty,
   type CreateBatchUpdate,
 } from "./shared/use-style-data";
+import type { StyleInfo } from "./shared/style-info";
 import type { RenderPropertyProps } from "./style-sections";
 
 // Finds a property/value by using any available form: property, label, value
@@ -52,14 +53,17 @@ const filterProperties = (
   });
 };
 
-const appliesTo = (styleConfig: StyleConfig, currentStyle: Style): boolean => {
+const appliesTo = (
+  styleConfig: StyleConfig,
+  currentStyle: StyleInfo
+): boolean => {
   const { appliesTo } = styleConfig;
   if (appliesTo in dependencies) {
     const dependency = dependencies[appliesTo];
     if (dependency === undefined) {
       return false;
     }
-    const currentValue = toValue(currentStyle[dependency.property]);
+    const currentValue = toValue(currentStyle[dependency.property]?.value);
     if (currentValue === undefined) {
       return false;
     }
@@ -83,7 +87,7 @@ const didRender = (category: Category, property: StyleProperty): boolean => {
 };
 
 export type StyleSettingsProps = {
-  currentStyle: Style;
+  currentStyle: StyleInfo;
   setProperty: SetProperty;
   deleteProperty: (property: StyleProperty) => void;
   createBatchUpdate: CreateBatchUpdate;


### PR DESCRIPTION
This is a step toward https://github.com/webstudio-is/webstudio-designer/issues/29

When merge browser style and local styles we can specify the source of the style. Later we can add additional info about inherited and cascaded styles.

## Code Review

- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)
- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
