### PR TITLE
Synchronize transactions created in designer

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -174,7 +174,7 @@ export const Canvas = ({ data }: CanvasProps): JSX.Element | null => {
   useSetStyles(data.tree.styles);
   usePopulateRootInstance(data.tree);
   setParams(data.params ?? null);
-  useCanvasStore();
+  useCanvasStore(publish);
 
   registerComponents(customComponents);
 

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -6,7 +6,7 @@ import {
   utils as projectUtils,
 } from "@webstudio-is/project";
 import { Box, type CSS, Flex, Grid } from "@webstudio-is/design-system";
-import { useDesignerStore } from "~/shared/sync";
+import { registerContainers, useDesignerStore } from "~/shared/sync";
 import interStyles from "~/shared/font-faces/inter.css";
 import { SidebarLeft } from "./features/sidebar-left";
 import { Inspector } from "./features/inspector";
@@ -42,6 +42,8 @@ import { Navigator } from "./features/sidebar-left";
 import { getBuildUrl } from "~/shared/router-utils";
 import { useInstanceCopyPaste } from "~/shared/copy-paste";
 import { AssetsProvider, usePublishAssets } from "./shared/assets";
+
+registerContainers();
 
 export const links = () => {
   return [
@@ -289,7 +291,6 @@ export const Designer = ({
   buildOrigin,
 }: DesignerProps) => {
   useSubscribeSyncStatus();
-  useDesignerStore();
   useSubscribeSelectedInstanceData();
   useSubscribeHoveredInstanceData();
   useSubscribeBreakpoints();
@@ -297,6 +298,7 @@ export const Designer = ({
   useSetPages(pages);
   useSetCurrentPageId(pageId);
   const [publish, publishRef] = usePublish();
+  useDesignerStore(publish);
   usePublishAssets(publish);
   const [isPreviewMode] = useIsPreviewMode();
   usePublishShortcuts(publish);

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -87,7 +87,7 @@ export const useCanvasStore = (publish: Publish) => {
     const unsubscribeChanges = syncChanges("canvas", publish);
 
     return unsubscribeChanges;
-  }, []);
+  }, [publish]);
 };
 
 export const useDesignerStore = (publish: Publish) => {
@@ -107,5 +107,5 @@ export const useDesignerStore = (publish: Publish) => {
       unsubscribeSendStoreData();
       unsubscribeChanges();
     };
-  }, []);
+  }, [publish]);
 };

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -1,9 +1,7 @@
-import { applyPatches } from "immer";
 import store, { type Change } from "immerhin";
-import type { ValueContainer } from "react-nano-state";
 import { useEffect } from "react";
 import { allUserPropsContainer } from "@webstudio-is/react-sdk";
