### PR TITLE
Style panel css value input layout was broken 

### DIFF
--- a/packages/design-system/src/components/box.tsx
+++ b/packages/design-system/src/components/box.tsx
@@ -3,4 +3,5 @@ import { styled } from "../stitches.config";
 export const Box = styled("div", {
   // Reset
   boxSizing: "border-box",
+  minWidth: 0,
 });


### PR DESCRIPTION

## Description

because we removed width:100% from input it seems like ideal strategy is to always have minWidth: 0 defined since it just fixes flexbox everywhere

## Steps for reproduction

1. open style panel


## Code Review

- [ ] hi @istarkov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
