### PR TITLE
Restrict assets uploading by MAX_ASSETS_PER_PROJECT env variable

### DIFF
--- a/apps/designer/.env.example
+++ b/apps/designer/.env.example
@@ -6,7 +6,7 @@ GH_CLIENT_ID=
 DEV_LOGIN=true
 
 # Restrictions
-MAX_ASSETS_PER_PROJECT=
+MAX_ASSETS_PER_PROJECT=50
 
 # relative to the public directory
 FILE_UPLOAD_PATH="uploads"

--- a/apps/designer/.env.example
+++ b/apps/designer/.env.example
@@ -5,6 +5,8 @@ GH_CLIENT_SECRET=
 GH_CLIENT_ID=
 DEV_LOGIN=true
 
+# Restrictions
+MAX_ASSETS_PER_PROJECT=
 
 # relative to the public directory
 FILE_UPLOAD_PATH="uploads"
@@ -32,7 +34,7 @@ PUBLISHER_TOKEN=
 # Will be detected automatically in development environments like localhost or preview deployment
 BUILD_ORIGIN=
 
-# If set to `true`, user-generated build will be available 
+# If set to `true`, user-generated build will be available
 # only at {project.domain} subdomain of {BUILD_ORIGIN}.
 # This is used in production deployment for security reasons.
 BUILD_REQUIRE_SUBDOMAIN=

--- a/apps/designer/app/designer/shared/assets/use-assets.tsx
+++ b/apps/designer/app/designer/shared/assets/use-assets.tsx
@@ -203,7 +203,7 @@ export const AssetsProvider = ({ children }: { children: ReactNode }) => {
       load(action);
     }
 
