### PR TITLE
Add Background image to Designer app (without image-set)

### DIFF
--- a/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
@@ -396,6 +396,7 @@ describe("usePropsLogic", () => {
       result.current.handleChangePropValue("1", {
         type: "asset",
         value: {
+          type: "image",
           id: "string",
           projectId: "string",
           format: "string",
@@ -431,6 +432,7 @@ describe("usePropsLogic", () => {
             "path": "string",
             "projectId": "string",
             "size": 1111,
+            "type": "image",
           },
         },
       ]

--- a/apps/designer/app/designer/features/style-panel/controls/image/image-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/image/image-control.tsx
@@ -2,26 +2,24 @@ import { TextField } from "@webstudio-is/design-system";
 import type { ControlProps } from "../../style-sections";
 import { FloatingPanel } from "~/designer/shared/floating-panel";
 import { ImageManager } from "~/designer/shared/image-manager";
-import { useAssets } from "~/designer/shared/assets";
-import { toValue } from "@webstudio-is/css-engine";
 
 export const ImageControl = ({
   property,
   currentStyle,
   setProperty,
 }: ControlProps) => {
-  const { assetContainers } = useAssets("image");
-  const value = currentStyle[property];
+  const styleInfo = currentStyle[property];
 
-  if (value === undefined) {
+  if (styleInfo === undefined) {
     return null;
   }
 
   const setValue = setProperty(property);
 
-  const selectedAsset = assetContainers.find(
-    (assetContainer) => assetContainer.asset.id === toValue(value)
-  );
+  const valueAssets =
+    styleInfo.type === "image"
+      ? styleInfo.value.filter((image) => image.type === "asset")
+      : [];
 
   return (
     <FloatingPanel
@@ -29,13 +27,15 @@ export const ImageControl = ({
       content={
         <ImageManager
           onChange={(asset) => {
-            // @todo looks like a bug fix next PRs
-            setValue(asset.id);
+            setValue({
+              type: "image",
+              value: [{ type: "asset", value: asset }],
+            });
           }}
         />
       }
     >
-      <TextField defaultValue={selectedAsset?.asset.name} />
+      <TextField defaultValue={valueAssets?.[0]?.value.name} />
     </FloatingPanel>
   );
 };

--- a/apps/designer/app/designer/features/style-panel/controls/image/image-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/image/image-control.tsx
@@ -8,17 +8,17 @@ export const ImageControl = ({
   currentStyle,
   setProperty,
 }: ControlProps) => {
-  const styleInfo = currentStyle[property];
+  const styleValue = currentStyle[property];
 
-  if (styleInfo === undefined) {
+  if (styleValue === undefined) {
     return null;
   }
 
   const setValue = setProperty(property);
 
   const valueAssets =
-    styleInfo.type === "image"
-      ? styleInfo.value.filter((image) => image.type === "asset")
+    styleValue.type === "image"
+      ? styleValue.value.filter((image) => image.type === "asset")
       : [];
 
   return (

--- a/apps/designer/app/designer/features/style-panel/shared/configs.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/configs.ts
@@ -61,8 +61,7 @@ const getControl = (property: StyleProperty): Control => {
     }
     case "backgroundImage": {
       // @todo implement image picker for background image
-      return "TextControl";
-      //return "ImageControl";
+      return "ImageControl";
     }
     case "fontWeight": {
       return "FontWeightControl";

--- a/apps/designer/app/designer/shared/assets/types.ts
+++ b/apps/designer/app/designer/shared/assets/types.ts
@@ -1,8 +1,8 @@
-import { Asset } from "@webstudio-is/asset-uploader";
+import type { Asset } from "@webstudio-is/asset-uploader";
 
 type PreviewAsset = Pick<
   Asset,
-  "path" | "name" | "id" | "format" | "description"
+  "path" | "name" | "id" | "format" | "description" | "type"
 >;
 
 export type UploadedAssetContainer = {

--- a/apps/designer/app/designer/shared/assets/update-asset-containers.test.ts
+++ b/apps/designer/app/designer/shared/assets/update-asset-containers.test.ts
@@ -14,7 +14,7 @@ const getAssetId = (
 
 const createServerAsset = (id: string, name?: string): Asset => ({
   id,
-
+  type: "image",
   name: name ?? "test",
   location: "FS",
   projectId: "id",

--- a/apps/designer/app/designer/shared/assets/use-assets.tsx
+++ b/apps/designer/app/designer/shared/assets/use-assets.tsx
@@ -13,7 +13,6 @@ import {
   toBytes,
   type Asset,
 } from "@webstudio-is/asset-uploader";
-import { type FontFormat, FONT_FORMATS } from "@webstudio-is/fonts";
 import { toast } from "@webstudio-is/design-system";
 import { restAssetsPath } from "~/shared/router-utils";
 import { useAssetsContainer, useProject } from "../nano-states";
@@ -93,6 +92,7 @@ const toUploadingAssetsAndFormData = (
             {
               status: "uploading",
               asset: {
+                type,
                 format: file.type.split("/")[1],
                 path: String(dataUri),
                 name: file.name,
@@ -336,14 +336,7 @@ export const AssetsProvider = ({ children }: { children: ReactNode }) => {
 
 const filterByType = (assetContainers: AssetContainer[], type: AssetType) => {
   return assetContainers.filter((assetContainer) => {
-    const format = assetContainer.asset.format;
-
-    const isFont = FONT_FORMATS.has(format as FontFormat);
-    if (type === "font") {
-      return isFont;
-    }
-
-    return isFont === false;
+    return assetContainer.asset.type === type;
   });
 };
 

--- a/apps/designer/app/designer/shared/image-manager/image-manager.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-manager.tsx
@@ -9,7 +9,7 @@ import {
 import { useFilter } from "../assets/use-filter";
 import { ImageThumbnail } from "./image-thumbnail";
 import { matchSorter } from "match-sorter";
-import { Asset } from "@webstudio-is/asset-uploader";
+import { ImageAsset } from "@webstudio-is/asset-uploader";
 
 const filterItems = (search: string, items: AssetContainer[]) => {
   return matchSorter(items, search, {
@@ -17,7 +17,7 @@ const filterItems = (search: string, items: AssetContainer[]) => {
   });
 };
 
-const useLogic = ({ onChange }: { onChange?: (asset: Asset) => void }) => {
+const useLogic = ({ onChange }: { onChange?: (asset: ImageAsset) => void }) => {
   const { assetContainers, handleDelete } = useAssets("image");
 
   const [selectedIndex, setSelectedIndex] = useState(-1);
@@ -43,7 +43,10 @@ const useLogic = ({ onChange }: { onChange?: (asset: Asset) => void }) => {
       if (direction === "current") {
         setSelectedIndex(selectedIndex);
         const assetContainer = filteredItems[selectedIndex];
-        if (assetContainer.status === "uploaded") {
+        if (
+          assetContainer.status === "uploaded" &&
+          assetContainer.asset.type === "image"
+        ) {
           onChange?.(assetContainer.asset);
         }
         return;
@@ -74,7 +77,7 @@ const useLogic = ({ onChange }: { onChange?: (asset: Asset) => void }) => {
 };
 
 type ImageManagerProps = {
-  onChange?: (asset: Asset) => void;
+  onChange?: (asset: ImageAsset) => void;
 };
 
 export const ImageManager = ({ onChange }: ImageManagerProps) => {
@@ -101,7 +104,10 @@ export const ImageManager = ({ onChange }: ImageManagerProps) => {
             onSelect={handleSelect}
             onChange={(assetContainer) => {
               // @todo we probably should not allow select uploading images too
-              if (assetContainer.status === "uploaded") {
+              if (
+                assetContainer.status === "uploaded" &&
+                assetContainer.asset.type === "image"
+              ) {
                 onChange?.(assetContainer.asset);
               }
             }}

--- a/packages/asset-uploader/src/schema.ts
+++ b/packages/asset-uploader/src/schema.ts
@@ -48,11 +48,13 @@ const BaseAsset = z.object({
 export const FontAsset = BaseAsset.omit({ format: true }).extend({
   format: FontFormat,
   meta: FontMeta,
+  type: z.literal("font"),
 });
 export type FontAsset = z.infer<typeof FontAsset>;
 
 export const ImageAsset = BaseAsset.extend({
   meta: ImageMeta,
+  type: z.literal("image"),
 });
 export type ImageAsset = z.infer<typeof ImageAsset>;
 

--- a/packages/asset-uploader/src/utils/format-asset.ts
+++ b/packages/asset-uploader/src/utils/format-asset.ts
@@ -12,6 +12,7 @@ export const formatAsset = (asset: DbAsset): Asset => {
   if (isFont) {
     return {
       ...base,
+      type: "font",
       createdAt: base.createdAt.toISOString(),
       format: asset.format as FontFormat,
       meta: FontMeta.parse(JSON.parse(asset.meta)),
@@ -20,6 +21,7 @@ export const formatAsset = (asset: DbAsset): Asset => {
 
   return {
     ...base,
+    type: "image",
     createdAt: base.createdAt.toISOString(),
     meta: ImageMeta.parse(JSON.parse(asset.meta)),
   };


### PR DESCRIPTION
## Description

ref  #534

PR atop of #701

Next PR: image-set support

Ability to select background image from asset

<img width="496" alt="image" src="https://user-images.githubusercontent.com/5077042/209625480-f0b4b5a0-8ca7-438d-bbd8-3b4874f9428d.png">


## Steps for reproduction

Create a div, and select an asset for the background image.


## Code Review

- [ ] hi @TrySound , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
