### PR TITLE
Show remote style source in UI

### DIFF
--- a/apps/designer/app/designer/features/style-panel/controls/menu/menu-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/menu/menu-control.tsx
@@ -41,13 +41,20 @@ export const MenuControl = ({
       };
     })
     .filter((item) => item.icon);
+  let variant: "default" | "set" | "inherited" = "default";
+  if (styleSource === "local") {
+    variant = "set";
+  }
+  if (styleSource === "remote") {
+    variant = "inherited";
+  }
   return (
     <IconButtonWithMenu
+      variant={variant}
       icon={items.find(({ name }) => name === currentValue)?.icon}
       label={label}
       items={items}
       value={String(currentValue)}
-      isActive={styleSource === "local"}
       onChange={setValue}
       onHover={(value) => setValue(value, { isEphemeral: true })}
     />

--- a/apps/designer/app/designer/features/style-panel/controls/toggle/toggle-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/toggle/toggle-control.tsx
@@ -20,9 +20,12 @@ export const ToggleGroupControl = ({
   items = [],
   onValueChange,
 }: ToggleGroupControlProps) => {
-  let state: undefined | "set" = undefined;
+  let state: undefined | "set" | "inherited" = undefined;
   if (styleSource === "local") {
     state = "set";
+  }
+  if (styleSource === "remote") {
+    state = "inherited";
   }
   return (
     <ToggleGroup
@@ -55,7 +58,7 @@ const ToggleGroupControlItem = styled(ToggleGroupItem, {
       },
       inherited: {
         "&[data-state=on]": {
-          color: "$colors$orange4",
+          color: "$colors$orange11",
           backgroundColor: "$colors$orange4",
         },
       },

--- a/apps/designer/app/designer/features/style-panel/sections/layout/layout.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/layout.tsx
@@ -11,14 +11,16 @@ import { styleConfigByName } from "../../shared/configs";
 
 const LayoutSectionFlex = ({
   currentStyle,
+  setProperty,
+  deleteProperty,
   createBatchUpdate,
 }: {
   currentStyle: RenderCategoryProps["currentStyle"];
+  setProperty: RenderCategoryProps["setProperty"];
   deleteProperty: RenderCategoryProps["deleteProperty"];
   createBatchUpdate: RenderCategoryProps["createBatchUpdate"];
 }) => {
   const batchUpdate = createBatchUpdate();
-  const { setProperty, deleteProperty } = batchUpdate;
 
   const flexWrapValue = currentStyle.flexWrap?.value;
 
@@ -178,9 +180,10 @@ export const LayoutSection = ({
 
       {displayValue === "flex" || displayValue === "inline-flex" ? (
         <LayoutSectionFlex
+          currentStyle={currentStyle}
+          setProperty={setProperty}
           deleteProperty={deleteProperty}
           createBatchUpdate={createBatchUpdate}
-          currentStyle={currentStyle}
         />
       ) : (
         styleConfigsByCategory.map((entry) =>

--- a/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.tsx
@@ -33,6 +33,14 @@ export const FlexGrid = ({
   const isFlexDirectionColumn =
     flexDirection === "column" || flexDirection === "column-reverse";
 
+  let color = "$slate8";
+  if (styleSource === "local") {
+    color = "$blue9";
+  }
+  if (styleSource === "remote") {
+    color = "$orange9";
+  }
+
   return (
     <Grid
       css={{
@@ -46,7 +54,7 @@ export const FlexGrid = ({
         gap: "$spacing$1",
         gridTemplateColumns: "repeat(3, 1fr)",
         gridTemplateRows: "repeat(3, 1fr)",
-        color: styleSource === "local" ? "$colors$blue9" : "$colors$slate8",
+        color,
       }}
     >
       {Array.from(Array(gridSize * gridSize), (_, index) => {

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
@@ -42,9 +42,12 @@ const Cell = ({
     return null;
   }
 
-  let origin: "set" | "unset" = "unset";
+  let origin: "set" | "inherited" | "unset" = "unset";
   if (styleSource === "local") {
     origin = "set";
+  }
+  if (styleSource === "remote") {
+    origin = "inherited";
   }
 
   return (

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -418,6 +418,9 @@ export const CssValueInput = ({
   if (styleSource === "local") {
     state = "set" as const;
   }
+  if (styleSource === "remote") {
+    state = "inherited" as const;
+  }
   const prefix = icon && (
     <CssValueInputIconButton
       state={state}

--- a/apps/designer/app/designer/features/style-panel/shared/property-name.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/property-name.tsx
@@ -43,15 +43,18 @@ export const PropertyName = ({
       css={{
         fontWeight: "inherit",
         padding: "calc($spacing$3 / 2) $spacing$3",
-        ...(styleSource === "local"
-          ? {
-              color: "$blue11",
-              backgroundColor: "$colors$blue4",
-              borderRadius: "$borderRadius$4",
-            }
-          : {
-              color: "$hiContrast",
-            }),
+        borderRadius: "$borderRadius$4",
+        ...(styleSource === "local" && {
+          color: "$blue11",
+          backgroundColor: "$blue4",
+        }),
+        ...(styleSource === "remote" && {
+          color: "$orange11",
+          backgroundColor: "$orange4",
+        }),
+        ...(styleSource === "preset" && {
+          color: "$hiContrast",
+        }),
       }}
       htmlFor={property.toString()}
     >

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -49,6 +49,8 @@ export type StyleSource = "local" | "remote" | "preset";
 export const getStyleSource = (
   ...styleValueInfos: (undefined | StyleValueInfo)[]
 ): StyleSource => {
+  // show source to use if at least one of control properties matches
+  // so user could see if something is set or something is inherited
   for (const info of styleValueInfos) {
     if (info?.local) {
       return "local";

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -44,7 +44,7 @@ export type StyleInfo = {
   [property in StyleProperty]?: StyleValueInfo;
 };
 
-export type StyleSource = "local" | "preset";
+export type StyleSource = "local" | "remote" | "preset";
 
 export const getStyleSource = (
   ...styleValueInfos: (undefined | StyleValueInfo)[]
@@ -52,6 +52,11 @@ export const getStyleSource = (
   for (const info of styleValueInfos) {
     if (info?.local) {
       return "local";
+    }
+  }
+  for (const info of styleValueInfos) {
+    if (info?.cascaded !== undefined || info?.inherited !== undefined) {
+      return "remote";
     }
   }
   return "preset";
@@ -152,7 +157,7 @@ export const useStyleInfo = ({
   localStyle,
   browserStyle,
 }: {
-  localStyle: Style;
+  localStyle?: Style;
   browserStyle?: Style;
 }) => {
   const [breakpoints] = useBreakpoints();
@@ -203,7 +208,7 @@ export const useStyleInfo = ({
       const computed = browserStyle?.[property];
       const inherited = inheritedInfo[property];
       const cascaded = cascadedInfo[property];
-      const local = localStyle[property];
+      const local = localStyle?.[property];
       const value = local ?? cascaded?.value ?? inherited?.value ?? computed;
       if (value) {
         styleInfoData[property] = {

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -55,9 +55,7 @@ export const useStyleData = ({
     [selectedInstanceData?.cssRules, selectedBreakpoint]
   );
 
-  const [breakpointStyle, setBreakpointStyle] = useState(
-    () => cssRule?.style as Style
-  );
+  const [breakpointStyle, setBreakpointStyle] = useState(() => cssRule?.style);
 
   const currentStyle = useStyleInfo({
     localStyle: breakpointStyle,

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
 import warnOnce from "warn-once";
 import type { SelectedInstanceData, StyleUpdates } from "@webstudio-is/project";
-import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
+import type { StyleProperty, StyleValue } from "@webstudio-is/css-data";
 import { type Publish } from "~/shared/pubsub";
 import { useSelectedBreakpoint } from "~/designer/shared/nano-states";
 import { getCssRuleForBreakpoint } from "./get-css-rule-for-breakpoint";

--- a/packages/design-system/src/components/icon-button-with-menu.tsx
+++ b/packages/design-system/src/components/icon-button-with-menu.tsx
@@ -2,7 +2,7 @@ import { CheckIcon, IconComponent } from "@webstudio-is/icons";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { styled } from "../stitches.config";
 import { Tooltip } from "./tooltip";
-import { DeprecatedIconButton } from "./__DEPRECATED__/icon-button";
+import { IconButton } from "./icon-button";
 
 const StyledContent = styled(DropdownMenuPrimitive.Content, {
   width: 192,
@@ -46,29 +46,6 @@ const itemIndicatorStyle = {
   justifyContent: "center",
 };
 
-const iconButtonStyle = {
-  width: "$spacing$11",
-  height: "$spacing$11",
-  color: "$colors$gray12",
-  backgroundColor: "$colors$loContrast",
-  "&:focus-visible": {
-    outline: "none",
-    boxShadow: "inset 0 0 0 1px $colors$blue9, 0 0 0 1px $colors$blue9",
-  },
-};
-
-const iconButtonActiveStyle = {
-  color: "$colors$blue11",
-  backgroundColor: "$colors$blue4",
-  "&:hover,&:focus-visible": {
-    backgroundColor: "$colors$blue4",
-  },
-  "&:focus-visible": {
-    outline: "none",
-    boxShadow: "inset 0 0 0 1px $colors$blue9, 0 0 0 1px $colors$blue9",
-  },
-};
-
 const arrowStyle = {
   "& *": {
     fill: "$colors$gray4",
@@ -86,14 +63,15 @@ const StyledItemIndicator = styled(
 const StyledArrow = styled(DropdownMenuPrimitive.Arrow, arrowStyle);
 
 export const IconButtonWithMenu = ({
+  variant,
   icon: Icon,
   label,
   value,
   items,
-  isActive,
   onChange,
   onHover,
 }: {
+  variant: "default" | "preset" | "set" | "inherited" | "active";
   icon?: JSX.Element;
   label?: string;
   value: string;
@@ -102,7 +80,6 @@ export const IconButtonWithMenu = ({
     name: string;
     icon?: ReturnType<IconComponent>;
   }>;
-  isActive?: boolean;
   onChange?: (value: string) => void;
   onHover?: (value: string) => void;
 }) => {
@@ -114,14 +91,7 @@ export const IconButtonWithMenu = ({
         disableHoverableContent={true}
       >
         <DropdownMenuPrimitive.Trigger asChild>
-          <DeprecatedIconButton
-            css={{
-              ...iconButtonStyle,
-              ...(isActive && iconButtonActiveStyle),
-            }}
-          >
-            {Icon}
-          </DeprecatedIconButton>
+          <IconButton variant={variant}>{Icon}</IconButton>
         </DropdownMenuPrimitive.Trigger>
       </Tooltip>
       <DropdownMenuPrimitive.Portal>


### PR DESCRIPTION
Added remote (ex inherited) highlight for controls.
Migrated menu control to new icon button.

<img width="228" alt="Screenshot 2022-12-28 at 11 17 00" src="https://user-images.githubusercontent.com/5635476/209782189-9aa4b8e6-f7a6-4f90-9579-56a0c1d86bf7.png">
<img width="232" alt="Screenshot 2022-12-28 at 11 17 36" src="https://user-images.githubusercontent.com/5635476/209782191-6a84c61f-c0c5-4892-ae3b-0f8480f2d49d.png">
<img width="232" alt="Screenshot 2022-12-28 at 11 18 36" src="https://user-images.githubusercontent.com/5635476/209782192-e9ce0fcc-6d70-40c8-a2a7-91d7dea2f0a1.png">
<img width="219" alt="Screenshot 2022-12-28 at 11 24 46" src="https://user-images.githubusercontent.com/5635476/209782195-dc794dcb-2ac6-4703-8ecf-2fca511f4306.png">

## Code Review

- [ ] hi @kof, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
