### PR TITLE
Fix selected breakpoint to delete

### DIFF
--- a/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
+++ b/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
@@ -127,9 +127,9 @@ export const Breakpoints = ({ publish }: BreakpointsProps) => {
           sideOffset={4}
           collisionPadding={4}
         >
-          {view === "confirmation" && (
+          {view === "confirmation" && breakpointToDelete && (
             <ConfirmationDialog
-              breakpoint={selectedBreakpoint}
+              breakpoint={breakpointToDelete}
               onAbort={() => {
                 setBreakpointToDelete(undefined);
                 setView("editor");


### PR DESCRIPTION
Issue:
Breakpoints panel suggests delete currently selected instead of specific breakpoint #691

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click edit breakpoint in top bar
2. delete other breakpoint than the currently selected
3. expect to show the message to delete the breakpoint and not the currently selected in the confirm message

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review

## Before merging

- [x] tested locally
- [x] tested on preview link