### PR TITLE
Fallback to cascaded and inherited when value not set

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/style-info.test.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.test.ts
@@ -141,10 +141,12 @@ test("compute cascaded styles", () => {
 
 test("compute inherited styles", () => {
   expect(
-    getInheritedInfo(rootInstance, selectedInstanceId, [
-      ...cascadedBreakpointIds,
-      selectedBreakpointId,
-    ])
+    getInheritedInfo(
+      rootInstance,
+      selectedInstanceId,
+      cascadedBreakpointIds,
+      selectedBreakpointId
+    )
   ).toMatchInlineSnapshot(`
     {
       "fontSize": {

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.test.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.test.ts
@@ -1,0 +1,167 @@
+import type { Breakpoint, CssRule } from "@webstudio-is/css-data";
+import type { Instance } from "@webstudio-is/react-sdk";
+import {
+  getCascadedBreakpointIds,
+  getCascadedInfo,
+  getInheritedInfo,
+} from "./style-info";
+
+const breakpoints: Breakpoint[] = [
+  {
+    id: "1",
+    label: "1",
+    minWidth: 0,
+  },
+  {
+    id: "2",
+    label: "2",
+    minWidth: 768,
+  },
+  {
+    id: "3",
+    label: "3",
+    minWidth: 1280,
+  },
+  {
+    id: "4",
+    label: "4",
+    minWidth: 1920,
+  },
+];
+
+const selectedBreakpointId = "3";
+const cascadedBreakpointIds = getCascadedBreakpointIds(
+  breakpoints,
+  selectedBreakpointId
+);
+
+const cssRules: CssRule[] = [
+  {
+    breakpoint: "1",
+    style: {
+      width: { type: "unit", value: 100, unit: "px" },
+      height: { type: "unit", value: 50, unit: "px" },
+    },
+  },
+  {
+    breakpoint: "2",
+    style: {
+      width: { type: "unit", value: 200, unit: "px" },
+    },
+  },
+  {
+    breakpoint: "3",
+    style: {
+      // should not be computed because current breakpoint
+      height: { type: "unit", value: 150, unit: "px" },
+    },
+  },
+  {
+    breakpoint: "4",
+    style: {
+      width: { type: "unit", value: 400, unit: "px" },
+    },
+  },
+];
+
+const rootInstance: Instance = {
+  type: "instance",
+  id: "1",
+  component: "Body",
+  cssRules: [
+    {
+      breakpoint: "1",
+      style: {
+        // should be inherited even from another breakpoint
+        fontSize: { type: "unit", value: 20, unit: "px" },
+      },
+    },
+  ],
+  children: [
+    {
+      type: "instance",
+      id: "2",
+      component: "Box",
+      cssRules: [
+        {
+          breakpoint: "3",
+          style: {
+            // should not be inherited because width is not inheritable
+            width: { type: "unit", value: 100, unit: "px" },
+            // should be inherited from selected breakpoint
+            fontWeight: { type: "keyword", value: "600" },
+          },
+        },
+      ],
+      children: [
+        {
+          type: "instance",
+          id: "3",
+          component: "Box",
+          cssRules: [
+            {
+              breakpoint: "3",
+              style: {
+                // should not show selected style as inherited
+                fontWeight: { type: "keyword", value: "500" },
+              },
+            },
+          ],
+          children: [],
+        },
+      ],
+    },
+  ],
+};
+const selectedInstanceId = "3";
+
+test("compute cascaded styles", () => {
+  expect(getCascadedInfo(cssRules, cascadedBreakpointIds))
+    .toMatchInlineSnapshot(`
+    {
+      "height": {
+        "breakpointId": "1",
+        "value": {
+          "type": "unit",
+          "unit": "px",
+          "value": 50,
+        },
+      },
+      "width": {
+        "breakpointId": "2",
+        "value": {
+          "type": "unit",
+          "unit": "px",
+          "value": 200,
+        },
+      },
+    }
+  `);
+});
+
+test("compute inherited styles", () => {
+  expect(
+    getInheritedInfo(rootInstance, selectedInstanceId, [
+      ...cascadedBreakpointIds,
+      selectedBreakpointId,
+    ])
+  ).toMatchInlineSnapshot(`
+    {
+      "fontSize": {
+        "instanceId": "1",
+        "value": {
+          "type": "unit",
+          "unit": "px",
+          "value": 20,
+        },
+      },
+      "fontWeight": {
+        "instanceId": "2",
+        "value": {
+          "type": "keyword",
+          "value": "600",
+        },
+      },
+    }
+  `);
+});

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -15,29 +15,29 @@ import {
   useSelectedInstanceData,
 } from "~/designer/shared/nano-states";
 
-type Cascaded = {
+type CascadedValueInfo = {
   breakpointId: string;
   value: StyleValue;
 };
 
-type CascadedInfo = {
-  [property in StyleProperty]?: Cascaded;
+type CascadedProperties = {
+  [property in StyleProperty]?: CascadedValueInfo;
 };
 
-type Inherited = {
+type InheritedValueInfo = {
   instanceId: string;
   value: StyleValue;
 };
 
-type InheritedInfo = {
-  [property in StyleProperty]?: Inherited;
+type InheritedProperties = {
+  [property in StyleProperty]?: InheritedValueInfo;
 };
 
 export type StyleValueInfo = {
   value: StyleValue;
   local?: StyleValue;
-  cascaded?: Cascaded;
-  inherited?: Inherited;
+  cascaded?: CascadedValueInfo;
+  inherited?: InheritedValueInfo;
 };
 
 export type StyleInfo = {
@@ -99,7 +99,7 @@ export const getCascadedInfo = (
       styles.set(rule.breakpoint, rule.style);
     }
   }
-  const cascadedStyle: CascadedInfo = {};
+  const cascadedStyle: CascadedProperties = {};
   for (const breakpointId of cascadedBreakpointIds) {
     const style = styles.get(breakpointId);
     if (style !== undefined) {
@@ -123,7 +123,7 @@ export const getInheritedInfo = (
   instanceId: string,
   cascadedAndSelectedBreakpoints: string[]
 ) => {
-  const inheritedStyle: InheritedInfo = {};
+  const inheritedStyle: InheritedProperties = {};
   const parents = utils.tree.getInstancePath(rootInstance, instanceId);
   for (const parentInstance of parents) {
     // skip current element

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -122,20 +122,20 @@ export const getInheritedInfo = (
   cascadedAndSelectedBreakpoints: string[]
 ) => {
   const inheritedStyle: InheritedProperties = {};
-  const parents = utils.tree.getInstancePath(rootInstance, instanceId);
-  for (const parentInstance of parents) {
+  const ancestors = utils.tree.getInstancePath(rootInstance, instanceId);
+  for (const ancestorInstance of ancestors) {
     // skip current element
-    if (parentInstance.id === instanceId) {
+    if (ancestorInstance.id === instanceId) {
       continue;
     }
     const cascadedStyle = getCascadedInfo(
-      parentInstance.cssRules,
+      ancestorInstance.cssRules,
       cascadedAndSelectedBreakpoints
     );
     for (const [property, cascaded] of Object.entries(cascadedStyle)) {
       if (cascaded !== undefined && inheritableProperties.has(property)) {
         inheritedStyle[property as StyleProperty] = {
-          instanceId: parentInstance.id,
+          instanceId: ancestorInstance.id,
           value: cascaded.value,
         };
       }

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -1,9 +1,43 @@
-import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
+import type {
+  Breakpoint,
+  CssRule,
+  Style,
+  StyleProperty,
+  StyleValue,
+} from "@webstudio-is/css-data";
+import { properties } from "@webstudio-is/css-data";
+import { utils } from "@webstudio-is/project";
+import { Instance } from "@webstudio-is/react-sdk";
 import { useMemo } from "react";
+import {
+  useSelectedBreakpoint,
+  useSelectedInstanceData,
+} from "~/designer/shared/nano-states";
+import { useBreakpoints, useRootInstance } from "~/shared/nano-states";
+
+type Cascaded = {
+  breakpointId: string;
+  value: StyleValue;
+};
+
+type CascadedInfo = {
+  [property in StyleProperty]?: Cascaded;
+};
+
+type Inherited = {
+  instanceId: string;
+  value: StyleValue;
+};
+
+type InheritedInfo = {
+  [property in StyleProperty]?: Inherited;
+};
 
 export type StyleValueInfo = {
   value: StyleValue;
   local?: StyleValue;
+  cascaded?: Cascaded;
+  inherited?: Inherited;
 };
 
 export type StyleInfo = {
@@ -23,6 +57,98 @@ export const getStyleSource = (
   return "preset";
 };
 
+const styleProperties = Object.keys(properties) as StyleProperty[];
+const inheritableProperties = new Set<string>();
+for (const [property, value] of Object.entries(properties)) {
+  if (value.inherited) {
+    inheritableProperties.add(property);
+  }
+}
+
+/**
+ * find all breakpoints which may affect current view
+ */
+export const getCascadedBreakpointIds = (
+  breakpoints: Breakpoint[],
+  selectedBreakpointId?: string
+) => {
+  const sortedBreakpoints = breakpoints
+    .slice()
+    .sort((a, b) => a.minWidth - b.minWidth);
+  const cascadedBreakpointIds: string[] = [];
+  for (const breakpoint of sortedBreakpoints) {
+    if (breakpoint.id === selectedBreakpointId) {
+      break;
+    }
+    cascadedBreakpointIds.push(breakpoint.id);
+  }
+  return cascadedBreakpointIds;
+};
+
+/**
+ * extract all styles from breakpoints
+ * affecting current view
+ */
+export const getCascadedInfo = (
+  cssRules: CssRule[],
+  cascadedBreakpointIds: string[]
+) => {
+  const styles = new Map<string, Style>();
+  for (const rule of cssRules) {
+    if (rule.breakpoint !== undefined) {
+      styles.set(rule.breakpoint, rule.style);
+    }
+  }
+  const cascadedStyle: CascadedInfo = {};
+  for (const breakpointId of cascadedBreakpointIds) {
+    const style = styles.get(breakpointId);
+    if (style !== undefined) {
+      for (const [property, value] of Object.entries(style)) {
+        cascadedStyle[property as StyleProperty] = {
+          breakpointId,
+          value,
+        };
+      }
+    }
+  }
+  return cascadedStyle;
+};
+
+/**
+ * extract all inheritable styles from ancestor instances
+ * including active breakpoints
+ */
+export const getInheritedInfo = (
+  rootInstance: Instance,
+  instanceId: string,
+  cascadedAndSelectedBreakpoints: string[]
+) => {
+  const inheritedStyle: InheritedInfo = {};
+  const parents = utils.tree.getInstancePath(rootInstance, instanceId);
+  for (const parentInstance of parents) {
+    // skip current element
+    if (parentInstance.id === instanceId) {
+      continue;
+    }
+    const cascadedStyle = getCascadedInfo(
+      parentInstance.cssRules,
+      cascadedAndSelectedBreakpoints
+    );
+    for (const [property, cascaded] of Object.entries(cascadedStyle)) {
+      if (cascaded !== undefined && inheritableProperties.has(property)) {
+        inheritedStyle[property as StyleProperty] = {
+          instanceId: parentInstance.id,
+          value: cascaded.value,
+        };
+      }
+    }
+  }
+  return inheritedStyle;
+};
+
+/**
+ * combine all local, cascaded, inherited and browser styles
+ */
 export const useStyleInfo = ({
   localStyle,
   browserStyle,
@@ -30,24 +156,65 @@ export const useStyleInfo = ({
   localStyle: Style;
   browserStyle?: Style;
 }) => {
+  const [breakpoints] = useBreakpoints();
+  const [selectedBreakpoint] = useSelectedBreakpoint();
+  const selectedBreakpointId = selectedBreakpoint?.id;
+  const [selectedInstanceData] = useSelectedInstanceData();
+  const selectedInstanceId = selectedInstanceData?.id;
+  const selectedInstanceCssRules = selectedInstanceData?.cssRules;
+  const [rootInstance] = useRootInstance();
+
+  const cascadedBreakpointIds = useMemo(
+    () => getCascadedBreakpointIds(breakpoints, selectedBreakpointId),
+    [breakpoints, selectedBreakpointId]
+  );
+
+  const inheritedInfo = useMemo(() => {
+    if (
+      rootInstance === undefined ||
+      selectedBreakpointId === undefined ||
+      selectedInstanceId === undefined
+    ) {
+      return {};
+    }
+    return getInheritedInfo(rootInstance, selectedInstanceId, [
+      ...cascadedBreakpointIds,
+      selectedBreakpointId,
+    ]);
+  }, [
+    rootInstance,
+    cascadedBreakpointIds,
+    selectedBreakpointId,
+    selectedInstanceId,
+  ]);
+
+  const cascadedInfo = useMemo(() => {
+    if (selectedInstanceCssRules === undefined) {
+      return {};
+    }
+    return getCascadedInfo(selectedInstanceCssRules, cascadedBreakpointIds);
+  }, [selectedInstanceCssRules, cascadedBreakpointIds]);
+
   const styleInfoData = useMemo(() => {
     const styleInfoData: StyleInfo = {};
-    // temporary solution until we start computing all styles from data
-    if (browserStyle) {
-      for (const [property, value] of Object.entries(browserStyle)) {
-        styleInfoData[property as StyleProperty] = {
+    for (const property of styleProperties) {
+      // temporary solution until we start computing all styles from data
+      const computed = browserStyle?.[property];
+      const inherited = inheritedInfo[property];
+      const cascaded = cascadedInfo[property];
+      const local = localStyle[property];
+      const value = local ?? cascaded?.value ?? inherited?.value ?? computed;
+      if (value) {
+        styleInfoData[property] = {
           value,
+          local,
+          cascaded,
+          inherited,
         };
       }
     }
-    for (const [property, value] of Object.entries(localStyle)) {
-      styleInfoData[property as StyleProperty] = {
-        value,
-        local: value,
-      };
-    }
     return styleInfoData;
-  }, [browserStyle, localStyle]);
+  }, [browserStyle, inheritedInfo, cascadedInfo, localStyle]);
 
   return styleInfoData;
 };

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -72,9 +72,7 @@ export const getCascadedBreakpointIds = (
   breakpoints: Breakpoint[],
   selectedBreakpointId?: string
 ) => {
-  const sortedBreakpoints = breakpoints
-    .slice()
-    .sort((a, b) => a.minWidth - b.minWidth);
+  const sortedBreakpoints = utils.breakpoints.sort(breakpoints);
   const cascadedBreakpointIds: string[] = [];
   for (const breakpoint of sortedBreakpoints) {
     if (breakpoint.id === selectedBreakpointId) {

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import type {
   Breakpoint,
   CssRule,
@@ -7,13 +8,12 @@ import type {
 } from "@webstudio-is/css-data";
 import { properties } from "@webstudio-is/css-data";
 import { utils } from "@webstudio-is/project";
-import { Instance } from "@webstudio-is/react-sdk";
-import { useMemo } from "react";
+import type { Instance } from "@webstudio-is/react-sdk";
+import { useBreakpoints, useRootInstance } from "~/shared/nano-states";
 import {
   useSelectedBreakpoint,
   useSelectedInstanceData,
 } from "~/designer/shared/nano-states";
-import { useBreakpoints, useRootInstance } from "~/shared/nano-states";
 
 type Cascaded = {
   breakpointId: string;

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -119,7 +119,8 @@ export const getCascadedInfo = (
 export const getInheritedInfo = (
   rootInstance: Instance,
   instanceId: string,
-  cascadedAndSelectedBreakpoints: string[]
+  cascadedBreakpointIds: string[],
+  selectedBreakpointId: string
 ) => {
   const inheritedStyle: InheritedProperties = {};
   const ancestors = utils.tree.getInstancePath(rootInstance, instanceId);
@@ -128,10 +129,10 @@ export const getInheritedInfo = (
     if (ancestorInstance.id === instanceId) {
       continue;
     }
-    const cascadedStyle = getCascadedInfo(
-      ancestorInstance.cssRules,
-      cascadedAndSelectedBreakpoints
-    );
+    const cascadedStyle = getCascadedInfo(ancestorInstance.cssRules, [
+      ...cascadedBreakpointIds,
+      selectedBreakpointId,
+    ]);
     for (const [property, cascaded] of Object.entries(cascadedStyle)) {
       if (cascaded !== undefined && inheritableProperties.has(property)) {
         inheritedStyle[property as StyleProperty] = {
@@ -175,10 +176,12 @@ export const useStyleInfo = ({
     ) {
       return {};
     }
-    return getInheritedInfo(rootInstance, selectedInstanceId, [
-      ...cascadedBreakpointIds,
-      selectedBreakpointId,
-    ]);
+    return getInheritedInfo(
+      rootInstance,
+      selectedInstanceId,
+      cascadedBreakpointIds,
+      selectedBreakpointId
+    );
   }, [
     rootInstance,
     cascadedBreakpointIds,


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/29 https://github.com/webstudio-is/webstudio-designer/issues/649

Now instead of showing computed styles which come from parent instances or other breakpoints we can show actual value we set there.

## Steps for reproduction

### Inherited styles

1. add Box to canvas
2. change font size on Body to 2rem
3. check Box font size

### Cascaded styles

1. add Box to canvas
2. change font weight on Box to 600
3. select tablet breakpoint
4. check Box font weight

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [x] hi @istarkov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
