### PR TITLE
Use props from synchronize state instead of selected instance

### DIFF
--- a/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
+++ b/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
@@ -131,7 +131,6 @@ export const SelectedInstanceConnector = ({
         id: instance.id,
         component: instance.component,
         browserStyle: getBrowserStyle(element),
-        props: instanceProps,
       },
     });
 

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -42,6 +42,7 @@ import { Navigator } from "./features/sidebar-left";
 import { getBuildUrl } from "~/shared/router-utils";
 import { useInstanceCopyPaste } from "~/shared/copy-paste";
 import { AssetsProvider, usePublishAssets } from "./shared/assets";
+import { useAllUserProps } from "@webstudio-is/react-sdk";
 
 registerContainers();
 
@@ -104,6 +105,7 @@ const useSubscribeCanvasReady = (publish: Publish) => {
 const useCopyPaste = (publish: Publish) => {
   const [selectedInstance] = useSelectedInstanceData();
   const [rootInstance] = useRootInstance();
+  const allUserProps = useAllUserProps();
 
   const selectedInstanceData = useMemo(() => {
     if (selectedInstance && rootInstance) {
@@ -111,9 +113,11 @@ const useCopyPaste = (publish: Publish) => {
         rootInstance,
         selectedInstance.id
       );
-      return instance && { instance, props: selectedInstance.props ?? [] };
+      return (
+        instance && { instance, props: allUserProps[selectedInstance.id] ?? [] }
+      );
     }
-  }, [rootInstance, selectedInstance]);
+  }, [rootInstance, selectedInstance, allUserProps]);
 
   // We need to initialize this in both canvas and designer,
   // because the events will fire in either one, depending on where the focus is