-import { publish, subscribe } from "~/shared/pubsub";
+import { type Publish, subscribe } from "~/shared/pubsub";
 import {
   rootInstanceContainer,
   breakpointsContainer,
@@ -16,38 +14,66 @@ type StoreData = {
   value: unknown;
 };
 
+type SyncEventSource = "canvas" | "designer";
+
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
     sendStoreData: StoreData[];
     sendStoreChanges: {
-      // distinct target to avoid infinite loop
-      // @todo implement two-way patches
-      target: "canvas" | "designer";
+      // distinct source to avoid infinite loop
+      source: SyncEventSource;
       changes: Change[];
     };
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const containers = new Map<string, ValueContainer<any>>([
-  ["breakpoints", breakpointsContainer],
-  ["root", rootInstanceContainer],
-  ["styles", stylesContainer],
-  ["props", allUserPropsContainer],
-  ["designTokens", designTokensContainer],
-]);
-
 export const registerContainers = () => {
-  for (const [namespace, container] of containers) {
-    store.register(namespace, container);
-  }
+  store.register("breakpoints", breakpointsContainer);
+  store.register("root", rootInstanceContainer);
+  store.register("styles", stylesContainer);
+  store.register("props", allUserPropsContainer);
+  store.register("designTokens", designTokensContainer);
 };
 
-export const useCanvasStore = () => {
+const syncChanges = (name: SyncEventSource, publish: Publish) => {
+  const unsubscribeRemoteChanges = subscribe(
+    "sendStoreChanges",
+    ({ source, changes }) => {
+      /// prevent reapplying own changes
+      if (source === name) {
+        return;
+      }
+      store.createTransactionFromChanges(changes, "remote");
+    }
+  );
+
+  const unsubscribeStoreChanges = store.subscribe(
+    (_transactionId, changes, source) => {
+      // prevent sending remote patches back
+      if (source === "remote") {
+        return;
+      }
+      publish({
+        type: "sendStoreChanges",
+        payload: {
+          source: name,
+          changes,
+        },
+      });
+    }
+  );
+
+  return () => {
+    unsubscribeRemoteChanges();
+    unsubscribeStoreChanges();
+  };
+};
+
+export const useCanvasStore = (publish: Publish) => {
   useEffect(() => {
     // expect data to be populated by the time effect is called
     const data = [];
-    for (const [namespace, container] of containers) {
+    for (const [namespace, container] of store.containers) {
       data.push({
         namespace,
         value: container.value,
@@ -57,48 +83,29 @@ export const useCanvasStore = () => {
       type: "sendStoreData",
       payload: data,
     });
-    const unsubscribeStore = store.subscribe((_transactionId, changes) => {
-      publish({
-        type: "sendStoreChanges",
-        payload: {
-          target: "designer",
-          changes,
-        },
-      });
-    });
-    return () => {
-      unsubscribeStore();
-    };
+
+    const unsubscribeChanges = syncChanges("canvas", publish);
+
+    return unsubscribeChanges;
   }, []);
 };
 
-export const useDesignerStore = () => {
+export const useDesignerStore = (publish: Publish) => {
   useEffect(() => {
     const unsubscribeSendStoreData = subscribe("sendStoreData", (data) => {
       for (const { namespace, value } of data) {
-        const container = containers.get(namespace);
+        const container = store.containers.get(namespace);
         if (container) {
           container.dispatch(value);
         }
       }
     });
-    const unsubscribeSendStoreChanges = subscribe(
-      "sendStoreChanges",
-      ({ target, changes }) => {
-        if (target !== "designer") {
-          return;
-        }
-        for (const { namespace, patches } of changes) {
-          const container = containers.get(namespace);
-          if (container) {
-            container.dispatch(applyPatches(container.value, patches));
-          }
-        }
-      }
-    );
+
+    const unsubscribeChanges = syncChanges("designer", publish);
+
     return () => {
       unsubscribeSendStoreData();
-      unsubscribeSendStoreChanges();
+      unsubscribeChanges();
     };
   }, []);
 };

--- a/apps/designer/package.json
+++ b/apps/designer/package.json
@@ -55,7 +55,7 @@
     "fast-deep-equal": "3.1.3",
     "hyphenate-style-name": "^1.0.4",
     "immer": "^9.0.12",
-    "immerhin": "^0.2.1",
+    "immerhin": "^0.3.1",
     "lexical": "^0.6.0",
     "lodash": "4.17.21",
     "lodash.capitalize": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,7 @@ importers:
       fast-deep-equal: 3.1.3
       hyphenate-style-name: ^1.0.4
       immer: ^9.0.12
-      immerhin: ^0.2.1
+      immerhin: ^0.3.1
       jest: ^29.3.1
       lexical: ^0.6.0
       lodash: 4.17.21
@@ -184,7 +184,7 @@ importers:
       fast-deep-equal: 3.1.3
       hyphenate-style-name: 1.0.4
       immer: 9.0.15
-      immerhin: 0.2.1
+      immerhin: 0.3.1
       lexical: 0.6.0
       lodash: 4.17.21
       lodash.capitalize: 4.2.1
@@ -14942,8 +14942,8 @@ packages:
     resolution: {integrity: sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==}
     dev: false
 
-  /immerhin/0.2.1:
-    resolution: {integrity: sha512-f+pfXUlcguigFuLFWSeadkIzO3Uiyc5bJ0vfwP/0/XioTvHfT210RYaOS4D5EIRtEdq7acsENM8dcfLXE1lCkQ==}
+  /immerhin/0.3.1:
+    resolution: {integrity: sha512-ZWO7lR+WPHJRUxNpNw76K6+YQKnAEnWFZcCFKqWfYHg0lyVxs+D7k72NSe92GGwyr9gH7Yj6HbMaKXfgArYpyw==}
     dependencies:
       bson-objectid: 2.0.4
       immer: 9.0.15


### PR DESCRIPTION
We finally can change states connected to immerhin from designer. Here I added subscription to designer changes and fixed cyclic events with new "source" parameter provided on transaction creation.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
