### PR TITLE
Use normalized styles in style panel

### DIFF
--- a/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
+++ b/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
@@ -132,7 +132,6 @@ export const SelectedInstanceConnector = ({
       payload: {
         id: instance.id,
         component: instance.component,
-        cssRules: instance.cssRules,
         browserStyle: getBrowserStyle(element),
         props: instanceProps,
       },

--- a/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
@@ -12,7 +12,6 @@ export const NoProps: ComponentStoryObj<typeof PropsPanel> = {
     selectedInstanceData: {
       id: "1",
       component: "Button",
-      cssRules: [],
       browserStyle: {},
       props: {
         id: "1",
@@ -36,7 +35,6 @@ export const RequiredProps: ComponentStoryObj<typeof PropsPanel> = {
     selectedInstanceData: {
       id: "1",
       component: "Link",
-      cssRules: [],
       browserStyle: {},
       props: {
         id: "1",
@@ -53,7 +51,6 @@ export const DefaultProps: ComponentStoryObj<typeof PropsPanel> = {
     selectedInstanceData: {
       id: "1",
       component: "Button",
-      cssRules: [],
       browserStyle: {},
       props: {
         id: "1",
@@ -72,7 +69,6 @@ export const AllProps: ComponentStoryObj<typeof PropsPanel> = {
     selectedInstanceData: {
       id: "3",
       component: "Heading",
-      cssRules: [],
       browserStyle: {},
       props: {
         id: "2",

--- a/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
@@ -16,7 +16,6 @@ const getSelectedInstanceData = (
   return {
     id: nanoid(8),
     component: componentName,
-    cssRules: [],
     browserStyle: {},
     props: {
       id: nanoid(8),

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.test.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.test.ts
@@ -1,5 +1,5 @@
-import type { Breakpoint, CssRule } from "@webstudio-is/css-data";
-import type { Instance } from "@webstudio-is/react-sdk";
+import type { Breakpoint } from "@webstudio-is/css-data";
+import type { Instance, Styles } from "@webstudio-is/react-sdk";
 import {
   getCascadedBreakpointIds,
   getCascadedInfo,
@@ -30,37 +30,43 @@ const breakpoints: Breakpoint[] = [
 ];
 
 const selectedBreakpointId = "3";
+const selectedInstanceId = "3";
 const cascadedBreakpointIds = getCascadedBreakpointIds(
   breakpoints,
   selectedBreakpointId
 );
 
-const cssRules: CssRule[] = [
+const cascadingStyles: Styles = [
   {
-    breakpoint: "1",
-    style: {
-      width: { type: "unit", value: 100, unit: "px" },
-      height: { type: "unit", value: 50, unit: "px" },
-    },
+    breakpointId: "1",
+    instanceId: selectedInstanceId,
+    property: "width",
+    value: { type: "unit", value: 100, unit: "px" },
   },
   {
-    breakpoint: "2",
-    style: {
-      width: { type: "unit", value: 200, unit: "px" },
-    },
+    breakpointId: "1",
+    instanceId: selectedInstanceId,
+    property: "height",
+    value: { type: "unit", value: 50, unit: "px" },
   },
   {
-    breakpoint: "3",
-    style: {
-      // should not be computed because current breakpoint
-      height: { type: "unit", value: 150, unit: "px" },
-    },
+    breakpointId: "2",
+    instanceId: selectedInstanceId,
+    property: "width",
+    value: { type: "unit", value: 200, unit: "px" },
   },
   {
-    breakpoint: "4",
-    style: {
-      width: { type: "unit", value: 400, unit: "px" },
-    },
+    breakpointId: "3",
+    instanceId: selectedInstanceId,
+    // should not be computed because current breakpoint
+    property: "height",
+    value: { type: "unit", value: 150, unit: "px" },
+  },
+  {
+    breakpointId: "4",
+    instanceId: selectedInstanceId,
+    property: "width",
+    value: { type: "unit", value: 400, unit: "px" },
   },
 ];
 
@@ -68,56 +74,63 @@ const rootInstance: Instance = {
   type: "instance",
   id: "1",
   component: "Body",
-  cssRules: [
-    {
-      breakpoint: "1",
-      style: {
-        // should be inherited even from another breakpoint
-        fontSize: { type: "unit", value: 20, unit: "px" },
-      },
-    },
-  ],
+  cssRules: [],
   children: [
     {
       type: "instance",
       id: "2",
       component: "Box",
-      cssRules: [
-        {
-          breakpoint: "3",
-          style: {
-            // should not be inherited because width is not inheritable
-            width: { type: "unit", value: 100, unit: "px" },
-            // should be inherited from selected breakpoint
-            fontWeight: { type: "keyword", value: "600" },
-          },
-        },
-      ],
+      cssRules: [],
       children: [
         {
           type: "instance",
           id: "3",
           component: "Box",
-          cssRules: [
-            {
-              breakpoint: "3",
-              style: {
-                // should not show selected style as inherited
-                fontWeight: { type: "keyword", value: "500" },
-              },
-            },
-          ],
+          cssRules: [],
           children: [],
         },
       ],
     },
   ],
 };
-const selectedInstanceId = "3";
+
+const inheritingStyles: Styles = [
+  // should be inherited even from another breakpoint
+  {
+    breakpointId: "1",
+    instanceId: "1",
+    property: "fontSize",
+    value: { type: "unit", value: 20, unit: "px" },
+  },
+
+  // should not be inherited because width is not inheritable
+  {
+    breakpointId: "3",
+    instanceId: "2",
+    property: "width",
+    value: { type: "unit", value: 100, unit: "px" },
+  },
+  // should be inherited from selected breakpoint
+  {
+    breakpointId: "3",
+    instanceId: "2",
+    property: "fontWeight",
+    value: { type: "keyword", value: "600" },
+  },
+
+  // should not show selected style as inherited
+  {
+    breakpointId: "3",
+    instanceId: "3",
+    property: "fontWeight",
+    value: { type: "keyword", value: "500" },
+  },
+];
 
 test("compute cascaded styles", () => {
-  expect(getCascadedInfo(cssRules, cascadedBreakpointIds))
-    .toMatchInlineSnapshot(`
+  expect(
+    getCascadedInfo(cascadingStyles, selectedInstanceId, cascadedBreakpointIds)
+  ).toMatchInlineSnapshot(`
     {
       "height": {
         "breakpointId": "1",
@@ -143,6 +156,7 @@ test("compute inherited styles", () => {
   expect(
     getInheritedInfo(
       rootInstance,
+      inheritingStyles,
       selectedInstanceId,
       cascadedBreakpointIds,
       selectedBreakpointId

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -1,10 +1,10 @@
-import { useMemo, useCallback } from "react";
+import { useCallback } from "react";
 import store from "immerhin";
 import warnOnce from "warn-once";
 import type { SelectedInstanceData, StyleUpdates } from "@webstudio-is/project";
-import type { Style, StyleProperty, StyleValue } from "@webstudio-is/css-data";
+import type { StyleProperty, StyleValue } from "@webstudio-is/css-data";
 import { type Publish } from "~/shared/pubsub";
-import { stylesContainer, useStyles } from "~/shared/nano-states";
+import { stylesContainer } from "~/shared/nano-states";
 import { useSelectedBreakpoint } from "~/designer/shared/nano-states";
 // @todo: must be removed, now it's only for compatibility with existing code
 import { parseCssValue } from "./parse-css-value";
@@ -47,26 +47,8 @@ export const useStyleData = ({
   publish,
 }: UseStyleData) => {
   const [selectedBreakpoint] = useSelectedBreakpoint();
-  const selectedBreakpointId = selectedBreakpoint?.id;
-  const selectedInstanceId = selectedInstanceData?.id;
-  const [styles] = useStyles();
-  const localStyle = useMemo(() => {
-    const style: Style = {};
-    for (const styleItem of styles) {
-      if (
-        styleItem.breakpointId === selectedBreakpointId &&
-        styleItem.instanceId === selectedInstanceId
-      ) {
-        style[styleItem.property] = styleItem.value;
-      }
-    }
-    return style;
-  }, [styles, selectedBreakpointId, selectedInstanceId]);
 
-  const currentStyle = useStyleInfo({
-    localStyle,
-    browserStyle: selectedInstanceData?.browserStyle,
-  });
+  const currentStyle = useStyleInfo();
 
   const publishUpdates = useCallback(
     (type: "update" | "preview", updates: StyleUpdates["updates"]) => {

--- a/packages/project/src/shared/canvas-components/instance-data.ts
+++ b/packages/project/src/shared/canvas-components/instance-data.ts
@@ -1,6 +1,5 @@
 import type { Instance, InstanceProps } from "@webstudio-is/react-sdk";
 import type {
-  CssRule,
   Style,
   StyleProperty,
   StyleValue,
@@ -10,7 +9,6 @@ import type {
 export type SelectedInstanceData = {
   id: Instance["id"];
   component: Instance["component"];
-  cssRules: Array<CssRule>;
   browserStyle: Style;
   props?: InstanceProps;
 };


### PR DESCRIPTION
Here rewritten style info computing with normalized styles list. Was able to get rid of sending element css rules from canvas.

## Code Review

- [ ] hi @kof, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