--- a/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
@@ -1,5 +1,9 @@
-import { ComponentStoryObj } from "@storybook/react";
-import { getComponentMetaProps, type UserProp } from "@webstudio-is/react-sdk";
+import type { ComponentStory } from "@storybook/react";
+import {
+  allUserPropsContainer,
+  getComponentMetaProps,
+  type UserProp,
+} from "@webstudio-is/react-sdk";
 import { PropsPanel } from "./props-panel";
 
 export default {
@@ -7,61 +11,85 @@ export default {
   component: PropsPanel,
 };
 
-export const NoProps: ComponentStoryObj<typeof PropsPanel> = {
-  args: {
-    selectedInstanceData: {
-      id: "1",
-      component: "Button",
-      browserStyle: {},
-      props: [
-        {
-          id: "disabled",
-          prop: "disabled",
-          type: "boolean",
-          value: true,
-        },
-      ],
-    },
-  },
+export const NoProps: ComponentStory<typeof PropsPanel> = () => {
+  allUserPropsContainer.set({
+    "1": [
+      {
+        id: "disabled",
+        prop: "disabled",
+        type: "boolean",
+        value: true,
+      },
+    ],
+  });
+  return (
+    <PropsPanel
+      selectedInstanceData={{
+        id: "1",
+        component: "Button",
+        browserStyle: {},
+      }}
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      publish={() => {}}
+    />
+  );
 };
 
-export const RequiredProps: ComponentStoryObj<typeof PropsPanel> = {
-  args: {
-    selectedInstanceData: {
-      id: "1",
-      component: "Link",
-      browserStyle: {},
-      props: [],
-    },
-  },
+export const RequiredProps: ComponentStory<typeof PropsPanel> = () => {
+  allUserPropsContainer.set({
+    "1": [],
+  });
+  return (
+    <PropsPanel
+      selectedInstanceData={{
+        id: "1",
+        component: "Link",
+        browserStyle: {},
+      }}
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      publish={() => {}}
+    />
+  );
 };
 
-export const DefaultProps: ComponentStoryObj<typeof PropsPanel> = {
-  args: {
-    selectedInstanceData: {
-      id: "1",
-      component: "Button",
-      browserStyle: {},
-      props: [],
-    },
-  },
+export const DefaultProps: ComponentStory<typeof PropsPanel> = () => {
+  allUserPropsContainer.set({
+    "1": [],
+  });
+  return (
+    <PropsPanel
+      selectedInstanceData={{
+        id: "1",
+        component: "Button",
+        browserStyle: {},
+      }}
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      publish={() => {}}
+    />
+  );
 };
 
 const meta = getComponentMetaProps("Button");
 
-export const AllProps: ComponentStoryObj<typeof PropsPanel> = {
-  args: {
-    selectedInstanceData: {
-      id: "3",
-      component: "Heading",
-      browserStyle: {},
-      props: Object.entries(meta).map(([prop, value]) => {
-        return {
-          id: prop,
-          prop,
-          value: value?.defaultValue ?? "",
-        } as UserProp;
-      }),
-    },
-  },
+export const AllProps: ComponentStory<typeof PropsPanel> = () => {
+  allUserPropsContainer.set({
+    "3": Object.entries(meta).map(([prop, value]) => {
+      return {
+        id: prop,
+        prop,
+        value: value?.defaultValue ?? "",
+      } as UserProp;
+    }),
+  });
+  return (
+    <PropsPanel
+      selectedInstanceData={{
+        id: "3",
+        component: "Heading",
+        browserStyle: {},
+      }}
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      publish={() => {}}
+    />
+  );
 };

--- a/apps/designer/app/designer/features/props-panel/props-panel.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.tsx
@@ -3,6 +3,7 @@ import store from "immerhin";
 import {
   allUserPropsContainer,
   getComponentMetaProps,
+  useAllUserProps,
   type Instance,
   type UserProp,
 } from "@webstudio-is/react-sdk";
@@ -230,6 +231,9 @@ export const PropsPanel = ({
   selectedInstanceData,
   publish,
 }: PropsPanelProps) => {
+  const allUserProps = useAllUserProps();
+  const props = allUserProps[selectedInstanceData.id] ?? [];
+
   const {
     userProps,
     addEmptyProp,
@@ -238,6 +242,7 @@ export const PropsPanel = ({
     handleDeleteProp,
     isRequired,
   } = usePropsLogic({
+    props,
     selectedInstanceData,
 
     updateProps: (updates) => {

--- a/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
@@ -1,23 +1,17 @@
 import { jest, describe, test, expect } from "@jest/globals";
 import { renderHook, act } from "@testing-library/react-hooks";
-import {
-  ComponentName,
-  getComponentMeta,
-  UserProp,
-} from "@webstudio-is/react-sdk";
+import { ComponentName, getComponentMeta } from "@webstudio-is/react-sdk";
 import { nanoid } from "nanoid";
 import type { SelectedInstanceData } from "@webstudio-is/project";
 import { usePropsLogic } from "./use-props-logic";
 
 const getSelectedInstanceData = (
-  componentName: ComponentName,
-  props: UserProp[]
+  componentName: ComponentName
 ): SelectedInstanceData => {
   return {
     id: nanoid(8),
     component: componentName,
     browserStyle: {},
-    props,
   };
 };
 
@@ -25,7 +19,8 @@ describe("usePropsLogic", () => {
   test("should return required props", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Link", []),
+        props: [],
+        selectedInstanceData: getSelectedInstanceData("Link"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -40,14 +35,16 @@ describe("usePropsLogic", () => {
   test("should return different default props for different instances", () => {
     const { result: res1 } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Heading", []),
+        props: [],
+        selectedInstanceData: getSelectedInstanceData("Heading"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
     );
     const { result: res2 } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Button", []),
+        props: [],
+        selectedInstanceData: getSelectedInstanceData("Button"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -65,7 +62,8 @@ describe("usePropsLogic", () => {
   test("should return props with defaultValue set", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Button", []),
+        props: [],
+        selectedInstanceData: getSelectedInstanceData("Button"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -80,14 +78,15 @@ describe("usePropsLogic", () => {
   test("should dedupe by prop name and user props take precedence ", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Button", [
+        props: [
           {
             id: "default",
             prop: "type",
             type: "string",
             value: "submit",
           },
-        ]),
+        ],
+        selectedInstanceData: getSelectedInstanceData("Button"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -102,7 +101,8 @@ describe("usePropsLogic", () => {
   test("should add an empty prop", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Box", []),
+        props: [],
+        selectedInstanceData: getSelectedInstanceData("Box"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -121,7 +121,7 @@ describe("usePropsLogic", () => {
   test("should remove a prop", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Box", [
+        props: [
           {
             id: "1",
             prop: "tag",
@@ -135,7 +135,8 @@ describe("usePropsLogic", () => {
             type: "boolean",
             value: true,
           },
-        ]),
+        ],
+        selectedInstanceData: getSelectedInstanceData("Box"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -162,7 +163,7 @@ describe("usePropsLogic", () => {
   test("should update a prop", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Box", [
+        props: [
           {
             id: "1",
             prop: "tag",
@@ -176,7 +177,8 @@ describe("usePropsLogic", () => {
             type: "boolean",
             value: true,
           },
-        ]),
+        ],
+        selectedInstanceData: getSelectedInstanceData("Box"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -215,7 +217,7 @@ describe("usePropsLogic", () => {
   test("should not remove a required prop", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Box", [
+        props: [
           {
             id: "1",
             prop: "tag",
@@ -230,7 +232,8 @@ describe("usePropsLogic", () => {
             value: true,
             required: true,
           },
-        ]),
+        ],
+        selectedInstanceData: getSelectedInstanceData("Box"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -266,7 +269,7 @@ describe("usePropsLogic", () => {
   test("should not update a required prop name", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Box", [
+        props: [
           {
             id: "1",
             prop: "tag",
@@ -281,7 +284,8 @@ describe("usePropsLogic", () => {
             value: "test",
             required: true,
           },
-        ]),
+        ],
+        selectedInstanceData: getSelectedInstanceData("Box"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -314,7 +318,7 @@ describe("usePropsLogic", () => {
   test("should update a required prop value", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Box", [
+        props: [
           {
             id: "1",
             prop: "tag",
@@ -329,7 +333,8 @@ describe("usePropsLogic", () => {
             value: true,
             required: true,
           },
-        ]),
+        ],
+        selectedInstanceData: getSelectedInstanceData("Box"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -365,7 +370,7 @@ describe("usePropsLogic", () => {
   test("should update value and asset", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Box", [
+        props: [
           {
             id: "1",
             prop: "tag",
@@ -373,7 +378,8 @@ describe("usePropsLogic", () => {
             value: "div",
             required: true,
           },
-        ]),
+        ],
+        selectedInstanceData: getSelectedInstanceData("Box"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -467,7 +473,7 @@ describe("usePropsLogic", () => {
   test("should respect initialProps ordering", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Image", [
+        props: [
           {
             id: "22",
             prop: "aria-label",
@@ -503,7 +509,8 @@ describe("usePropsLogic", () => {
             value: "https://example.com",
             required: true,
           },
-        ]),
+        ],
+        selectedInstanceData: getSelectedInstanceData("Image"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -529,7 +536,8 @@ describe("usePropsLogic", () => {
   test("should return isRequired true for initial props", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Image", []),
+        props: [],
+        selectedInstanceData: getSelectedInstanceData("Image"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -549,7 +557,8 @@ describe("usePropsLogic", () => {
   test("isRequired should respect required prop", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
-        selectedInstanceData: getSelectedInstanceData("Image", []),
+        props: [],
+        selectedInstanceData: getSelectedInstanceData("Image"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })

--- a/apps/designer/app/designer/features/props-panel/use-props-logic.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.ts
@@ -1,4 +1,4 @@
-import { UserProp, MetaProps } from "@webstudio-is/react-sdk";
+import type { UserProp, MetaProps } from "@webstudio-is/react-sdk";
 import {
   getComponentMeta,
   getComponentMetaProps,
@@ -45,12 +45,11 @@ export const getValueFromPropMeta = (propValue: MetaProps[string]) => {
 };
 
 const getRequiredProps = (
-  selectedInstanceData: SelectedInstanceData
+  selectedInstanceData: SelectedInstanceData,
+  props: UserProp[]
 ): UserProp[] => {
   const { component } = selectedInstanceData;
   const meta = getComponentMetaProps(component);
-
-  const props = selectedInstanceData.props ?? [];
 
   return Object.entries(meta)
     .filter(([_, value]) => value?.required)
@@ -79,12 +78,11 @@ const getRequiredProps = (
 // @todo: This returns same props for all instances.
 // See the failing test in use-props-logic.test.ts
 const getPropsWithDefaultValue = (
-  selectedInstanceData: SelectedInstanceData
+  selectedInstanceData: SelectedInstanceData,
+  props: UserProp[]
 ): UserProp[] => {
   const { component } = selectedInstanceData;
   const meta = getComponentMetaProps(component);
-
-  const props = selectedInstanceData.props ?? [];
 
   return Object.entries(meta)
     .filter(([_, value]) => value?.defaultValue != null)
@@ -106,10 +104,9 @@ const getPropsWithDefaultValue = (
 };
 
 const getInitialProps = (
-  selectedInstanceData: SelectedInstanceData
+  selectedInstanceData: SelectedInstanceData,
+  props: UserProp[]
 ): UserProp[] => {
-  const props = selectedInstanceData.props ?? [];
-
   const { component } = selectedInstanceData;
   const meta = getComponentMeta(component);
   const metaProps = getComponentMetaProps(component);
@@ -143,6 +140,7 @@ const getInitialProps = (
 };
 
 type UsePropsLogic = {
+  props: UserProp[];
   selectedInstanceData: SelectedInstanceData;
   updateProps: (updates: Array<UserProp>) => void;
   deleteProp: (id: UserProp["id"]) => void;
@@ -152,18 +150,17 @@ type UsePropsLogic = {
  * usePropsLogic expects that key={selectedInstanceData.id} is used on the ancestor component
  */
 export const usePropsLogic = ({
+  props,
   selectedInstanceData,
   updateProps,
   deleteProp,
 }: UsePropsLogic) => {
-  const props = selectedInstanceData.props ?? [];
-
   const [requiredProps] = useState<Array<UserProp>>(() =>
     uniqBy(
       [
-        ...getInitialProps(selectedInstanceData),
-        ...getRequiredProps(selectedInstanceData),
-        ...getPropsWithDefaultValue(selectedInstanceData),
+        ...getInitialProps(selectedInstanceData, props),
+        ...getRequiredProps(selectedInstanceData, props),
+        ...getPropsWithDefaultValue(selectedInstanceData, props),
       ],
       "prop"
     )

--- a/packages/project/src/shared/canvas-components/instance-data.ts
+++ b/packages/project/src/shared/canvas-components/instance-data.ts
@@ -1,4 +1,4 @@
-import type { Instance, UserProp } from "@webstudio-is/react-sdk";
+import type { Instance } from "@webstudio-is/react-sdk";
 import type {
   Style,
   StyleProperty,
@@ -10,7 +10,6 @@ export type SelectedInstanceData = {
   id: Instance["id"];
   component: Instance["component"];
   browserStyle: Style;
-  props?: UserProp[];
 };
 
 export type HoveredInstanceData = {


### PR DESCRIPTION
Props state is synchronized between designer and canvas. We can safely get rid of sending props in selectInstance event.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