-    if (data.status === "error") {
+    if (data.status === "error" || data.errors !== undefined) {
       // We don't know what's wrong, remove uploading asset and wait for the load to fix it
       setAssetContainers(
         assetContainers.filter(
@@ -213,7 +213,10 @@ export const AssetsProvider = ({ children }: { children: ReactNode }) => {
         )
       );
 
-      return toastUnknownFieldErrors(normalizeErrors(data.errors), []);
+      return toastUnknownFieldErrors(
+        normalizeErrors(data.errors ?? "Could not upload an asset"),
+        []
+      );
     }
 
     warnOnce(

--- a/packages/asset-uploader/src/db/create.ts
+++ b/packages/asset-uploader/src/db/create.ts
@@ -59,7 +59,7 @@ export const createAssetWithLimit = async (
        * it's probable that the user can exceed the limit a little bit.
        * So it can be a little bit strange that the limit is 5 but the user already has 7.
        **/
-      throw new Error(`Max ${count} assets per project reached`);
+      throw new Error(`The maximum number of assets per project is ${count}.`);
     }
 
     /**
@@ -88,7 +88,7 @@ export const createAssetWithLimit = async (
 
     const asset = await uploadAsset();
 
-    const size = asset.size || 0;
+    const size = asset.size ?? 0;
     const { id, meta, format, name, location } = asset;
 
     const dbAsset = await prisma.asset.update({

--- a/packages/asset-uploader/src/db/create.ts
+++ b/packages/asset-uploader/src/db/create.ts
@@ -3,9 +3,12 @@ import {
   prisma,
   type Location,
   type Project,
+  type Asset,
 } from "@webstudio-is/prisma-client";
-import { type ImageMeta } from "../schema";
+import { Env, type ImageMeta } from "../schema";
 import { formatAsset } from "../utils/format-asset";
+
+const env = Env.parse(process.env);
 
 type BaseOptions = {
   id: string;
@@ -13,6 +16,7 @@ type BaseOptions = {
   size: number;
   location: Location;
   format: string;
+  status?: Asset["status"];
 };
 
 type Options =
@@ -22,28 +26,86 @@ type Options =
     } & BaseOptions)
   | ({ type: "font"; meta: FontMeta } & BaseOptions);
 
-const create = (projectId: Project["id"], options: Options) => {
-  const size = options.size || 0;
-  const { id, meta, format, name, location } = options;
-  return prisma.asset.create({
-    data: {
-      id,
-      location,
-      name,
-      size,
-      format,
-      projectId,
-      meta: JSON.stringify(meta),
-    },
-  });
-};
-
-// @todo this could be one aggregated query for perf.
-export const createMany = async (
+export const createAssetWithLimit = async (
   projectId: Project["id"],
-  values: Array<Options>
+  uploadAsset: () => Promise<Options>
 ) => {
-  const promisedData = values.map((options) => create(projectId, options));
-  const data = await Promise.all(promisedData);
-  return data.map(formatAsset);
+  let updated: { id: string } | undefined;
+
+  try {
+    /**
+     * sometimes for example on request timeout we don't know what happened to the "UPLOADING" asset,
+     * so we don't take into account assets with the "UPLOADING" status that were created more
+     * than UPLOADING_STALE_TIMEOUT milliseconds ago
+     **/
+    const UPLOADING_STALE_TIMEOUT = 1000 * 60 * 30; // 30 minutes
+
+    const count = await prisma.asset.count({
+      where: {
+        OR: [
+          { projectId, status: "UPLOADED" },
+          {
+            projectId,
+            status: "UPLOADING",
+            createdAt: { gt: new Date(Date.now() - UPLOADING_STALE_TIMEOUT) },
+          },
+        ],
+      },
+    });
+
+    if (count >= env.MAX_ASSETS_PER_PROJECT) {
+      throw new Error(`Max ${count} assets per project reached`);
+    }
+
+    /**
+     * Create a temporary "UPLOADING" asset, so it can be counted in the next query
+     * Assumptions:
+     * - it's possible to create more assets than MAX_ASSETS_PER_PROJECT,
+     *   but for now we assume that the time since the `count` query above and the `create` query below is negligible,
+     *   and some kind of rate limiting exists on API.
+     * Also no locking exists in Prisma, and no raw query locking like
+     * "SELECT id FROM "Project" where id=? FOR UPDATE;" is shareable between sqlite and postgres.
+     **/
+
+    updated = await prisma.asset.create({
+      data: {
+        projectId,
+        status: "UPLOADING",
+        format: "unknown",
+        location: "REMOTE",
+        name: "unknown",
+        size: 0,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    const asset = await uploadAsset();
+
+    const size = asset.size || 0;
+    const { id, meta, format, name, location } = asset;
+
+    const dbAsset = await prisma.asset.update({
+      where: { id: updated.id },
+      data: {
+        id,
+        location,
+        name,
+        size,
+        format,
+        projectId,
+        meta: JSON.stringify(meta),
+        status: "UPLOADED",
+      },
+    });
+
+    return formatAsset(dbAsset);
+  } catch (error) {
+    if (updated) {
+      await prisma.asset.delete({ where: { id: updated.id } });
+    }
+
+    throw error;
+  }
 };

--- a/packages/asset-uploader/src/db/create.ts
+++ b/packages/asset-uploader/src/db/create.ts
@@ -54,6 +54,11 @@ export const createAssetWithLimit = async (
     });
 
     if (count >= env.MAX_ASSETS_PER_PROJECT) {
+      /**
+       * Here is right to write `Max ${MAX_ASSETS_PER_PROJECT}` but see the comment below,
+       * it's probable that the user can exceed the limit a little bit.
+       * So it can be a little bit strange that the limit is 5 but the user already has 7.
+       **/
       throw new Error(`Max ${count} assets per project reached`);
     }
 

--- a/packages/asset-uploader/src/db/load.ts
+++ b/packages/asset-uploader/src/db/load.ts
@@ -10,7 +10,7 @@ export const loadByProject = async (
   }
 
   const assets = await prisma.asset.findMany({
-    where: { projectId },
+    where: { projectId, status: "UPLOADED" },
     orderBy: {
       createdAt: "desc",
     },

--- a/packages/asset-uploader/src/schema.ts
+++ b/packages/asset-uploader/src/schema.ts
@@ -15,6 +15,10 @@ const maxSize = z
   .transform(toBytes)
   .default(MAX_UPLOAD_SIZE);
 
+export const Env = z.object({
+  MAX_ASSETS_PER_PROJECT: z.string().default("50").transform(Number.parseFloat),
+});
+
 export const S3Env = z.object({
   S3_ENDPOINT: z.string(),
   S3_REGION: z.string(),

--- a/packages/asset-uploader/src/schema.ts
+++ b/packages/asset-uploader/src/schema.ts
@@ -35,7 +35,8 @@ export const FsEnv = z.object({
   FILE_UPLOAD_PATH: z.string().default(DEFAULT_UPLOAD_PATH),
 });
 
-const Location = z.union([z.literal("FS"), z.literal("REMOTE")]);
+export const Location = z.union([z.literal("FS"), z.literal("REMOTE")]);
+export type Location = z.infer<typeof Location>;
 
 const BaseAsset = z.object({
   id: z.string(),

--- a/packages/asset-uploader/src/targets/fs/upload.ts
+++ b/packages/asset-uploader/src/targets/fs/upload.ts
@@ -7,7 +7,7 @@ import {
 } from "@remix-run/node";
 import { Location } from "@webstudio-is/prisma-client";
 import { getAssetData } from "../../utils/get-asset-data";
-import { createMany } from "../../db";
+import { createAssetWithLimit } from "../../db";
 import { FILE_DIRECTORY } from "./file-path";
 import { Asset, idsFormDataFieldName } from "../../schema";
 import { getUniqueFilename } from "../../utils/get-unique-filename";
@@ -16,6 +16,11 @@ import { uuidHandler } from "../../utils/uuid-handler";
 
 const AssetsFromFs = z.array(z.instanceof(NodeOnDiskFile));
 const Ids = z.array(z.string().uuid());
+
+/**
+ * Do not change. Upload code assumes its 1.
+ */
+const MAX_FILES_PER_REQUEST = 1;
 
 export const uploadToFs = async ({
   request,
@@ -26,34 +31,41 @@ export const uploadToFs = async ({
   projectId: string;
   maxSize: number;
 }): Promise<Array<Asset>> => {
-  const uploadHandler = await unstableCreateFileUploadHandler({
-    maxPartSize: maxSize,
-    directory: FILE_DIRECTORY,
-    file: ({ filename }) => getUniqueFilename(sanitizeS3Key(filename)),
+  const asset = await createAssetWithLimit(projectId, async () => {
+    const uploadHandler = await unstableCreateFileUploadHandler({
+      maxPartSize: maxSize,
+      directory: FILE_DIRECTORY,
+      file: ({ filename }) => getUniqueFilename(sanitizeS3Key(filename)),
+    });
+
+    const formData = await unstableParseMultipartFormData(
+      request,
+      unstableComposeUploadHandlers(uploadHandler, uuidHandler)
+    );
+
+    const formDataImages = AssetsFromFs.parse(formData.getAll("image"));
+    const formDataFonts = AssetsFromFs.parse(formData.getAll("font"));
+    const formDataAll = [...formDataImages, ...formDataFonts].slice(
+      0,
+      MAX_FILES_PER_REQUEST
+    );
+    const ids = Ids.parse(formData.getAll(idsFormDataFieldName));
+
+    const assets = formDataAll.map(async (asset, index) =>
+      getAssetData({
+        id: ids[index],
+        type: formDataFonts.includes(asset) ? "font" : "image",
+        name: asset.name,
+        size: asset.size,
+        data: new Uint8Array(await asset.arrayBuffer()),
+        location: Location.FS,
+      })
+    );
+
+    const assetsData = await Promise.all(assets);
+
+    return assetsData[0];
   });
 
-  const formData = await unstableParseMultipartFormData(
-    request,
-    unstableComposeUploadHandlers(uploadHandler, uuidHandler)
-  );
-
-  const formDataImages = AssetsFromFs.parse(formData.getAll("image"));
-  const formDataFonts = AssetsFromFs.parse(formData.getAll("font"));
-  const formDataAll = [...formDataImages, ...formDataFonts];
-  const ids = Ids.parse(formData.getAll(idsFormDataFieldName));
-
-  const assets = formDataAll.map(async (asset, index) =>
-    getAssetData({
-      id: ids[index],
-      type: formDataFonts.includes(asset) ? "font" : "image",
-      name: asset.name,
-      size: asset.size,
-      data: new Uint8Array(await asset.arrayBuffer()),
-      location: Location.FS,
-    })
-  );
-
-  const assetsData = await Promise.all(assets);
-
-  return await createMany(projectId, assetsData);
+  return [asset];
 };

--- a/packages/asset-uploader/src/targets/s3/upload.ts
+++ b/packages/asset-uploader/src/targets/s3/upload.ts
@@ -11,7 +11,7 @@ import { Location } from "@webstudio-is/prisma-client";
 import { S3Env } from "../../schema";
 import { toUint8Array } from "../../utils/to-uint8-array";
 import { getAssetData } from "../../utils/get-asset-data";
-import { createMany } from "../../db";
+import { createAssetWithLimit } from "../../db";
 import { idsFormDataFieldName, type Asset } from "../../schema";
 import { getUniqueFilename } from "../../utils/get-unique-filename";
 import { getS3Client } from "./client";
@@ -23,6 +23,10 @@ const AssetsUploadedSuccess = z.object({
 });
 
 const Ids = z.array(z.string().uuid());
+
+/**
+ * Do not change. Upload code assumes its 1.
+ */
 const MAX_FILES_PER_REQUEST = 1;
 
 export const uploadToS3 = async ({
@@ -34,32 +38,36 @@ export const uploadToS3 = async ({
   projectId: string;
   maxSize: number;
 }): Promise<Array<Asset>> => {
-  const uploadHandler = createUploadHandler(MAX_FILES_PER_REQUEST);
+  const asset = await createAssetWithLimit(projectId, async () => {
+    const uploadHandler = createUploadHandler(MAX_FILES_PER_REQUEST);
 
-  const formData = await unstableCreateFileUploadHandler(
-    request,
-    unstableComposeUploadHandlers(
-      (file: UploadHandlerPart) =>
-        uploadHandler({
-          file,
-          maxSize,
-        }),
-      uuidHandler
-    )
-  );
+    const formData = await unstableCreateFileUploadHandler(
+      request,
+      unstableComposeUploadHandlers(
+        (file: UploadHandlerPart) =>
+          uploadHandler({
+            file,
+            maxSize,
+          }),
+        uuidHandler
+      )
+    );
 
-  const imagesFormData = formData.getAll("image") as Array<string>;
-  const fontsFormData = formData.getAll("font") as Array<string>;
-  const ids = Ids.parse(formData.getAll(idsFormDataFieldName));
+    const imagesFormData = formData.getAll("image") as Array<string>;
+    const fontsFormData = formData.getAll("font") as Array<string>;
+    const ids = Ids.parse(formData.getAll(idsFormDataFieldName));
 
-  const assetsData = [...imagesFormData, ...fontsFormData]
-    .slice(0, MAX_FILES_PER_REQUEST)
-    .map((dataString, i) => {
-      // @todo validate with zod
-      return { ...JSON.parse(dataString), id: ids[i] };
-    });
+    const assetsData = [...imagesFormData, ...fontsFormData]
+      .slice(0, MAX_FILES_PER_REQUEST)
+      .map((dataString, i) => {
+        // @todo validate with zod
+        return { ...JSON.parse(dataString), id: ids[i] };
+      });
 
-  return await createMany(projectId, assetsData);
+    return assetsData[0];
+  });
+
+  return [asset];
 };
 
 const createUploadHandler = (maxFiles: number) => {

--- a/packages/asset-uploader/src/targets/s3/upload.ts
+++ b/packages/asset-uploader/src/targets/s3/upload.ts
@@ -10,7 +10,7 @@ import { Upload } from "@aws-sdk/lib-storage";
 import { Location } from "@webstudio-is/prisma-client";
 import { S3Env } from "../../schema";
 import { toUint8Array } from "../../utils/to-uint8-array";
-import { getAssetData } from "../../utils/get-asset-data";
+import { getAssetData, AssetData } from "../../utils/get-asset-data";
 import { createAssetWithLimit } from "../../db";
 import { idsFormDataFieldName, type Asset } from "../../schema";
 import { getUniqueFilename } from "../../utils/get-unique-filename";
@@ -60,8 +60,7 @@ export const uploadToS3 = async ({
     const assetsData = [...imagesFormData, ...fontsFormData]
       .slice(0, MAX_FILES_PER_REQUEST)
       .map((dataString, index) => {
-        // @todo validate with zod
-        return { ...JSON.parse(dataString), id: ids[index] };
+        return AssetData.parse({ ...JSON.parse(dataString), id: ids[index] });
       });
 
     return assetsData[0];

--- a/packages/asset-uploader/src/targets/s3/upload.ts
+++ b/packages/asset-uploader/src/targets/s3/upload.ts
@@ -59,9 +59,9 @@ export const uploadToS3 = async ({
 
     const assetsData = [...imagesFormData, ...fontsFormData]
       .slice(0, MAX_FILES_PER_REQUEST)
-      .map((dataString, i) => {
+      .map((dataString, index) => {
         // @todo validate with zod
-        return { ...JSON.parse(dataString), id: ids[i] };
+        return { ...JSON.parse(dataString), id: ids[index] };
       });
 
     return assetsData[0];

--- a/packages/asset-uploader/src/utils/get-asset-data.ts
+++ b/packages/asset-uploader/src/utils/get-asset-data.ts
@@ -1,28 +1,31 @@
-import { Location } from "@webstudio-is/prisma-client";
+import { z } from "zod";
+
 import sharp from "sharp";
-import { type ImageMeta } from "../schema";
-import { type FontMeta } from "@webstudio-is/fonts";
+import { Location, ImageMeta } from "../schema";
+import { FontMeta } from "@webstudio-is/fonts";
 import { getFontData } from "@webstudio-is/fonts/server";
 
-type BaseData = {
-  id: string;
-  name: string;
-  size: number;
-  location: Location;
-  format: string;
-};
+const BaseData = z.object({
+  id: z.string(),
+  name: z.string(),
+  size: z.number(),
+  location: Location,
+  format: z.string(),
+});
 
-type ImageData = BaseData & {
-  type: "image";
-  meta: ImageMeta;
-};
+const ImageData = BaseData.extend({
+  type: z.literal("image"),
+  meta: ImageMeta,
+});
 
-type FontData = BaseData & {
-  type: "font";
-  meta: FontMeta;
-};
+const FontData = BaseData.extend({
+  type: z.literal("font"),
+  meta: FontMeta,
+});
 
-export type AssetData = ImageData | FontData;
+export const AssetData = z.union([ImageData, FontData]);
+
+export type AssetData = z.infer<typeof AssetData>;
 
 type BaseAssetOptions = {
   id: string;


### PR DESCRIPTION
Set at VERCEL env 
<img width="930" alt="image" src="https://user-images.githubusercontent.com/5077042/209917100-86d1f7e9-a5ca-4aaa-a877-456850fa5153.png">


## Description

Restrict assets by MAX_ASSETS_PER_PROJECT env variable.

## Steps for reproduction

- [x] - set MAX_ASSETS_PER_PROJECT = 4 as env variable for Vercel

Try upload more than 4 files.
Get Error: "`Max ${count} assets per project reached`"

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @TrySound plz check code

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [x] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory


