### PR TITLE
Add background-image asset support to the designer app

### DIFF
--- a/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
@@ -396,6 +396,7 @@ describe("usePropsLogic", () => {
       result.current.handleChangePropValue("1", {
         type: "asset",
         value: {
+          type: "image",
           id: "string",
           projectId: "string",
           format: "string",
@@ -431,6 +432,7 @@ describe("usePropsLogic", () => {
             "path": "string",
             "projectId": "string",
             "size": 1111,
+            "type": "image",
           },
         },
       ]

--- a/apps/designer/app/designer/features/style-panel/controls/image/image-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/image/image-control.tsx
@@ -2,26 +2,24 @@ import { TextField } from "@webstudio-is/design-system";
 import type { ControlProps } from "../../style-sections";
 import { FloatingPanel } from "~/designer/shared/floating-panel";
 import { ImageManager } from "~/designer/shared/image-manager";
-import { useAssets } from "~/designer/shared/assets";
-import { toValue } from "@webstudio-is/css-engine";
 
 export const ImageControl = ({
   property,
   currentStyle,
   setProperty,
 }: ControlProps) => {
-  const { assetContainers } = useAssets("image");
-  const value = currentStyle[property];
+  const styleInfo = currentStyle[property];
 
-  if (value === undefined) {
+  if (styleInfo === undefined) {
     return null;
   }
 
   const setValue = setProperty(property);
 
-  const selectedAsset = assetContainers.find(
-    (assetContainer) => assetContainer.asset.id === toValue(value)
-  );
+  const valueAssets =
+    styleInfo.type === "image"
+      ? styleInfo.value.filter((image) => image.type === "asset")
+      : [];
 
   return (
     <FloatingPanel
@@ -29,13 +27,15 @@ export const ImageControl = ({
       content={
         <ImageManager
           onChange={(asset) => {
-            // @todo looks like a bug fix next PRs
-            setValue(asset.id);
+            setValue({
+              type: "image",
+              value: [{ type: "asset", value: asset }],
+            });
           }}
         />
       }
     >
-      <TextField defaultValue={selectedAsset?.asset.name} />
+      <TextField defaultValue={valueAssets?.[0]?.value.name} />
     </FloatingPanel>
   );
 };

--- a/apps/designer/app/designer/features/style-panel/shared/configs.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/configs.ts
@@ -61,8 +61,7 @@ const getControl = (property: StyleProperty): Control => {
     }
     case "backgroundImage": {
       // @todo implement image picker for background image
-      return "TextControl";
-      //return "ImageControl";
+      return "ImageControl";
     }
     case "fontWeight": {
       return "FontWeightControl";

--- a/apps/designer/app/designer/shared/assets/types.ts
+++ b/apps/designer/app/designer/shared/assets/types.ts
@@ -1,8 +1,8 @@
-import { Asset } from "@webstudio-is/asset-uploader";
+import type { Asset } from "@webstudio-is/asset-uploader";
 
 type PreviewAsset = Pick<
   Asset,
-  "path" | "name" | "id" | "format" | "description"
+  "path" | "name" | "id" | "format" | "description" | "type"
 >;
 
 export type UploadedAssetContainer = {

--- a/apps/designer/app/designer/shared/assets/update-asset-containers.test.ts
+++ b/apps/designer/app/designer/shared/assets/update-asset-containers.test.ts
@@ -14,7 +14,7 @@ const getAssetId = (
 
 const createServerAsset = (id: string, name?: string): Asset => ({
   id,
-
+  type: "image",
   name: name ?? "test",
   location: "FS",
   projectId: "id",

--- a/apps/designer/app/designer/shared/assets/use-assets.tsx
+++ b/apps/designer/app/designer/shared/assets/use-assets.tsx
@@ -13,7 +13,6 @@ import {
   toBytes,
   type Asset,
 } from "@webstudio-is/asset-uploader";
-import { type FontFormat, FONT_FORMATS } from "@webstudio-is/fonts";
 import { toast } from "@webstudio-is/design-system";
 import { restAssetsPath } from "~/shared/router-utils";
 import { useAssetsContainer, useProject } from "../nano-states";
@@ -93,6 +92,7 @@ const toUploadingAssetsAndFormData = (
             {
               status: "uploading",
               asset: {
+                type,
                 format: file.type.split("/")[1],
                 path: String(dataUri),
                 name: file.name,
@@ -336,14 +336,7 @@ export const AssetsProvider = ({ children }: { children: ReactNode }) => {
 
 const filterByType = (assetContainers: AssetContainer[], type: AssetType) => {
   return assetContainers.filter((assetContainer) => {
-    const format = assetContainer.asset.format;
-
-    const isFont = FONT_FORMATS.has(format as FontFormat);
-    if (type === "font") {
-      return isFont;
-    }
-
-    return isFont === false;
+    return assetContainer.asset.type === type;
   });
 };
 

--- a/apps/designer/app/designer/shared/image-manager/image-manager.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-manager.tsx
@@ -9,7 +9,7 @@ import {
 import { useFilter } from "../assets/use-filter";
 import { ImageThumbnail } from "./image-thumbnail";
 import { matchSorter } from "match-sorter";
-import { Asset } from "@webstudio-is/asset-uploader";
+import { ImageAsset } from "@webstudio-is/asset-uploader";
 
 const filterItems = (search: string, items: AssetContainer[]) => {
   return matchSorter(items, search, {
@@ -17,7 +17,7 @@ const filterItems = (search: string, items: AssetContainer[]) => {
   });
 };
 
-const useLogic = ({ onChange }: { onChange?: (asset: Asset) => void }) => {
+const useLogic = ({ onChange }: { onChange?: (asset: ImageAsset) => void }) => {
   const { assetContainers, handleDelete } = useAssets("image");
 
   const [selectedIndex, setSelectedIndex] = useState(-1);
@@ -43,7 +43,10 @@ const useLogic = ({ onChange }: { onChange?: (asset: Asset) => void }) => {
       if (direction === "current") {
         setSelectedIndex(selectedIndex);
         const assetContainer = filteredItems[selectedIndex];
-        if (assetContainer.status === "uploaded") {
+        if (
+          assetContainer.status === "uploaded" &&
+          assetContainer.asset.type === "image"
+        ) {
           onChange?.(assetContainer.asset);
         }
         return;
@@ -74,7 +77,7 @@ const useLogic = ({ onChange }: { onChange?: (asset: Asset) => void }) => {
 };
 
 type ImageManagerProps = {
-  onChange?: (asset: Asset) => void;
+  onChange?: (asset: ImageAsset) => void;
 };
 
 export const ImageManager = ({ onChange }: ImageManagerProps) => {
@@ -101,7 +104,10 @@ export const ImageManager = ({ onChange }: ImageManagerProps) => {
             onSelect={handleSelect}
             onChange={(assetContainer) => {
               // @todo we probably should not allow select uploading images too
-              if (assetContainer.status === "uploaded") {
+              if (
+                assetContainer.status === "uploaded" &&
+                assetContainer.asset.type === "image"
+              ) {
                 onChange?.(assetContainer.asset);
               }
             }}

--- a/packages/asset-uploader/src/schema.ts
+++ b/packages/asset-uploader/src/schema.ts
@@ -48,11 +48,13 @@ const BaseAsset = z.object({
 export const FontAsset = BaseAsset.omit({ format: true }).extend({
   format: FontFormat,
   meta: FontMeta,
+  type: z.literal("font"),
 });
 export type FontAsset = z.infer<typeof FontAsset>;
 
 export const ImageAsset = BaseAsset.extend({
   meta: ImageMeta,
+  type: z.literal("image"),
 });
 export type ImageAsset = z.infer<typeof ImageAsset>;
 

--- a/packages/asset-uploader/src/utils/format-asset.ts
+++ b/packages/asset-uploader/src/utils/format-asset.ts
@@ -12,6 +12,7 @@ export const formatAsset = (asset: DbAsset): Asset => {
   if (isFont) {
     return {
       ...base,
+      type: "font",
       createdAt: base.createdAt.toISOString(),
       format: asset.format as FontFormat,
       meta: FontMeta.parse(JSON.parse(asset.meta)),
@@ -20,6 +21,7 @@ export const formatAsset = (asset: DbAsset): Asset => {
 
   return {
     ...base,
+    type: "image",
     createdAt: base.createdAt.toISOString(),
     meta: ImageMeta.parse(JSON.parse(asset.meta)),
   };

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -18,6 +18,7 @@
     "@types/css-tree": "^2.0.0",
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
+    "@webstudio-is/asset-uploader": "workspace:^",
     "camelcase": "^6.3.0",
     "css-tree": "^2.3.0",
     "mdn-data": "2.0.23",

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -1,6 +1,7 @@
 import { units } from "./__generated__/units";
 import { properties } from "./__generated__/properties";
 import { z } from "zod";
+import { ImageAsset } from "@webstudio-is/asset-uploader";
 
 type Properties = typeof properties & {
   [custom: CustomProperty]: {
@@ -50,6 +51,13 @@ const RgbValue = z.object({
 });
 export type RgbValue = z.infer<typeof RgbValue>;
 
+export const ImageValue = z.object({
+  type: z.literal("image"),
+  value: z.array(z.object({ type: z.literal("asset"), value: ImageAsset })),
+});
+
+export type ImageValue = z.infer<typeof ImageValue>;
+
 // We want to be able to render the invalid value
 // and show it is invalid visually, without saving it to the db
 const InvalidValue = z.object({
@@ -69,14 +77,22 @@ export const validStaticValueTypes = [
   "keyword",
   "fontFamily",
   "rgb",
+  "image",
 ] as const;
 
-const ValidStaticStyleValue = z.union([
+/**
+ * Shared zod types with DB types.
+ * ImageValue in DB has a different type
+ */
+const SharedStaticStyleValue = z.union([
   UnitValue,
   KeywordValue,
   FontFamilyValue,
   RgbValue,
 ]);
+
+const ValidStaticStyleValue = z.union([ImageValue, SharedStaticStyleValue]);
+
 export type ValidStaticStyleValue = z.infer<typeof ValidStaticStyleValue>;
 
 const VarValue = z.object({
@@ -91,8 +107,18 @@ const StyleValue = z.union([
   InvalidValue,
   UnsetValue,
   VarValue,
-  RgbValue,
 ]);
+
+/**
+ * Shared types with DB types
+ */
+export const SharedStyleValue = z.union([
+  SharedStaticStyleValue,
+  InvalidValue,
+  UnsetValue,
+  VarValue,
+]);
+
 export type StyleValue = z.infer<typeof StyleValue>;
 
 const Style = z.record(z.string(), StyleValue);

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -61,6 +61,16 @@ export const toValue = (
     return `rgba(${value.r}, ${value.g}, ${value.b}, ${value.alpha})`;
   }
 
+  if (value.type === "image") {
+    // @todo image-set
+    return value.value
+      .map(
+        (imageAsset) =>
+          `url(${imageAsset.value.path}) /* id=${imageAsset.value.id} */`
+      )
+      .join(", ");
+  }
+
   // Will give ts error in case of missing type
   assertUnreachable(value, `Unknown value type`);
 

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -22,6 +22,7 @@
     "@webstudio-is/prisma-client": "workspace:^",
     "@webstudio-is/react-sdk": "workspace:^",
     "bson-objectid": "^2.0.2",
+    "dataloader": "^2.1.0",
     "immer": "^9.0.12",
     "nanoid": "^3.2.0",
     "react": "^17.0.2",

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -1,12 +1,126 @@
-import { type Tree, Instance } from "@webstudio-is/react-sdk";
+import { formatAsset } from "@webstudio-is/asset-uploader/server";
+import { type Tree, Instance, Text } from "@webstudio-is/react-sdk";
 import { applyPatches, type Patch } from "immer";
 import {
+  Asset,
   prisma,
   type Prisma,
   type Tree as DbTree,
 } from "@webstudio-is/prisma-client";
 import { utils } from "../index";
-import type { Breakpoint } from "@webstudio-is/css-data";
+import {
+  type Breakpoint,
+  SharedStyleValue,
+  ImageValue,
+} from "@webstudio-is/css-data";
+import { z } from "zod";
+import DataLoader from "dataloader";
+import warnOnce from "warn-once";
+
+const assetsLoader = new DataLoader<string, Asset | undefined>(
+  async (assetIds) => {
+    const assets = await prisma.asset.findMany({
+      where: {
+        id: {
+          // Spread to remove readonly from assetIds, otherwise ts error.
+          in: [...assetIds],
+        },
+      },
+    });
+
+    /**
+     * Dataloader docs:
+     * The Array of values must be the same length as the Array of keys.
+     * Each index in the Array of values must correspond to the same index in the Array of keys.
+     * (assets returned from DB can have a different order, some could not exist)
+     */
+    return assetIds.map((assetId) =>
+      assets.find((asset) => asset.id === assetId)
+    );
+  }
+);
+
+/**
+ * Use zod + DataLoader to load/format assets from the Assets table.
+ */
+const ImageAssetDbOut = z.object({
+  type: z.literal("asset"),
+  value: z
+    .string()
+    .uuid()
+    .transform(async (assetId) => {
+      const asset = await assetsLoader.load(assetId);
+      if (asset === undefined) {
+        warnOnce(true, `Asset with assetId "${assetId}" not found`);
+        return;
+      }
+
+      return formatAsset(asset);
+    }),
+});
+
+const ImageValueDbOut = z.object({
+  type: z.literal("image"),
+  value: z
+    .array(ImageAssetDbOut)
+    // an Asset can be not present in DB, skip it.
+    .transform((assets) => assets.filter((asset) => asset.value !== undefined)),
+});
+
+const StyleValueDbOut = z.union([SharedStyleValue, ImageValueDbOut]);
+
+const StyleDbOut = z.record(z.string(), StyleValueDbOut);
+
+export const CssRuleDbOut = z.object({
+  style: StyleDbOut,
+  breakpoint: z.optional(z.string()),
+});
+
+/**
+ * validate/transform DB data schema to the client schema.
+ */
+const InstanceDbOut = z.lazy(() =>
+  z.object({
+    type: z.literal("instance"),
+    id: z.string(),
+    component: z.string(),
+    children: z.array(z.union([InstanceDbOut, Text])),
+    cssRules: z.array(CssRuleDbOut),
+  })
+) as z.ZodType<Instance>;
+
+/**
+ * In the DB we hold only assetId
+ **/
+const ImageValueDbIn = ImageValue.transform((imageStyle) => ({
+  type: imageStyle.type,
+  value: imageStyle.value.map((value) =>
+    /* Now value.type is always equal to the "asset", but in the future, it will have additional types */
+    value.type === "asset" ? { type: "asset", value: value.value.id } : value
+  ),
+}));
+
+const StyleValueDbIn = z.union([SharedStyleValue, ImageValueDbIn]);
+
+const StyleDbIn = z.record(z.string(), StyleValueDbIn);
+
+export const CssRuleDbIn = z.object({
+  style: StyleDbIn,
+  breakpoint: z.optional(z.string()),
+});
+
+/**
+ * validate/transform client schema into DB data schema.
+ */
+const InstanceDbIn = z.lazy(() =>
+  z.object({
+    type: z.literal("instance"),
+    id: z.string(),
+    component: z.string(),
+    children: z.array(z.union([InstanceDbIn, Text])),
+    cssRules: z.array(CssRuleDbIn),
+  })
+) as /* Instance is wrong type here, ImageValue is different after transform. We don't use it anyway */ z.ZodType<Instance>;
 
 export const createRootInstance = (breakpoints: Array<Breakpoint>) => {
   // Take the smallest breakpoint as default
@@ -19,11 +133,13 @@ export const createRootInstance = (breakpoints: Array<Breakpoint>) => {
 };
 
 export const create = async (
-  root: Instance,
+  clientRoot: Instance,
   client: Prisma.TransactionClient = prisma
 ): Promise<DbTree> => {
-  Instance.parse(root);
+  const root = InstanceDbIn.parse(clientRoot);
+
   const rootString = JSON.stringify(root);
+
   return await client.tree.create({
     data: { root: rootString },
   });
@@ -45,8 +161,12 @@ export const loadById = async (
     return null;
   }
 
-  const root = JSON.parse(tree.root);
+  const dbRoot = JSON.parse(tree.root);
+
+  const root = await InstanceDbOut.parseAsync(dbRoot);
+
   Instance.parse(root);
+
   return {
     ...tree,
     root,
@@ -72,8 +192,10 @@ export const patch = async (
   if (tree === null) {
     throw new Error(`Tree ${treeId} not found`);
   }
-  const root = applyPatches(tree.root, patches);
-  Instance.parse(root);
+  const clientRoot = applyPatches(tree.root, patches);
+
+  const root = InstanceDbIn.parse(clientRoot);
+
   await prisma.tree.update({
     data: { root: JSON.stringify(root) },
     where: { id: treeId },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,7 @@ importers:
   packages/css-data:
     specifiers:
       '@types/css-tree': ^2.0.0
+      '@webstudio-is/asset-uploader': workspace:^
       '@webstudio-is/scripts': workspace:^
       '@webstudio-is/tsconfig': workspace:^
       camelcase: ^6.3.0
@@ -307,6 +308,7 @@ importers:
       zod: ^3.19.1
     devDependencies:
       '@types/css-tree': 2.0.0
+      '@webstudio-is/asset-uploader': link:../asset-uploader
       '@webstudio-is/scripts': link:../scripts
       '@webstudio-is/tsconfig': link:../tsconfig
       camelcase: 6.3.0
@@ -721,6 +723,7 @@ importers:
       '@webstudio-is/scripts': workspace:^
       '@webstudio-is/tsconfig': workspace:^
       bson-objectid: ^2.0.2
+      dataloader: ^2.1.0
       immer: ^9.0.12
       jest: ^29.3.1
       nanoid: ^3.2.0
@@ -739,6 +742,7 @@ importers:
       '@webstudio-is/prisma-client': link:../prisma-client
       '@webstudio-is/react-sdk': link:../react-sdk
       bson-objectid: 2.0.3
+      dataloader: 2.1.0
       immer: 9.0.15
       nanoid: 3.3.4
       react: 17.0.2
@@ -12365,6 +12369,10 @@ packages:
   /data-uri-to-buffer/3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
     engines: {node: '>= 6'}
+
+  /dataloader/2.1.0:
+    resolution: {integrity: sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==}
+    dev: false
 
   /deasync/0.1.26:
     resolution: {integrity: sha512-YKw0BmJSWxkjtQsbgn6Q9CHSWB7DKMen8vKrgyC006zy0UZ6nWyGidB0IzZgqkVRkOglAeUaFtiRTeLyel72bg==}


### PR DESCRIPTION
## Description

ref  #534

PR atop of #701

Next PR: image-set support

Ability to select background image from asset

<img width="496" alt="image" src="https://user-images.githubusercontent.com/5077042/209625480-f0b4b5a0-8ca7-438d-bbd8-3b4874f9428d.png">


## Steps for reproduction

Create a div, and select an asset for the background image.


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
