### PR TITLE
Support option/shift in spacing's scrub

### DIFF
--- a/apps/designer/app/designer/features/style-panel/sections/spacing/input-popover.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/input-popover.tsx
@@ -74,7 +74,6 @@ const Input = ({
         setIntermediateValue(undefined);
         onChange({ operation: "set", property, value }, { isEphemeral: false });
 
-        // @todo: handle Esc
         if (reason === "blur" || reason === "enter") {
           onClosePopover();
         }

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/input-popover.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/input-popover.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useState } from "react";
+import { type ComponentProps, useState } from "react";
 import {
   keyframes,
   Popover,

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/input-popover.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/input-popover.tsx
@@ -51,7 +51,6 @@ const Input = ({
           return;
         }
 
-        setIntermediateValue(styleValue);
         if (styleValue.type !== "intermediate") {
           onChange(
             { operation: "set", property, value: styleValue },

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/input-popover.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/input-popover.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { ComponentProps, useState } from "react";
 import {
   keyframes,
   Popover,
@@ -7,13 +7,14 @@ import {
   PopoverPortal,
   styled,
 } from "@webstudio-is/design-system";
+import { StyleUpdate } from "@webstudio-is/project";
+import type { StyleProperty, StyleValue } from "@webstudio-is/css-data";
 import {
   CssValueInput,
   type IntermediateStyleValue,
 } from "../../shared/css-value-input";
-import type { StyleProperty, StyleValue } from "@webstudio-is/css-data";
-import type { StyleChangeHandler } from "./types";
 import type { StyleSource } from "../../shared/style-info";
+import { StyleUpdateOptions } from "../../shared/use-style-data";
 
 const slideUpAndFade = keyframes({
   "0%": { opacity: 0, transform: "scale(0.8)" },
@@ -30,7 +31,7 @@ const Input = ({
   styleSource: StyleSource;
   property: StyleProperty;
   value: StyleValue;
-  onChange: StyleChangeHandler;
+  onChange: (update: StyleUpdate, options: StyleUpdateOptions) => void;
   onClosePopover: () => void;
 }) => {
   const [intermediateValue, setIntermediateValue] = useState<
@@ -112,7 +113,7 @@ export const InputPopover = ({
   styleSource: StyleSource;
   property: StyleProperty;
   value: StyleValue;
-  onChange: StyleChangeHandler;
+  onChange: ComponentProps<typeof Input>["onChange"];
   isOpen: boolean;
   onClose: () => void;
 }) => {

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/layout.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/layout.tsx
@@ -223,7 +223,7 @@ const getPath = (property: SpacingStyleProperty) => {
 type LayoutProps = {
   onClick: () => void;
   onHover: (hoverTarget: HoverTagret | undefined) => void;
-  activeProperties?: SpacingStyleProperty[];
+  activeProperties?: ReadonlyArray<SpacingStyleProperty>;
   renderCell: (args: { property: SpacingStyleProperty }) => React.ReactNode;
 };
 

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/layout.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/layout.tsx
@@ -223,14 +223,14 @@ const getPath = (property: SpacingStyleProperty) => {
 type LayoutProps = {
   onClick: () => void;
   onHover: (hoverTarget: HoverTagret | undefined) => void;
-  activeProperty?: SpacingStyleProperty;
+  activeProperties?: SpacingStyleProperty[];
   renderCell: (args: { property: SpacingStyleProperty }) => React.ReactNode;
 };
 
 export const SpacingLayout = ({
   onClick,
   onHover,
-  activeProperty,
+  activeProperties,
   renderCell,
 }: LayoutProps) => {
   const outerClipId = useId();
@@ -244,7 +244,7 @@ export const SpacingLayout = ({
         onHover({ element: event.currentTarget, property })
       }
       onMouseLeave={() => onHover(undefined)}
-      isActive={activeProperty === property}
+      isActive={activeProperties?.includes(property)}
     />
   );
 

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/scrub.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/scrub.tsx
@@ -12,7 +12,7 @@ type ScrubStatus = {
 
   // Properties that should be affected on the next pointer move.
   // We keep track of these properties even when scrub is not active.
-  properties: SpacingStyleProperty[];
+  properties: ReadonlyArray<SpacingStyleProperty>;
 
   // When scrub is active, this contains ephemeral values for all properties
   // that have been affected during current scrub.
@@ -114,24 +114,28 @@ export const useScrub = (props: {
   };
 };
 
+const opposingGroups = [
+  ["paddingTop", "paddingBottom"],
+  ["paddingRight", "paddingLeft"],
+  ["marginTop", "marginBottom"],
+  ["marginRight", "marginLeft"],
+] as const;
+
+const circleGroups = [
+  ["paddingTop", "paddingRight", "paddingBottom", "paddingLeft"],
+  ["marginTop", "marginRight", "marginBottom", "marginLeft"],
+] as const;
+
 const getModifiersGroup = (
   property: SpacingStyleProperty,
   modifiers: { shiftKey: boolean; altKey: boolean }
 ) => {
-  let groups: SpacingStyleProperty[][] = [];
+  let groups: ReadonlyArray<ReadonlyArray<SpacingStyleProperty>> = [];
 
   if (modifiers.shiftKey) {
-    groups = [
-      ["paddingTop", "paddingRight", "paddingBottom", "paddingLeft"],
-      ["marginTop", "marginRight", "marginBottom", "marginLeft"],
-    ];
+    groups = circleGroups;
   } else if (modifiers.altKey) {
-    groups = [
-      ["paddingTop", "paddingBottom"],
-      ["paddingRight", "paddingLeft"],
-      ["marginTop", "marginBottom"],
-      ["marginRight", "marginLeft"],
-    ];
+    groups = opposingGroups;
   }
 
   return groups.find((group) => group.includes(property)) ?? [property];

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/scrub.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/scrub.tsx
@@ -1,30 +1,48 @@
 import type { StyleValue, UnitValue } from "@webstudio-is/css-data";
 import { numericScrubControl } from "@webstudio-is/design-system";
 import { useState, useEffect, useRef } from "react";
-import type {
-  StyleChangeHandler,
-  SpacingStyleProperty,
-  HoverTagret,
-} from "./types";
+import { StyleUpdateOptions } from "../../shared/use-style-data";
+import type { SpacingStyleProperty, HoverTagret } from "./types";
 
-type ScrubStatus =
-  | { isActive: false }
-  | { isActive: true; property: SpacingStyleProperty; value: UnitValue };
+type Values = Partial<Record<SpacingStyleProperty, StyleValue>>;
+
+type ScrubStatus = {
+  isActive: boolean;
+
+  // Properties that should be affected on the next pointer move.
+  // We keep track of these properties even when scrub is not active.
+  properties: SpacingStyleProperty[];
+
+  // When scrub is active, this contains ephemeral values for all properties
+  // that have been affected during current scrub.
+  //
+  // When scrub is not active, this contains the final values of properties
+  // from the last scrub. (@todo: remove this if not used)
+  values: Values;
+};
 
 export const useScrub = (props: {
   value?: StyleValue;
   target: HoverTagret | undefined;
-  onChange: StyleChangeHandler;
+  onChange: (values: Values, options: StyleUpdateOptions) => void;
 }): ScrubStatus => {
   // we want to hold on to the target while scrub is active even if hover changes
   const [activeTarget, setActiveTarget] = useState<HoverTagret>();
   const finalTarget = activeTarget ?? props.target;
 
-  const [value, setValue] = useState<UnitValue>();
+  const modifiers = useModifierKeys();
+
+  const properties =
+    finalTarget === undefined
+      ? []
+      : getModifiersGroup(finalTarget.property, modifiers);
+
+  const [values, setValues] = useState<Values>({});
 
   // we need this in useEffect, but don't want it as a dependency
-  const latestProps = useRef(props);
-  latestProps.current = props;
+  // @todo: better name or split
+  const ref = useRef({ props, values, properties });
+  ref.current = { props, values, properties };
 
   const unitRef = useRef<UnitValue["unit"]>();
 
@@ -35,56 +53,48 @@ export const useScrub = (props: {
 
     const property = finalTarget.property;
 
+    const handleChange = (event: { value: number }, isEphemeral: boolean) => {
+      // for TypeScript
+      if (unitRef.current === undefined) {
+        return;
+      }
+
+      const value = {
+        type: "unit",
+        value: event.value,
+        unit: unitRef.current,
+      } as const;
+
+      const nextValues = { ...ref.current.values };
+      for (const property of ref.current.properties) {
+        nextValues[property] = value;
+      }
+      setValues(nextValues);
+
+      ref.current.props.onChange(nextValues, { isEphemeral });
+    };
+
     const scrub = numericScrubControl(finalTarget.element, {
       direction:
         property.endsWith("Left") || property.endsWith("Right")
           ? "horizontal"
           : "vertical",
       getValue() {
-        const { value } = latestProps.current;
+        const { value } = ref.current.props;
         if (value?.type === "unit") {
           unitRef.current = value.unit;
           return value.value;
         }
       },
       onValueInput(event) {
-        // for TypeScript
-        if (unitRef.current === undefined) {
-          return;
-        }
-
-        const value = {
-          type: "unit",
-          value: event.value,
-          unit: unitRef.current,
-        } as const;
-
-        setValue(value);
-        latestProps.current.onChange(
-          { operation: "set", property, value },
-          { isEphemeral: true }
-        );
+        handleChange(event, true);
       },
       onValueChange(event) {
-        // for TypeScript
-        if (unitRef.current === undefined) {
-          return;
-        }
-
-        const value = {
-          type: "unit",
-          value: event.value,
-          unit: unitRef.current,
-        } as const;
-
-        latestProps.current.onChange(
-          { operation: "set", property, value },
-          { isEphemeral: false }
-        );
+        handleChange(event, false);
       },
       onStatusChange(status) {
         setActiveTarget(
-          status === "scrubbing" ? latestProps.current.target : undefined
+          status === "scrubbing" ? ref.current.props.target : undefined
         );
       },
     });
@@ -92,7 +102,62 @@ export const useScrub = (props: {
     return scrub.disconnectedCallback;
   }, [finalTarget]);
 
-  return activeTarget === undefined || value === undefined
-    ? { isActive: false }
-    : { isActive: true, property: activeTarget.property, value };
+  return {
+    isActive: activeTarget !== undefined,
+    properties,
+    values,
+  };
+};
+
+// @todo: move to shared? merge with getModifiersGroup?
+const useModifierKeys = () => {
+  const [state, setState] = useState({
+    shiftKey: false,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+  });
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) =>
+      setState({
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+      });
+
+    window.addEventListener("keydown", handler);
+    window.addEventListener("keyup", handler);
+
+    return () => {
+      window.removeEventListener("keydown", handler);
+      window.removeEventListener("keyup", handler);
+    };
+  }, []);
+
+  return state;
+};
+
+const getModifiersGroup = (
+  property: SpacingStyleProperty,
+  modifiers: { shiftKey: boolean; altKey: boolean }
+) => {
+  let groups: SpacingStyleProperty[][] = [];
+
+  if (modifiers.shiftKey) {
+    groups = [
+      ["paddingTop", "paddingRight", "paddingBottom", "paddingLeft"],
+      ["marginTop", "marginRight", "marginBottom", "marginLeft"],
+    ];
+  } else if (modifiers.altKey) {
+    groups = [
+      ["paddingTop", "paddingBottom"],
+      ["paddingRight", "paddingLeft"],
+      ["marginTop", "marginBottom"],
+      ["marginRight", "marginLeft"],
+    ];
+  }
+
+  return groups.find((group) => group.includes(property)) ?? [property];
 };

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useState } from "react";
+import { type ComponentProps, useState } from "react";
 import type { RenderCategoryProps } from "../../style-sections";
 import { SpacingLayout } from "./layout";
 import { ValueText } from "./value-text";

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
@@ -3,6 +3,7 @@ import type { RenderCategoryProps } from "../../style-sections";
 import { SpacingLayout } from "./layout";
 import { ValueText } from "./value-text";
 import { useScrub } from "./scrub";
+import { spacingPropertiesNames } from "./types";
 import type {
   StyleChangeHandler,
   SpacingStyleProperty,
@@ -11,7 +12,6 @@ import type {
 import { InputPopover } from "./input-popover";
 import { SpacingTooltip } from "./tooltip";
 import { getStyleSource } from "../../shared/style-info";
-import { StyleProperty } from "@webstudio-is/css-data";
 
 const Cell = ({
   isPopoverOpen,
@@ -110,8 +110,11 @@ export const SpacingSection = ({
     target: hoverTarget,
     onChange: (values, options) => {
       const batch = createBatchUpdate();
-      for (const [property, value] of Object.entries(values)) {
-        batch.setProperty(property as StyleProperty)(value);
+      for (const property of spacingPropertiesNames) {
+        const value = values[property];
+        if (value !== undefined) {
+          batch.setProperty(property)(value);
+        }
       }
       batch.publish(options);
     },

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
@@ -1,14 +1,10 @@
-import { useState } from "react";
+import { ComponentProps, useState } from "react";
 import type { RenderCategoryProps } from "../../style-sections";
 import { SpacingLayout } from "./layout";
 import { ValueText } from "./value-text";
 import { useScrub } from "./scrub";
 import { spacingPropertiesNames } from "./types";
-import type {
-  StyleChangeHandler,
-  SpacingStyleProperty,
-  HoverTagret,
-} from "./types";
+import type { SpacingStyleProperty, HoverTagret } from "./types";
 import { InputPopover } from "./input-popover";
 import { SpacingTooltip } from "./tooltip";
 import { getStyleSource } from "../../shared/style-info";
@@ -25,7 +21,7 @@ const Cell = ({
 }: {
   isPopoverOpen: boolean;
   onPopoverClose: () => void;
-  onChange: StyleChangeHandler;
+  onChange: ComponentProps<typeof InputPopover>["onChange"];
   onHover: (target: HoverTagret | undefined) => void;
   property: SpacingStyleProperty;
   isActive: boolean;
@@ -93,15 +89,6 @@ export const SpacingSection = ({
 }: RenderCategoryProps) => {
   const [hoverTarget, setHoverTarget] = useState<HoverTagret>();
 
-  // @todo: simplify if possible, as this is used only for InputPopover.onChange now
-  const handleChange: StyleChangeHandler = (update, options) => {
-    if (update.operation === "set") {
-      setProperty(update.property)(update.value, options);
-    } else {
-      deleteProperty(update.property, options);
-    }
-  };
-
   const scrubStatus = useScrub({
     value:
       hoverTarget === undefined
@@ -138,7 +125,13 @@ export const SpacingSection = ({
               setOpenProperty(undefined);
             }
           }}
-          onChange={handleChange}
+          onChange={(update, options) => {
+            if (update.operation === "set") {
+              setProperty(update.property)(update.value, options);
+            } else {
+              deleteProperty(update.property, options);
+            }
+          }}
           onHover={setHoverTarget}
           property={property}
           scrubStatus={scrubStatus}

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/spacing.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { RenderCategoryProps } from "../../style-sections";
 import { SpacingLayout } from "./layout";
 import { ValueText } from "./value-text";
@@ -8,6 +8,7 @@ import type {
   SpacingStyleProperty,
   HoverTagret,
 } from "./types";
+import { toSpacingProperty } from "./types";
 import { InputPopover } from "./input-popover";
 import { SpacingTooltip } from "./tooltip";
 import { getStyleSource } from "../../shared/style-info";
@@ -88,6 +89,7 @@ const Cell = ({
 export const SpacingSection = ({
   setProperty,
   deleteProperty,
+  createBatchUpdate,
   currentStyle,
 }: RenderCategoryProps) => {
   const [hoverTarget, setHoverTarget] = useState<HoverTagret>();
@@ -106,7 +108,18 @@ export const SpacingSection = ({
         ? undefined
         : currentStyle[hoverTarget.property]?.value,
     target: hoverTarget,
-    onChange: handleChange,
+    onChange: (update, options) => {
+      const group = getModifiersGroup(
+        toSpacingProperty(update.property),
+        modifiers
+      );
+      const batch = createBatchUpdate();
+      for (const property of group) {
+        batch.add({ ...update, property });
+        // handleChange({ ...update, property }, options);
+      }
+      batch.publish(options);
+    },
   });
 
   const [openProperty, setOpenProperty] = useState<SpacingStyleProperty>();
@@ -119,7 +132,7 @@ export const SpacingSection = ({
     <SpacingLayout
       onClick={() => setOpenProperty(hoverTarget?.property)}
       onHover={setHoverTarget}
-      activeProperty={activeProperty}
+      activeProperties={activeProperty && [activeProperty]}
       renderCell={({ property }) => (
         <Cell
           isPopoverOpen={openProperty === property}

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/types.ts
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/types.ts
@@ -1,19 +1,6 @@
-import { StyleProperty } from "@webstudio-is/css-data";
-import { StyleUpdate } from "@webstudio-is/project";
 import { categories } from "@webstudio-is/react-sdk";
-import { StyleUpdateOptions } from "../../shared/use-style-data";
 
 export const spacingPropertiesNames = categories.spacing.properties;
-
-// @todo: remove if not used
-export const toSpacingProperty = (
-  property: StyleProperty
-): SpacingStyleProperty => {
-  if ((spacingPropertiesNames as readonly string[]).includes(property)) {
-    return property as SpacingStyleProperty;
-  }
-  throw new Error(`Property ${property} is not a spacing property`);
-};
 
 export type SpacingStyleProperty = typeof spacingPropertiesNames[number];
 
@@ -21,8 +8,3 @@ export type HoverTagret = {
   property: SpacingStyleProperty;
   element: SVGElement | HTMLElement;
 };
-
-export type StyleChangeHandler = (
-  update: StyleUpdate,
-  options: StyleUpdateOptions
-) => void;

--- a/apps/designer/app/designer/features/style-panel/sections/spacing/types.ts
+++ b/apps/designer/app/designer/features/style-panel/sections/spacing/types.ts
@@ -1,8 +1,19 @@
+import { StyleProperty } from "@webstudio-is/css-data";
 import { StyleUpdate } from "@webstudio-is/project";
 import { categories } from "@webstudio-is/react-sdk";
 import { StyleUpdateOptions } from "../../shared/use-style-data";
 
 export const spacingPropertiesNames = categories.spacing.properties;
+
+// @todo: remove if not used
+export const toSpacingProperty = (
+  property: StyleProperty
+): SpacingStyleProperty => {
+  if ((spacingPropertiesNames as readonly string[]).includes(property)) {
+    return property as SpacingStyleProperty;
+  }
+  throw new Error(`Property ${property} is not a spacing property`);
+};
 
 export type SpacingStyleProperty = typeof spacingPropertiesNames[number];
 

--- a/apps/designer/app/designer/features/style-panel/shared/modifier-keys.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/modifier-keys.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+export const useModifierKeys = () => {
+  const [state, setState] = useState({
+    shiftKey: false,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+  });
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) =>
+      setState({
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+      });
+
+    window.addEventListener("keydown", handler);
+    window.addEventListener("keyup", handler);
+
+    return () => {
+      window.removeEventListener("keydown", handler);
+      window.removeEventListener("keyup", handler);
+    };
+  }, []);
+
+  return state;
+};

--- a/apps/designer/app/designer/features/style-panel/shared/modifier-keys.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/modifier-keys.ts
@@ -1,5 +1,7 @@
 import { useState, useEffect } from "react";
 
+// Used for combined mouse and keyboard interactions, like scrubbing while holding ALT.
+// If it's just a keyboard interaction, you should already have a keyboard event at hand.
 export const useModifierKeys = () => {
   const [state, setState] = useState({
     shiftKey: false,

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -38,7 +38,6 @@ export type CreateBatchUpdate = () => {
     property: StyleProperty
   ) => (style: string | StyleValue) => void;
   deleteProperty: (property: StyleProperty) => void;
-  add: (update: StyleUpdates["updates"][number]) => void;
   publish: (options?: StyleUpdateOptions) => void;
 };
 
@@ -175,10 +174,6 @@ export const useStyleData = ({
       updates.push({ operation: "delete", property });
     };
 
-    const add = (update: StyleUpdates["updates"][number]) => {
-      updates.push(update);
-    };
-
     const publish = (options = { isEphemeral: false }) => {
       if (!updates.length) {
         return;
@@ -209,7 +204,6 @@ export const useStyleData = ({
     return {
       setProperty,
       deleteProperty,
-      add,
       publish,
     };
   }, [publishUpdates]);


### PR DESCRIPTION
## Description

Adds option / shift support to scrub in spacing. Closes #668

## Steps for reproduction

- Try to scrub in spacing while holding SHIFT or OPTION (ALT in Windows)
- Try to press and release SHIFT / OPTION multiple times during scrub
- Try to press SHIFT / OPTION while hovering over a property (other properties will highlight even without scrub)

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
