### PR TITLE
Update styles without patches

### DIFF
--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -378,7 +378,7 @@ export const Designer = ({
           {dragAndDropState.isDragging ? (
             <TreePrevew />
           ) : (
-            <Inspector publish={publish} />
+            <Inspector treeId={page.treeId} publish={publish} />
           )}
         </SidePanel>
         <Footer publish={publish} />

--- a/apps/designer/app/designer/features/inspector/inspector.tsx
+++ b/apps/designer/app/designer/features/inspector/inspector.tsx
@@ -18,6 +18,7 @@ import { FloatingPanelProvider } from "~/designer/shared/floating-panel";
 import { useRef } from "react";
 
 type InspectorProps = {
+  treeId: string;
   publish: Publish;
 };
 
@@ -27,7 +28,7 @@ const contentStyle = {
   overflow: "auto",
 };
 
-export const Inspector = ({ publish }: InspectorProps) => {
+export const Inspector = ({ treeId, publish }: InspectorProps) => {
   const [selectedInstanceData] = useSelectedInstanceData();
   const tabsRef = useRef<HTMLDivElement>(null);
 
@@ -64,12 +65,14 @@ export const Inspector = ({ publish }: InspectorProps) => {
           </TabsList>
           <TabsContent value="style" css={contentStyle}>
             <StylePanel
+              treeId={treeId}
               publish={publish}
               selectedInstanceData={selectedInstanceData}
             />
           </TabsContent>
           <TabsContent value="props" css={contentStyle}>
             <PropsPanel
+              treeId={treeId}
               publish={publish}
               key={
                 selectedInstanceData.id /* Re-render when instance changes */

--- a/apps/designer/app/designer/features/props-panel/props-panel.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.tsx
@@ -217,11 +217,13 @@ const Property = ({
 };
 
 type PropsPanelProps = {
+  treeId: string;
   publish: Publish;
   selectedInstanceData: SelectedInstanceData;
 };
 
 export const PropsPanel = ({
+  treeId,
   selectedInstanceData,
   publish,
 }: PropsPanelProps) => {
@@ -235,6 +237,7 @@ export const PropsPanel = ({
   } = usePropsLogic({ selectedInstanceData, publish });
 
   const { setProperty: setCssProperty } = useStyleData({
+    treeId,
     selectedInstanceData,
     publish,
   });

--- a/apps/designer/app/designer/features/style-panel/style-panel.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-panel.tsx
@@ -11,16 +11,19 @@ import {
 } from "~/designer/shared/nano-states";
 
 type StylePanelProps = {
+  treeId: string;
   publish: Publish;
   selectedInstanceData?: SelectedInstanceData;
 };
 
 export const StylePanel = ({
+  treeId,
   selectedInstanceData,
   publish,
 }: StylePanelProps) => {
   const { currentStyle, setProperty, deleteProperty, createBatchUpdate } =
     useStyleData({
+      treeId,
       selectedInstanceData,
       publish,
     });

--- a/apps/designer/app/routes/rest/update.ts
+++ b/apps/designer/app/routes/rest/update.ts
@@ -1,0 +1,75 @@
+import type { ActionArgs } from "@remix-run/node";
+import { prisma } from "@webstudio-is/prisma-client";
+import { Styles } from "@webstudio-is/react-sdk";
+import { Messages, type StylesMessage } from "~/shared/stores";
+
+const loadStylesByTreeId = async (treeId: string) => {
+  const tree = await prisma.tree.findUnique({
+    where: { id: treeId },
+  });
+
+  if (tree === null) {
+    return [];
+  }
+
+  return Styles.parse(JSON.parse(tree.styles));
+};
+
+export const updateStyles = async (messages: StylesMessage[]) => {
+  const stylesByTreeId = new Map<string, Styles>();
+
+  for (const message of messages) {
+    let styles = stylesByTreeId.get(message.treeId);
+    if (styles === undefined) {
+      styles = await loadStylesByTreeId(message.treeId);
+      stylesByTreeId.set(message.treeId, styles);
+    }
+
+    const { breakpointId, instanceId, property } = message.data;
+    const matchedIndex = styles.findIndex(
+      (item) =>
+        item.breakpointId === breakpointId &&
+        item.instanceId === instanceId &&
+        item.property === property
+    );
+
+    if (message.operation === "set") {
+      if (matchedIndex === -1) {
+        styles.push(message.data);
+      } else {
+        styles[matchedIndex] = message.data;
+      }
+    }
+
+    if (message.operation === "delete") {
+      styles.splice(matchedIndex, 1);
+    }
+  }
+
+  for (const [treeId, styles] of stylesByTreeId) {
+    await prisma.tree.update({
+      data: {
+        styles: JSON.stringify(styles),
+      },
+      where: { id: treeId },
+    });
+  }
+};
+
+export const action = async ({ request }: ActionArgs) => {
+  const messages = Messages.parse(await request.json());
+
+  const styleMessages: StylesMessage[] = [];
+
+  for (const message of messages) {
+    if (message.store === "styles") {
+      styleMessages.push(message);
+    }
+  }
+
+  if (styleMessages.length !== 0) {
+    await updateStyles(styleMessages);
+  }
+
+  return { status: "ok" };
+};

--- a/apps/designer/app/shared/router-utils/path-utils.ts
+++ b/apps/designer/app/shared/router-utils/path-utils.ts
@@ -55,6 +55,8 @@ export const restThemePath = ({ setting }: { setting: ThemeSetting }) =>
 
 export const restPatchPath = () => "/rest/patch";
 
+export const restUpdatePath = () => "/rest/update";
+
 export const restPublishPath = () => "/rest/publish";
 
 export const getBuildUrl = ({

--- a/apps/designer/app/shared/stores/index.ts
+++ b/apps/designer/app/shared/stores/index.ts
@@ -1,0 +1,2 @@
+export * from "./styles";
+export * from "./messages";

--- a/apps/designer/app/shared/stores/messages.ts
+++ b/apps/designer/app/shared/stores/messages.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { z } from "zod";
+import { subscribe } from "~/shared/pubsub";
+import { StylesMessage } from "./styles";
+
+const UnknownMessage = z.object({
+  store: z.literal("unknown"),
+});
+
+const Message = z.union([StylesMessage, UnknownMessage]);
+
+type Message = z.infer<typeof Message>;
+
+export const Messages = z.array(Message);
+
+declare module "~/shared/pubsub" {
+  export interface PubsubMap {
+    update: Message[];
+  }
+}
+
+let queue: Message[] = [];
+
+export const queueMessages = (newMessages: Message[]) => {
+  queue = [...queue, ...newMessages];
+};
+
+export const syncMessages = () => {
+  const messages = queue;
+  queue = [];
+  return messages;
+};
+
+export const useSubscribeMessages = () => {
+  useEffect(() => {
+    return subscribe("update", (messages) => {
+      queueMessages(messages);
+    });
+  }, []);
+};

--- a/apps/designer/app/shared/stores/styles.ts
+++ b/apps/designer/app/shared/stores/styles.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { StylesItem } from "@webstudio-is/react-sdk";
+
+const SetStylesMessage = z.object({
+  store: z.literal("styles"),
+  operation: z.literal("set"),
+  treeId: z.string(),
+  data: StylesItem,
+});
+
+type SetStylesMessage = z.infer<typeof SetStylesMessage>;
+
+const DeleteStylesMessage = z.object({
+  store: z.literal("styles"),
+  operation: z.literal("delete"),
+  treeId: z.string(),
+  data: StylesItem.omit({ value: true }) as z.ZodType<
+    Omit<StylesItem, "value">
+  >,
+});
+
+type DeleteStylesMessage = z.infer<typeof DeleteStylesMessage>;
+
+export const StylesMessage = z.union([SetStylesMessage, DeleteStylesMessage]);
+
+export type StylesMessage = z.infer<typeof StylesMessage>;

--- a/packages/react-sdk/src/db/style.ts
+++ b/packages/react-sdk/src/db/style.ts
@@ -7,18 +7,14 @@ import {
   getComponentNames,
 } from "../components";
 
-export type PresetStylesItem = {
-  component: ComponentName;
-  property: StyleProperty;
-  value: StyleValue;
-};
-
-// @todo can't figure out how to make property to be enum
 export const PresetStylesItem = z.object({
   component: z.enum(getComponentNames() as [ComponentName]),
-  property: z.string(),
-  value: SharedStyleValue,
-}) as z.ZodType<PresetStylesItem>;
+  // @todo can't figure out how to make property to be enum
+  property: z.string() as z.ZodType<StyleProperty>,
+  value: SharedStyleValue as z.ZodType<StyleValue>,
+});
+
+export type PresetStylesItem = z.infer<typeof PresetStylesItem>;
 
 export const PresetStyles = z.array(PresetStylesItem);
 
@@ -52,20 +48,15 @@ export const findMissingPresetStyles = (
   return missingPresetStyles;
 };
 
-export type StylesItem = {
-  breakpointId: string;
-  instanceId: string;
-  property: StyleProperty;
-  value: StyleValue;
-};
-
-// @todo can't figure out how to make property to be enum
 export const StylesItem = z.object({
   breakpointId: z.string(),
   instanceId: z.string(),
-  property: z.string(),
-  value: SharedStyleValue,
-}) as z.ZodType<StylesItem>;
+  // @todo can't figure out how to make property to be enum
+  property: z.string() as z.ZodType<StyleProperty>,
+  value: SharedStyleValue as z.ZodType<StyleValue>,
+});
+
+export type StylesItem = z.infer<typeof StylesItem>;
 
 export const Styles = z.array(StylesItem);
 


### PR DESCRIPTION
Here introducing first updates without patches.
Basic idea is that we need only two operations "set" and "delete" which can do all necessary changes on normalized data.

Added new `/update` rest endpoint which accepts a list of messages and changes data.

Once of important points is type safety of such operations. We can run zod validation on server and not worry about unexpected data in json.

Client side is implemented similar to immerhin. Messages are queued in global array and sent to server every second.

Queue is temporary updated on canvas frame to reuse the same queue and sync state. When all is migrated the code can be just moved to designer.

Intentionally tried to add all logic in designer app caz not needed for published worker.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
