### PR TITLE
Sortable  style source items

### DIFF
--- a/apps/designer/app/designer/features/style-panel/style-source-input/style-source-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-source-input/style-source-input.tsx
@@ -21,8 +21,10 @@ import {
 } from "react";
 import { mergeRefs } from "@react-aria/utils";
 import { StyleSource, type ItemState } from "./style-source";
+import { useSortable } from "./use-sortable";
 
 type IntermediateItem = {
+  id: string;
   label: string;
   hasMenu: boolean;
   state: ItemState;
@@ -43,6 +45,7 @@ type TextFieldBaseWrapperProps<Item> = Omit<ComponentProps<"input">, "value"> &
     onChangeItem?: (item: Item) => void;
     onDisableItem?: (item: Item) => void;
     onEnableItem?: (item: Item) => void;
+    onSort?: (items: Array<Item>) => void;
     editingIndex: number;
   };
 
@@ -69,6 +72,7 @@ const TextFieldBase: ForwardRefRenderFunction<
     onChangeItem,
     onDisableItem,
     onEnableItem,
+    onSort,
     editingIndex: editingIndexProp,
     ...textFieldProps
   } = props;
@@ -81,11 +85,16 @@ const TextFieldBase: ForwardRefRenderFunction<
   useEffect(() => {
     setEditingIndex(editingIndexProp);
   }, [editingIndexProp]);
