### PR TITLE
Add assets upload restriction 1 file per request

### DIFF
--- a/packages/asset-uploader/src/targets/s3/upload.ts
+++ b/packages/asset-uploader/src/targets/s3/upload.ts
@@ -33,6 +33,8 @@ export const uploadToS3 = async ({
   projectId: string;
   maxSize: number;
 }): Promise<Array<Asset>> => {
+  const uploadHandler = createUploadHandler(1);
+
   const formData = await unstableCreateFileUploadHandler(
     request,
     unstableComposeUploadHandlers(
@@ -59,90 +61,100 @@ export const uploadToS3 = async ({
   return await createMany(projectId, assetsData);
 };
 
-const uploadHandler = async ({
-  file,
-  maxSize,
-}: {
-  file: UploadHandlerPart;
-  maxSize: number;
-}): Promise<string | undefined> => {
-  if (file.filename === undefined) {
-    // Do not parse if it's not a file
-    return;
-  }
+const createUploadHandler = (maxFiles: number) => {
+  let count = 0;
 
-  if (!file.data) {
-    throw new Error("Your asset seems to be empty");
-  }
+  return async ({
+    file,
+    maxSize,
+  }: {
+    file: UploadHandlerPart;
+    maxSize: number;
+  }): Promise<string | undefined> => {
+    if (file.filename === undefined) {
+      // Do not parse if it's not a file
+      return;
+    }
 
-  // @todo this is going to put the entire file in memory
-  // this has to be a stream that goes directly to s3
-  // Size check has to happen as you stream and interrupted when size is too big
-  // Also check if S3 client has an option to check the size limit
-  const data = await toUint8Array(file.data);
+    if (count >= maxFiles) {
+      throw new Error("Only one file may be uploaded");
+    }
 
-  if (data.byteLength > maxSize) {
-    throw new MaxPartSizeExceededError(file.name, maxSize);
-  }
+    count++;
 
-  const fileName = sanitizeS3Key(file.filename);
+    if (!file.data) {
+      throw new Error("Your asset seems to be empty");
+    }
 
-  const uniqueFilename = getUniqueFilename(fileName);
+    // @todo this is going to put the entire file in memory
+    // this has to be a stream that goes directly to s3
+    // Size check has to happen as you stream and interrupted when size is too big
+    // Also check if S3 client has an option to check the size limit
+    const data = await toUint8Array(file.data);
 
-  const s3Env = S3Env.parse(process.env);
+    if (data.byteLength > maxSize) {
+      throw new MaxPartSizeExceededError(file.name, maxSize);
+    }
 
-  // if there is no ACL passed we do not default since some providers do not support it
-  const ACL = s3Env.S3_ACL ? { ACL: s3Env.S3_ACL } : {};
+    const fileName = sanitizeS3Key(file.filename);
 
-  const params: PutObjectCommandInput = {
-    ...ACL,
-    Bucket: s3Env.S3_BUCKET,
-    Key: uniqueFilename,
-    Body: data,
-    ContentType: file.contentType,
-    Metadata: {
-      // encodeURIComponent is needed to support special characters like Cyrillic
-      filename: encodeURIComponent(fileName) || "unnamed",
-    },
-  };
+    const uniqueFilename = getUniqueFilename(fileName);
 
-  const upload = new Upload({ client: getS3Client(), params });
+    const s3Env = S3Env.parse(process.env);
 
-  AssetsUploadedSuccess.parse(await upload.done());
+    // if there is no ACL passed we do not default since some providers do not support it
+    const ACL = s3Env.S3_ACL ? { ACL: s3Env.S3_ACL } : {};
 
-  const type = file.contentType.startsWith("image")
-    ? ("image" as const)
-    : ("font" as const);
-
-  const baseAssetOptions = {
-    name: uniqueFilename,
-    size: data.byteLength,
-    data,
-    location: Location.REMOTE,
-  };
-  let assetOptions;
-
-  if (type === "image") {
-    assetOptions = {
-      // Id will be set later
-      id: "",
-      type,
-      ...baseAssetOptions,
+    const params: PutObjectCommandInput = {
+      ...ACL,
+      Bucket: s3Env.S3_BUCKET,
+      Key: uniqueFilename,
+      Body: data,
+      ContentType: file.contentType,
+      Metadata: {
+        // encodeURIComponent is needed to support special characters like Cyrillic
+        filename: encodeURIComponent(fileName) || "unnamed",
+      },
     };
-  } else if (type === "font") {
-    assetOptions = {
-      // Id will be set later
-      id: "",
-      type,
-      ...baseAssetOptions,
+
+    const upload = new Upload({ client: getS3Client(), params });
+
+    AssetsUploadedSuccess.parse(await upload.done());
+
+    const type = file.contentType.startsWith("image")
+      ? ("image" as const)
+      : ("font" as const);
+
+    const baseAssetOptions = {
+      name: uniqueFilename,
+      size: data.byteLength,
+      data,
+      location: Location.REMOTE,
     };
-  }
+    let assetOptions;
 
-  if (assetOptions === undefined) {
-    throw new Error("Asset type not supported");
-  }
+    if (type === "image") {
+      assetOptions = {
+        // Id will be set later
+        id: "",
+        type,
+        ...baseAssetOptions,
+      };
+    } else if (type === "font") {
+      assetOptions = {
+        // Id will be set later
+        id: "",
+        type,
+        ...baseAssetOptions,
+      };
+    }
 
-  const assetData = await getAssetData(assetOptions);
+    if (assetOptions === undefined) {
+      throw new Error("Asset type not supported");
+    }
 
-  return JSON.stringify(assetData);
+    const assetData = await getAssetData(assetOptions);
+
+    return JSON.stringify(assetData);
+  };
 };

--- a/packages/asset-uploader/src/targets/s3/upload.ts
+++ b/packages/asset-uploader/src/targets/s3/upload.ts
@@ -78,7 +78,7 @@ const createUploadHandler = (maxFiles: number) => {
     }
 
     if (count >= maxFiles) {
-      // Вo not throw, just ignore the file
+      // Do not throw, just ignore the file
       // In case of throw we need to delete previously uploaded files
       return;
     }


### PR DESCRIPTION
## Description

As of now it's possible to directly upload via rest multiple files. 
The issue is that to get files count in request we need to parse request. 
Here I restrict uploading to just 1 file on request.

Next PR: Restrict file count per project.

Use hide whitespaces for review.

<img width="331" alt="image" src="https://user-images.githubusercontent.com/5077042/209684306-c1917dcb-7a57-4cb4-9a15-f0d06e0eca53.png">


## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
