### PR TITLE
Fix css input (scrub, etc) Beautify options and input for css-value-input

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -484,7 +484,7 @@ export const CssValueInput = ({
             }}
             onBlur={handleOnBlur}
             onKeyDown={handleKeyDown}
-            baseRef={scrubRef}
+            containerRef={scrubRef}
             inputRef={inputRef}
             name={property}
             state={value.type === "invalid" ? "invalid" : undefined}

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -32,6 +32,7 @@ import { parseIntermediateOrInvalidValue } from "./parse-intermediate-or-invalid
 import { toValue } from "@webstudio-is/css-engine";
 import { useDebouncedCallback } from "use-debounce";
 import type { StyleSource } from "../style-info";
+import { toPascalCaseNoDashes } from "./keyword-utils";
 
 // We increment by 10 when shift is pressed, by 0.1 when alt/option is pressed and by 1 by default.
 const calcNumberChange = (
@@ -228,20 +229,6 @@ const initialValue: IntermediateStyleValue = {
   value: "",
 };
 
-const keywordToLabel = (keyword: KeywordValue) => {
-  const { value } = keyword;
-
-  const label = value
-    .replace(/-/g, " ")
-    .split(" ")
-    .map((word) => {
-      return word[0].toUpperCase() + word.slice(1);
-    })
-    .join(" ");
-
-  return label;
-};
-
 /**
  * Common:
  * - Free text editing
@@ -317,7 +304,7 @@ export const CssValueInput = ({
     item === null
       ? ""
       : item.type === "keyword"
-      ? keywordToLabel(item)
+      ? toPascalCaseNoDashes(item.value)
       : item.type === "intermediate" || item.type === "unit"
       ? String(item.value)
       : toValue(item);

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -32,7 +32,7 @@ import { parseIntermediateOrInvalidValue } from "./parse-intermediate-or-invalid
 import { toValue } from "@webstudio-is/css-engine";
 import { useDebouncedCallback } from "use-debounce";
 import type { StyleSource } from "../style-info";
-import { toPascalCaseNoDashes } from "./keyword-utils";
+import { toPascalCase } from "./keyword-utils";
 
 // We increment by 10 when shift is pressed, by 0.1 when alt/option is pressed and by 1 by default.
 const calcNumberChange = (
@@ -304,7 +304,7 @@ export const CssValueInput = ({
     item === null
       ? ""
       : item.type === "keyword"
-      ? toPascalCaseNoDashes(item.value)
+      ? toPascalCase(item.value)
       : item.type === "intermediate" || item.type === "unit"
       ? String(item.value)
       : toValue(item);

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -228,6 +228,20 @@ const initialValue: IntermediateStyleValue = {
   value: "",
 };
 
+const keywordToLabel = (keyword: KeywordValue) => {
+  const { value } = keyword;
+
+  const label = value
+    .replace(/-/g, " ")
+    .split(" ")
+    .map((word) => {
+      return word[0].toUpperCase() + word.slice(1);
+    })
+    .join(" ");
+
+  return label;
+};
+
 /**
  * Common:
  * - Free text editing
@@ -299,6 +313,15 @@ export const CssValueInput = ({
     });
   };
 
+  const itemToString = (item: CssValueInputValue | null) =>
+    item === null
+      ? ""
+      : item.type === "keyword"
+      ? keywordToLabel(item)
+      : item.type === "intermediate" || item.type === "unit"
+      ? String(item.value)
+      : toValue(item);
+
   const {
     items,
     getInputProps,
@@ -312,12 +335,7 @@ export const CssValueInput = ({
     items: keywords,
     value,
     selectedItem: props.value,
-    itemToString: (item) =>
-      item === null
-        ? ""
-        : item.type === "intermediate" || item.type === "unit"
-        ? String(item.value)
-        : toValue(item),
+    itemToString,
     onInputChange: (inputValue) => {
       onChange(inputValue);
     },
@@ -487,7 +505,7 @@ export const CssValueInput = ({
                   {...getItemProps({ item, index })}
                   key={index}
                 >
-                  {item.type === "intermediate" ? item.value : toValue(item)}
+                  {itemToString(item)}
                 </ComboboxListboxItem>
               ))}
           </ComboboxListbox>

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -1,3 +1,4 @@
+import { matchSorter } from "match-sorter";
 import {
   Box,
   TextField,
@@ -229,6 +230,24 @@ const initialValue: IntermediateStyleValue = {
   value: "",
 };
 
+const itemToString = (item: CssValueInputValue | null) =>
+  item === null
+    ? ""
+    : item.type === "keyword"
+    ? toPascalCase(item.value)
+    : item.type === "intermediate" || item.type === "unit"
+    ? String(item.value)
+    : toValue(item);
+
+const match = <Item,>(
+  search: string,
+  items: Array<Item>,
+  itemToString: (item: Item | null) => string
+) =>
+  matchSorter(items, search, {
+    keys: [itemToString, (item) => itemToString(item).replace(/\s/g, "-")],
+  });
+
 /**
  * Common:
  * - Free text editing
@@ -300,15 +319,6 @@ export const CssValueInput = ({
     });
   };
 
-  const itemToString = (item: CssValueInputValue | null) =>
-    item === null
-      ? ""
-      : item.type === "keyword"
-      ? toPascalCase(item.value)
-      : item.type === "intermediate" || item.type === "unit"
-      ? String(item.value)
-      : toValue(item);
-
   const {
     items,
     getInputProps,
@@ -323,6 +333,7 @@ export const CssValueInput = ({
     value,
     selectedItem: props.value,
     itemToString,
+    match,
     onInputChange: (inputValue) => {
       onChange(inputValue);
     },

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/keyword-utils.test.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/keyword-utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect } from "@jest/globals";
+import { toKebabCase } from "./keyword-utils";
+
+describe("toKebabCase", () => {
+  test("PascalCase", () => {
+    expect(toKebabCase("PascalCase")).toEqual("pascal-case");
+  });
+
+  test("Pascal Case", () => {
+    expect(toKebabCase("Pascal Case")).toEqual("pascal-case");
+    expect(toKebabCase("Pascal  Case")).toEqual("pascal-case");
+  });
+
+  test("Pascal Case", () => {
+    expect(toKebabCase("Pascal Case")).toEqual("pascal-case");
+    expect(toKebabCase("Pascal  Case")).toEqual("pascal-case");
+  });
+
+  test("camelCase", () => {
+    expect(toKebabCase("camelCase")).toEqual("camel-case");
+  });
+
+  test("camel Case", () => {
+    expect(toKebabCase("camel Case")).toEqual("camel-case");
+  });
+
+  test("kebab-case", () => {
+    expect(toKebabCase("kebab-case")).toEqual("kebab-case");
+  });
+
+  test("not touches numerics", () => {
+    expect(toKebabCase("02020px")).toEqual("02020px");
+  });
+});

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/keyword-utils.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/keyword-utils.ts
@@ -2,7 +2,7 @@
  * Beautify a CSS keyword by capitalizing the first letter of each word,
  * and replacing dashes with spaces.
  */
-export const toPascalCaseNoDashes = (keyword: string) => {
+export const toPascalCase = (keyword: string) => {
   const label = keyword
     .replace(/-/g, " ")
     .split(" ")

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/keyword-utils.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/keyword-utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Beautify a CSS keyword by capitalizing the first letter of each word,
+ * and replacing dashes with spaces.
+ */
+export const toPascalCaseNoDashes = (keyword: string) => {
+  const label = keyword
+    .replace(/-/g, " ")
+    .split(" ")
+    .map((word) => {
+      return word[0].toUpperCase() + word.slice(1);
+    })
+    .join(" ");
+
+  return label;
+};
+
+/**
+ * Try to transform something from Pascal Case / Pascal Case / camelCase / camel Case to kebab-case
+ */
+export const toKebabCase = (keyword: string) => {
+  const label = keyword
+    .trim()
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/\s+/g, "-")
+    .toLowerCase();
+
+  return label;
+};

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
@@ -4,18 +4,15 @@ import type {
   InvalidValue,
 } from "@webstudio-is/css-data";
 import type { IntermediateStyleValue } from "./css-value-input";
-
 import { parseCssValue } from "../parse-css-value";
-
 import { evaluateMath } from "./evaluate-math";
 import { units } from "@webstudio-is/css-data";
+import { toKebabCase } from "./keyword-utils";
 
 export const parseIntermediateOrInvalidValue = (
   property: StyleProperty,
   value: IntermediateStyleValue | InvalidValue
 ): StyleValue => {
-  console.log(value);
-
   // Try value with existing or fallback unit
   const unit = "unit" in value ? value.unit ?? "px" : "px";
   let styleInput = parseCssValue(property, `${value.value}${unit}`);
@@ -26,6 +23,13 @@ export const parseIntermediateOrInvalidValue = (
 
   // Probably value is already valid, use it
   styleInput = parseCssValue(property, value.value);
+
+  if (styleInput.type !== "invalid") {
+    return styleInput;
+  }
+
+  // Probably in kebab-case value will be valid
+  styleInput = parseCssValue(property, toKebabCase(value.value));
 
   if (styleInput.type !== "invalid") {
     return styleInput;

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/parse-intermediate-or-invalid-value.ts
@@ -14,6 +14,8 @@ export const parseIntermediateOrInvalidValue = (
   property: StyleProperty,
   value: IntermediateStyleValue | InvalidValue
 ): StyleValue => {
+  console.log(value);
+
   // Try value with existing or fallback unit
   const unit = "unit" in value ? value.unit ?? "px" : "px";
   let styleInput = parseCssValue(property, `${value.value}${unit}`);

--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -6,6 +6,7 @@ import {
   type ForwardRefRenderFunction,
   useEffect,
   useRef,
+  type ChangeEvent,
 } from "react";
 import { CheckIcon, ChevronDownIcon } from "@webstudio-is/icons";
 import { Popper, PopperContent, PopperAnchor } from "@radix-ui/react-popper";
@@ -13,6 +14,7 @@ import {
   type DownshiftState,
   type UseComboboxStateChangeOptions,
   type UseComboboxProps as UseDownshiftComboboxProps,
+  type UseComboboxGetInputPropsOptions,
   useCombobox as useDownshiftCombobox,
 } from "downshift";
 import { matchSorter } from "match-sorter";
@@ -92,7 +94,7 @@ const defaultMatch = <Item,>(
   itemToString: (item: Item | null) => string
 ) =>
   matchSorter(items, search, {
-    keys: [(item) => itemToString(item)],
+    keys: [itemToString, (item) => itemToString(item).replace(/\s/g, "-")],
   });
 
 const useFilter = <Item,>({
@@ -198,7 +200,6 @@ export const useCombobox = <Item,>({
     onInputValueChange({ inputValue, type }) {
       if (type === comboboxStateChangeTypes.InputChange) {
         filter(inputValue);
-        onInputChange?.(inputValue);
       }
     },
     onSelectedItemChange({ selectedItem, type }) {
@@ -220,13 +221,30 @@ export const useCombobox = <Item,>({
     },
   });
 
-  const { getItemProps, highlightedIndex, getMenuProps } = downshiftProps;
+  const { getItemProps, highlightedIndex, getMenuProps, getInputProps } =
+    downshiftProps;
 
   useEffect(() => {
     if (isOpen === false) {
       resetFilter();
     }
   }, [isOpen, resetFilter]);
+
+  const enhancedGetInputProps = useCallback(
+    (options?: UseComboboxGetInputPropsOptions) => {
+      const inputProps = getInputProps(options);
+      return {
+        ...inputProps,
+        onChange: (event: ChangeEvent<HTMLInputElement>) => {
+          inputProps.onChange(event);
+          // If we want controllable input we need to call onInputChange here
+          // see https://github.com/downshift-js/downshift/issues/1108
+          onInputChange?.(event.target.value);
+        },
+      };
+    },
+    [getInputProps, onInputChange]
+  );
 
   const enhancedGetItemProps = useCallback(
     (options) => {
@@ -259,6 +277,7 @@ export const useCombobox = <Item,>({
     items: filteredItems,
     getItemProps: enhancedGetItemProps,
     getMenuProps: enhancedGetMenuProps,
+    getInputProps: enhancedGetInputProps,
     resetFilter,
   };
 };

--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -94,7 +94,7 @@ const defaultMatch = <Item,>(
   itemToString: (item: Item | null) => string
 ) =>
   matchSorter(items, search, {
-    keys: [itemToString, (item) => itemToString(item).replace(/\s/g, "-")],
+    keys: [itemToString],
   });
 
 const useFilter = <Item,>({


### PR DESCRIPTION
## Description

ref #465 for css-value-input

Add beauty names to keywords, a little bit better search for keywords.

+ Fixes non-working scrub.
+ Fixes jumping cursor.


## Steps for reproduction

1.
Write `min-content` inside `width` field  - All options you see must have `Pascal Case`
Select value through menu - inputValue must be also in `Pascal Case`

2.
Edit width input, write `Min Content`, and click Enter - must be saved with `Min Content` value. 
(internally must be keyword with value=`min-content`) 

3.
Edit width input, write `min-content`, and click Enter - must be saved with `Min Content` value. 
(internally must be keyword with value=`min-content`) 

4. 
Write `min content`, click tab - must be saved with `Min Content` value. 
(internally must be keyword with value=`min-content`)

5. Edit input in any place of cursor it must not jump to the end.


## Code Review

- [ ] hi @kof, I need you to do
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [x] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