+  const { sortableRefCallback, dragItemId, placementIndicator } = useSortable({
+    items: value,
+    onSort,
+  });
+
   return (
     <TextFieldContainer
       {...focusProps}
       aria-disabled={disabled}
-      ref={mergeRefs(forwardedRef, containerRef ?? null)}
+      ref={mergeRefs(forwardedRef, containerRef ?? null, sortableRefCallback)}
       state={state}
       variant={variant}
       css={{ ...css, px: "$spacing$3", py: "$spacing$2" }}
@@ -93,7 +102,14 @@ const TextFieldBase: ForwardRefRenderFunction<
     >
       {value.map((item, index) => (
         <StyleSource
-          state={index === editingIndex ? "editing" : item.state}
+          id={item.id}
+          state={
+            dragItemId === undefined
+              ? index === editingIndex
+                ? "editing"
+                : item.state
+              : "dragging"
+          }
           onStateChange={(state) => {
             setEditingIndex(state === "editing" ? index : -1);
             if (state === "disabled") {
@@ -118,6 +134,7 @@ const TextFieldBase: ForwardRefRenderFunction<
           key={index}
         />
       ))}
+      {placementIndicator}
       {/* We want input to be the first element in DOM so it receives the focus first */}
       {editingIndex === -1 && (
         <TextFieldInput
@@ -166,7 +183,7 @@ export const StyleSourceInput = <Item extends IntermediateItem>(
     isOpen,
   } = useCombobox({
     items: props.items ?? [],
-    value: { label, hasMenu: true, state: "initial" },
+    value: { label, hasMenu: true, state: "initial", id: "" },
     selectedItem: undefined,
     itemToString: (item) => (item ? item.label : ""),
     onItemSelect(item) {

--- a/apps/designer/app/designer/features/style-panel/style-source-input/style-source.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-source-input/style-source.tsx
@@ -93,7 +93,7 @@ const Menu = (props: MenuProps) => {
   );
 };
 
-export type ItemState = "initial" | "editing" | "disabled";
+export type ItemState = "initial" | "editing" | "disabled" | "dragging";
 
 type EditableTextProps = {
   label: string;
@@ -153,6 +153,7 @@ const EditableText = ({
       css={{
         outline: "none",
         textOverflow: state === "editing" ? "clip" : "ellipsis",
+        cursor: state === "dragging" ? "grab" : "default",
       }}
     >
       {label}
@@ -198,28 +199,31 @@ const Item = styled(Button, {
       },
       editing: {},
       initial: {},
+      dragging: {},
     },
   },
 });
 
 type EditableItemProps = {
+  id: string;
   children: Array<JSX.Element | false>;
   state: ItemState;
 };
 
-const EditableItem = ({ children, state }: EditableItemProps) => {
+const EditableItem = ({ children, state, id }: EditableItemProps) => {
   const ref = useForceRecalcStyle<HTMLDivElement>(
     "max-width",
     state === "editing"
   );
   return (
-    <Item variant="gray" state={state} ref={ref} as="div">
+    <Item variant="gray" state={state} ref={ref} as="div" data-id={id}>
       {children}
     </Item>
   );
 };
 
 type StyleSourceProps = {
+  id: string;
   label: string;
   hasMenu: boolean;
   state: ItemState;
@@ -230,15 +234,17 @@ type StyleSourceProps = {
 };
 
 export const StyleSource = ({
+  id,
   label,
   hasMenu,
   state,
   onChange,
   onStateChange,
-  ...menuProps
+  onDuplicate,
+  onRemove,
 }: StyleSourceProps) => {
   return (
-    <EditableItem state={state}>
+    <EditableItem state={state} id={id}>
       <EditableText
         state={state}
         onStateChange={onStateChange}
@@ -247,8 +253,9 @@ export const StyleSource = ({
       />
       {hasMenu === true && state !== "editing" && (
         <Menu
-          {...menuProps}
           state={state}
+          onDuplicate={onDuplicate}
+          onRemove={onRemove}
           onEnable={() => {
             onStateChange("initial");
           }}

--- a/apps/designer/app/designer/features/style-panel/style-source-input/use-sortable.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-source-input/use-sortable.tsx
@@ -1,0 +1,101 @@
+import { useState, useRef } from "react";
+import {
+  PlacementIndicator,
+  useDrag,
+  useDrop,
+  type DropTarget,
+} from "@webstudio-is/design-system";
+
+type UseSortable<Item> = {
+  items: Array<Item>;
+  onSort?: (items: Array<Item>) => void;
+};
+
+export const useSortable = <Item extends { id: string }>({
+  items,
+  onSort,
+}: UseSortable<Item>) => {
+  const [dropTarget, setDropTarget] = useState<DropTarget<true>>();
+  const [dragItemId, setDragItemId] = useState<string>();
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  const useDropHandlers = useDrop<true>({
+    elementToData(element) {
+      return element instanceof HTMLDivElement;
+    },
+    swapDropTarget(dropTarget) {
+      if (dropTarget) {
+        return dropTarget;
+      }
+
+      if (rootRef.current === null) {
+        throw new Error("Unexpected empty rootRef during drag");
+      }
+
+      return { data: true, element: rootRef.current };
+    },
+    onDropTargetChange(dropTarget) {
+      setDropTarget(dropTarget);
+    },
+  });
+
+  const useDragHandlers = useDrag<string>({
+    elementToData(element) {
+      const closest = element.closest("[data-id]");
+      return closest && closest instanceof HTMLElement
+        ? closest.dataset?.id || false
+        : false;
+    },
+    onStart({ data }) {
+      if (items.length < 2) {
+        return;
+      }
+      setDragItemId(data);
+      useDropHandlers.handleStart();
+    },
+    onMove: (point) => {
+      useDropHandlers.handleMove(point);
+    },
+    onEnd({ isCanceled }) {
+      if (dropTarget !== undefined && dragItemId !== undefined) {
+        const oldIndex = items.findIndex((item) => item.id === dragItemId);
+        if (oldIndex !== -1) {
+          let newIndex = dropTarget.indexWithinChildren;
+
+          // placement.index does not take into account the fact that the drag item will be removed.
+          // we need to do this to account for it.
+          if (oldIndex < newIndex) {
+            newIndex = Math.max(0, newIndex - 1);
+          }
+
+          if (oldIndex !== newIndex) {
+            const newItems = [...items];
+            newItems.splice(oldIndex, 1);
+            newItems.splice(newIndex, 0, newItems[oldIndex]);
+            onSort?.(newItems);
+          }
+        }
+      }
+
+      useDropHandlers.handleEnd({ isCanceled });
+      setDragItemId(undefined);
+      setDropTarget(undefined);
+    },
+  });
+
+  const placementIndicator = dropTarget ? (
+    <PlacementIndicator placement={dropTarget.placement} />
+  ) : undefined;
+
+  const sortableRefCallback = (element: HTMLDivElement | null) => {
+    useDropHandlers.rootRef(element);
+    useDragHandlers.rootRef(element);
+    rootRef.current = element;
+  };
+
+  return {
+    sortableRefCallback,
+    dragItemId,
+    placementIndicator,
+  };
+};


### PR DESCRIPTION
## Description

1. This adds ability to drag&drop style source items

## Steps for reproduction

1. open stories
2. get 2+ items
3. start dragging

## Code Review

- [ ] hi @rpominov , I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - help finish the sortable implementation: restrict drop targets, maybe add a preview item to the draggable, can go without it though for now



## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
