### PR TITLE
Type-safe CSS Stitches' variables

### DIFF
--- a/apps/designer/.storybook/preview.tsx
+++ b/apps/designer/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { globalCss } from "@webstudio-is/design-system";
+import { theme } from "@webstudio-is/design-system";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -14,9 +15,9 @@ export const parameters = {
 
 const globalStyles = globalCss({
   body: {
-    backgroundColor: "$background",
-    color: "$hiContrast",
-    fontFamily: "$sans",
+    backgroundColor: theme.colors.background,
+    color: theme.colors.hiContrast,
+    fontFamily: theme.fonts.sans,
   },
 });
 

--- a/apps/designer/app/auth/login-button.tsx
+++ b/apps/designer/app/auth/login-button.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Button, Flex, Tooltip } from "@webstudio-is/design-system";
 import env from "~/shared/env";
+import { theme } from "@webstudio-is/design-system";
 
 const isPreviewEnvironment = env.VERCEL_ENV === "preview";
 
@@ -29,7 +30,7 @@ export const LoginButton = ({
       css={{ width: "100%" }}
     >
       <Flex gap="2" align="center">
-        <Flex css={{ size: "$spacing$10" }}>{icon}</Flex>
+        <Flex css={{ size: theme.spacing[10] }}>{icon}</Flex>
         {children}
       </Flex>
     </Button>

--- a/apps/designer/app/auth/login.tsx
+++ b/apps/designer/app/auth/login.tsx
@@ -7,6 +7,7 @@ import { GithubIcon, CommitIcon, GoogleIcon } from "@webstudio-is/icons";
 import { LoginButton } from "./login-button";
 import loginStyles from "./login.css";
 import { authPath } from "~/shared/router-utils";
+import { theme } from "@webstudio-is/design-system";
 
 export const links: LinksFunction = () => {
   return [
@@ -68,7 +69,7 @@ export const Login = ({ errorMessage }: { errorMessage: string }) => {
                   method="post"
                   css={{
                     flexDirection: "row",
-                    gap: "$spacing$5",
+                    gap: theme.spacing[5],
                   }}
                 >
                   <TextField

--- a/apps/designer/app/canvas/features/text-editor/text-editor.stories.tsx
+++ b/apps/designer/app/canvas/features/text-editor/text-editor.stories.tsx
@@ -7,6 +7,7 @@ import { useSubscribe, publish } from "~/shared/pubsub";
 import { utils } from "@webstudio-is/project";
 import type { TextToolbarState } from "~/designer/shared/nano-states";
 import { TextEditor } from "./text-editor";
+import { theme } from "@webstudio-is/design-system";
 
 export default {
   component: TextEditor,
@@ -89,7 +90,7 @@ export const Basic: ComponentStory<typeof TextEditor> = ({ onChange }) => {
       <Box
         css={{
           "& > div": {
-            padding: "0 $spacing$5",
+            padding: `0 ${theme.spacing[5]}`,
             border: "1px solid #999",
             color: "black",
           },

--- a/apps/designer/app/dashboard/components/card.tsx
+++ b/apps/designer/app/dashboard/components/card.tsx
@@ -11,6 +11,7 @@ import {
   Text,
 } from "@webstudio-is/design-system";
 import { designerPath } from "~/shared/router-utils";
+import { theme } from "@webstudio-is/design-system";
 
 type SelectProjectProjectCardProps = {
   projects: Array<{ id: string; title: string }>;
@@ -73,7 +74,7 @@ export const SelectProjectCard = ({
               </Button>
             </Flex>
             {errors ? (
-              <Text color="error" css={{ marginTop: "$spacing$3" }}>
+              <Text color="error" css={{ marginTop: theme.spacing[3] }}>
                 {errors}
               </Text>
             ) : null}

--- a/apps/designer/app/dashboard/components/header.tsx
+++ b/apps/designer/app/dashboard/components/header.tsx
@@ -12,6 +12,7 @@ import {
 import { User as DbUser } from "@webstudio-is/prisma-client";
 import { useNavigate } from "react-router-dom";
 import { logoutPath } from "~/shared/router-utils";
+import { theme } from "@webstudio-is/design-system";
 
 type User = Omit<DbUser, "createdAt"> & {
   createdAt: string;
@@ -29,16 +30,16 @@ export const DashboardHeader = ({ user }: { user: User }) => {
       align="center"
       justify="end"
       css={{
-        p: "$spacing$3",
-        bc: "$loContrast",
-        borderBottom: "$spacing$1 solid $slate8",
+        p: theme.spacing[3],
+        bc: theme.colors.loContrast,
+        borderBottom: `${theme.spacing[1]} solid ${theme.colors.slate8}`,
       }}
     >
       <Flex gap="1" align="center">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <DeprecatedButton variant="raw" aria-label="Menu Button">
-              <Flex gap="1" align="center" css={{ height: "$spacing$11" }}>
+              <Flex gap="1" align="center" css={{ height: theme.spacing[11] }}>
                 <Avatar
                   src={user?.image || undefined}
                   fallback={userNameFallback}

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -43,6 +43,7 @@ import { getBuildUrl } from "~/shared/router-utils";
 import { useInstanceCopyPaste } from "~/shared/copy-paste";
 import { AssetsProvider, usePublishAssets } from "./shared/assets";
 import { useAllUserProps } from "@webstudio-is/react-sdk";
+import { theme } from "@webstudio-is/design-system";
 
 registerContainers();
 
@@ -162,13 +163,15 @@ const SidePanel = ({
         fg: 0,
         // Left sidebar tabs won't be able to pop out to the right if we set overflowX to auto.
         //overflowY: "auto",
-        bc: "$loContrast",
+        bc: theme.colors.loContrast,
         height: "100%",
         ...css,
         "&:first-of-type": {
-          boxShadow: "inset -1px 0 0 0 $colors$panelOutline",
+          boxShadow: `inset -1px 0 0 0 ${theme.colors.panelOutline}`,
         },
-        "&:last-of-type": { boxShadow: "inset 1px 0 0 0 $colors$panelOutline" },
+        "&:last-of-type": {
+          boxShadow: `inset 1px 0 0 0 ${theme.colors.panelOutline}`,
+        },
       }}
     >
       {children}
@@ -214,7 +217,7 @@ const getChromeLayout = ({
 
   if (navigatorLayout === "undocked") {
     return {
-      gridTemplateColumns: `auto $spacing$30 1fr $spacing$30`,
+      gridTemplateColumns: `auto ${theme.spacing[30]} 1fr ${theme.spacing[30]}`,
       gridTemplateAreas: `
             "header header header header"
             "sidebar navigator main inspector"
@@ -224,7 +227,7 @@ const getChromeLayout = ({
   }
 
   return {
-    gridTemplateColumns: `auto 1fr $spacing$30`,
+    gridTemplateColumns: `auto 1fr ${theme.spacing[30]}`,
     gridTemplateAreas: `
           "header header header"
           "sidebar main inspector"
@@ -268,8 +271,8 @@ const NavigatorPanel = ({ publish, isPreviewMode }: NavigatorPanelProps) => {
     <SidePanel gridArea="navigator" isPreviewMode={isPreviewMode}>
       <Box
         css={{
-          borderRight: "1px solid $slate7",
-          width: "$spacing$30",
+          borderRight: `1px solid ${theme.colors.slate7}`,
+          width: theme.spacing[30],
           height: "100%",
         }}
       >

--- a/apps/designer/app/designer/features/breakpoints/breakpoints-editor.tsx
+++ b/apps/designer/app/designer/features/breakpoints/breakpoints-editor.tsx
@@ -7,6 +7,7 @@ import { Button, TextField, Flex, Text } from "@webstudio-is/design-system";
 import { PlusIcon, TrashIcon } from "@webstudio-is/icons";
 import { breakpointsContainer, useBreakpoints } from "~/shared/nano-states";
 import { replaceByOrAppendMutable } from "~/shared/array-utils";
+import { theme } from "@webstudio-is/design-system";
 
 type BreakpointEditorItemProps = {
   breakpoint: Breakpoint;
@@ -53,7 +54,7 @@ const BreakpointEditorItem = ({
     >
       <Flex
         gap="1"
-        css={{ paddingLeft: "$spacing$10", paddingRight: "$spacing$9" }}
+        css={{ paddingLeft: theme.spacing[10], paddingRight: theme.spacing[9] }}
       >
         <TextField
           css={{ width: 100, flexGrow: 1 }}
@@ -112,9 +113,9 @@ export const BreakpointsEditor = ({ onDelete }: BreakpointsEditorProps) => {
         gap="1"
         justify="between"
         css={{
-          paddingLeft: "$spacing$11",
-          paddingRight: "$spacing$9",
-          py: "$spacing$3",
+          paddingLeft: theme.spacing[11],
+          paddingRight: theme.spacing[9],
+          py: theme.spacing[3],
         }}
       >
         <Text>Breakpoints</Text>

--- a/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
+++ b/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
@@ -31,6 +31,7 @@ import {
 } from "~/shared/nano-states";
 import { utils } from "@webstudio-is/project";
 import { removeByMutable } from "~/shared/array-utils";
+import { theme } from "@webstudio-is/design-system";
 
 type BreakpointSelectorItemProps = {
   breakpoint: Breakpoint;
@@ -48,7 +49,7 @@ const BreakpointSelectorItem = ({
 };
 const menuItemCss = {
   display: "flex",
-  gap: "$spacing$9",
+  gap: theme.spacing[9],
   justifyContent: "start",
   flexGrow: 1,
   minWidth: 180,

--- a/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
+++ b/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
@@ -120,7 +120,7 @@ export const Breakpoints = () => {
       </DropdownMenuTrigger>
       <DropdownMenuPortal>
         <DropdownMenuContent
-          css={{ zIndex: "$1" }}
+          css={{ zIndex: variables.zIndices[1] }}
           sideOffset={4}
           collisionPadding={4}
         >

--- a/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
+++ b/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
@@ -120,7 +120,7 @@ export const Breakpoints = () => {
       </DropdownMenuTrigger>
       <DropdownMenuPortal>
         <DropdownMenuContent
-          css={{ zIndex: variables.zIndices[1] }}
+          css={{ zIndex: theme.zIndices[1] }}
           sideOffset={4}
           collisionPadding={4}
         >

--- a/apps/designer/app/designer/features/breakpoints/confirmation-dialog.tsx
+++ b/apps/designer/app/designer/features/breakpoints/confirmation-dialog.tsx
@@ -1,5 +1,6 @@
 import { type Breakpoint } from "@webstudio-is/css-data";
 import { Button, Flex, Paragraph } from "@webstudio-is/design-system";
+import { theme } from "@webstudio-is/design-system";
 
 type ConfirmationDialogProps = {
   onAbort: () => void;
@@ -16,7 +17,7 @@ export const ConfirmationDialog = ({
     <Flex
       gap="2"
       direction="column"
-      css={{ px: "$spacing$11", py: "$spacing$5", width: 300 }}
+      css={{ px: theme.spacing[11], py: theme.spacing[5], width: 300 }}
     >
       <Paragraph>{`Are you sure you want to delete "${breakpoint.label}"?`}</Paragraph>
       <Paragraph>

--- a/apps/designer/app/designer/features/breakpoints/preview.tsx
+++ b/apps/designer/app/designer/features/breakpoints/preview.tsx
@@ -1,5 +1,6 @@
 import { type Breakpoint } from "@webstudio-is/css-data";
 import { Paragraph, Flex, Text } from "@webstudio-is/design-system";
+import { theme } from "@webstudio-is/design-system";
 
 type PreviewProps = {
   breakpoint?: Breakpoint;
@@ -8,7 +9,7 @@ type PreviewProps = {
 export const Preview = ({ breakpoint }: PreviewProps) => {
   return (
     <Flex
-      css={{ px: "$spacing$11", py: "$spacing$3" }}
+      css={{ px: theme.spacing[11], py: theme.spacing[3] }}
       gap="1"
       direction="column"
     >

--- a/apps/designer/app/designer/features/breakpoints/trigger-button.tsx
+++ b/apps/designer/app/designer/features/breakpoints/trigger-button.tsx
@@ -13,6 +13,7 @@ import {
   MobileIcon,
   TabletIcon,
 } from "@webstudio-is/icons";
+import { theme } from "@webstudio-is/design-system";
 
 type TriggerButtonProps = ComponentProps<typeof DeprecatedButton>;
 
@@ -46,7 +47,7 @@ export const TriggerButton = forwardRef<
     <DeprecatedButton
       {...props}
       ref={ref}
-      css={{ gap: "$spacing$3" }}
+      css={{ gap: theme.spacing[3] }}
       ghost
       aria-label="Show breakpoints"
     >

--- a/apps/designer/app/designer/features/breakpoints/width-setting.tsx
+++ b/apps/designer/app/designer/features/breakpoints/width-setting.tsx
@@ -5,6 +5,7 @@ import {
 import { Text, Flex, Slider } from "@webstudio-is/design-system";
 import { useIsPreviewMode } from "~/shared/nano-states";
 import { useNextBreakpoint } from "./use-next-breakpoint";
+import { theme } from "@webstudio-is/design-system";
 
 // Doesn't make sense to allow resizing the canvas lower/higher than this.
 export const minWidth = 360;
@@ -33,7 +34,7 @@ export const WidthSetting = () => {
 
   return (
     <Flex
-      css={{ px: "$spacing$11", py: "$spacing$3" }}
+      css={{ px: theme.spacing[11], py: theme.spacing[3] }}
       gap="1"
       direction="column"
     >

--- a/apps/designer/app/designer/features/breakpoints/zoom-setting.tsx
+++ b/apps/designer/app/designer/features/breakpoints/zoom-setting.tsx
@@ -1,5 +1,6 @@
 import { useZoom } from "~/designer/shared/nano-states";
 import { Slider, Text, Flex } from "@webstudio-is/design-system";
+import { theme } from "@webstudio-is/design-system";
 
 export const minZoom = 10;
 
@@ -7,7 +8,7 @@ export const ZoomSetting = () => {
   const [value, setValue] = useZoom();
   return (
     <Flex
-      css={{ px: "$spacing$11", py: "$spacing$3" }}
+      css={{ px: theme.spacing[11], py: theme.spacing[3] }}
       gap="1"
       direction="column"
     >

--- a/apps/designer/app/designer/features/footer/breadcrumbs.tsx
+++ b/apps/designer/app/designer/features/footer/breadcrumbs.tsx
@@ -3,6 +3,7 @@ import { DeprecatedButton, Flex, Text } from "@webstudio-is/design-system";
 import { type Publish } from "~/shared/pubsub";
 import { useSelectedInstancePath } from "~/designer/shared/instance/use-selected-instance-path";
 import { useSelectedInstanceData } from "~/designer/shared/nano-states";
+import { theme } from "@webstudio-is/design-system";
 
 type BreadcrumbProps = {
   children: JSX.Element | string;
@@ -16,8 +17,8 @@ const Breadcrumb = ({ children, onClick }: BreadcrumbProps) => {
         ghost
         onClick={onClick}
         css={{
-          color: "$hiContrast",
-          px: "$spacing$5",
+          color: theme.colors.hiContrast,
+          px: theme.spacing[5],
           borderRadius: "100vh",
           height: "100%",
         }}

--- a/apps/designer/app/designer/features/footer/footer.tsx
+++ b/apps/designer/app/designer/features/footer/footer.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, darkTheme } from "@webstudio-is/design-system";
 import { type Publish } from "~/shared/pubsub";
 import { Breadcrumbs } from "./breadcrumbs";
+import { theme } from "@webstudio-is/design-system";
 
 export const Footer = ({ publish }: { publish: Publish }) => {
   return (
@@ -10,12 +11,12 @@ export const Footer = ({ publish }: { publish: Publish }) => {
       align="center"
       css={{
         gridArea: "footer",
-        height: "$spacing$11",
-        background: "$loContrast",
-        boxShadow: "inset 0 1px 0 0 $colors$panelOutline",
+        height: theme.spacing[11],
+        background: theme.colors.loContrast,
+        boxShadow: `inset 0 1px 0 0 ${theme.colors.panelOutline}`,
       }}
     >
-      <Box css={{ height: "100%", p: "$spacing$3" }}>
+      <Box css={{ height: "100%", p: theme.spacing[3] }}>
         <Breadcrumbs publish={publish} />
       </Box>
     </Flex>

--- a/apps/designer/app/designer/features/inspector/inspector.tsx
+++ b/apps/designer/app/designer/features/inspector/inspector.tsx
@@ -16,6 +16,7 @@ import { PropsPanel } from "~/designer/features/props-panel";
 import { useSelectedInstanceData } from "~/designer/shared/nano-states";
 import { FloatingPanelProvider } from "~/designer/shared/floating-panel";
 import { useRef } from "react";
+import { theme } from "@webstudio-is/design-system";
 
 type InspectorProps = {
   publish: Publish;
@@ -33,9 +34,11 @@ export const Inspector = ({ publish }: InspectorProps) => {
 
   if (selectedInstanceData === undefined) {
     return (
-      <Box css={{ p: "$spacing$5", flexBasis: "100%" }}>
+      <Box css={{ p: theme.spacing[5], flexBasis: "100%" }}>
         {/* @todo: use this space for something more usefull: a-la figma's no instance selected sate, maybe create an issue with a more specific proposal? */}
-        <Card css={{ p: "$spacing$9", mt: "$spacing$9", width: "100%" }}>
+        <Card
+          css={{ p: theme.spacing[9], mt: theme.spacing[9], width: "100%" }}
+        >
           <Paragraph>Select an instance on the canvas</Paragraph>
         </Card>
       </Box>

--- a/apps/designer/app/designer/features/props-panel/props-panel.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.tsx
@@ -40,6 +40,7 @@ import {
   useStyleData,
   type SetProperty,
 } from "../style-panel/shared/use-style-data";
+import { theme } from "@webstudio-is/design-system";
 
 type ComboboxProps = {
   isReadonly: boolean;
@@ -285,7 +286,7 @@ export const PropsPanel = ({
 
   return (
     <Box>
-      <Box css={{ p: "$spacing$9" }}>
+      <Box css={{ p: theme.spacing[9] }}>
         <ComponentInfo selectedInstanceData={selectedInstanceData} />
       </Box>
       <CollapsibleSection

--- a/apps/designer/app/designer/features/sidebar-left/lib/header.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/lib/header.tsx
@@ -6,6 +6,7 @@ import {
 } from "@webstudio-is/design-system";
 import { Separator } from "@webstudio-is/design-system";
 import { CrossIcon } from "@webstudio-is/icons";
+import { theme } from "@webstudio-is/design-system";
 
 type HeaderProps = {
   title: string;
@@ -16,12 +17,14 @@ export const Header = ({ title, suffix }: HeaderProps) => {
   return (
     <>
       <Flex
-        css={{ height: 40, paddingLeft: "$spacing$9", flexShrink: 0 }}
+        css={{ height: 40, paddingLeft: theme.spacing[9], flexShrink: 0 }}
         align="center"
         justify="between"
       >
         <Text variant="title">{title}</Text>
-        {suffix && <Flex css={{ marginRight: "$spacing$5" }}>{suffix}</Flex>}
+        {suffix && (
+          <Flex css={{ marginRight: theme.spacing[5] }}>{suffix}</Flex>
+        )}
       </Flex>
       <Separator css={{ height: 2 }} />
     </>

--- a/apps/designer/app/designer/features/sidebar-left/panels/components/component-thumb.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/panels/components/component-thumb.tsx
@@ -1,22 +1,23 @@
 import { type Instance, getComponentMeta } from "@webstudio-is/react-sdk";
 import { forwardRef, type ElementRef, type ComponentProps } from "react";
 import { Flex, Text, styled } from "@webstudio-is/design-system";
+import { theme } from "@webstudio-is/design-system";
 
 const Thumb = styled(Flex, {
-  px: "$spacing$3",
+  px: theme.spacing[3],
   width: 72,
   height: 72,
-  border: "1px solid $slate6",
+  border: `1px solid ${theme.colors.slate6}`,
   userSelect: "none",
-  color: "$hiContrast",
+  color: theme.colors.hiContrast,
   cursor: "grab",
   "&:hover": {
-    background: "$slate3",
+    background: theme.colors.slate3,
   },
   variants: {
     state: {
       dragging: {
-        background: "$slate3",
+        background: theme.colors.slate3,
       },
     },
   },

--- a/apps/designer/app/designer/features/sidebar-left/panels/components/components.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/panels/components/components.tsx
@@ -14,6 +14,7 @@ import type { TabName } from "../../types";
 import { ComponentThumb } from "./component-thumb";
 import { useCanvasRect, useZoom } from "~/designer/shared/nano-states";
 import { Header, CloseButton } from "../../lib/header";
+import { theme } from "@webstudio-is/design-system";
 
 type DraggableThumbProps = {
   onClick: MouseEventHandler<HTMLDivElement>;
@@ -156,7 +157,7 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
       <Flex
         gap="1"
         wrap="wrap"
-        css={{ padding: "$spacing$3", overflow: "auto" }}
+        css={{ padding: theme.spacing[3], overflow: "auto" }}
         ref={useDragHandlers.rootRef}
       >
         {listedComponentNames.map((component: Instance["component"]) => (

--- a/apps/designer/app/designer/features/sidebar-left/panels/pages/pages.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/panels/pages/pages.tsx
@@ -29,6 +29,7 @@ import {
 import { SettingsPanel } from "./settings-panel";
 import { NewPageSettings, PageSettings } from "./settings";
 import { designerPath } from "~/shared/router-utils";
+import { theme } from "@webstudio-is/design-system";
 
 type TabContentProps = {
   onSetActiveTab: (tabName: TabName) => void;
@@ -73,13 +74,13 @@ const staticTreeProps = {
 };
 
 const MenuButton = styled(DeprecatedIconButton, {
-  color: "$hint",
-  "&:hover, &:focus-visible": { color: "$hiContrast" },
+  color: theme.colors.hint,
+  "&:hover, &:focus-visible": { color: theme.colors.hiContrast },
   variants: {
     isParentSelected: {
       true: {
-        color: "$loContrast",
-        "&:hover, &:focus-visible": { color: "$slate7" },
+        color: theme.colors.loContrast,
+        "&:hover, &:focus-visible": { color: theme.colors.slate7 },
       },
     },
   },
@@ -116,7 +117,7 @@ const ItemSuffix = ({
   }, [editingItemId, itemId]);
 
   return (
-    <Flex css={{ mr: "$spacing$5" }} align="center">
+    <Flex css={{ mr: theme.spacing[5] }} align="center">
       <Tooltip content={menuLabel} disableHoverableContent>
         <MenuButton
           aria-label={menuLabel}
@@ -194,7 +195,7 @@ const PagesPanel = ({
         // z-index needed for page settings animation
         zIndex: 1,
         flexGrow: 1,
-        background: "$loContrast",
+        background: theme.colors.loContrast,
       }}
     >
       <Header

--- a/apps/designer/app/designer/features/sidebar-left/panels/pages/settings-panel.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/panels/pages/settings-panel.tsx
@@ -4,6 +4,7 @@ import {
   Collapsible,
   Box,
 } from "@webstudio-is/design-system";
+import { theme } from "@webstudio-is/design-system";
 
 const CollapsibleRoot = styled(Collapsible.Root, {
   position: "absolute",
@@ -18,7 +19,7 @@ const CollapsibleRoot = styled(Collapsible.Root, {
 const openKeyframes = keyframes({
   from: {
     opacity: 0.5,
-    transform: "translateX(-$spacing$30)",
+    transform: `translateX(-${theme.spacing[30]})`,
   },
   to: {
     transform: "translateX(0)",
@@ -33,7 +34,7 @@ const closeKeyframes = keyframes({
   },
   to: {
     opacity: 0.2,
-    transform: "translateX(-$spacing$30)",
+    transform: `translateX(-${theme.spacing[30]})`,
   },
 });
 
@@ -43,10 +44,10 @@ const CollapsibleContent = styled(Collapsible.Content, {
   display: "flex",
   flexDirection: "column",
   '&[data-state="open"]': {
-    animation: `${openKeyframes} 200ms $easing$easeOutQuart`,
+    animation: `${openKeyframes} 200ms ${theme.easing.easeOutQuart}`,
   },
   '&[data-state="closed"]': {
-    animation: `${closeKeyframes} 200ms $easing$easeOutQuart`,
+    animation: `${closeKeyframes} 200ms ${theme.easing.easeOutQuart}`,
   },
 });
 
@@ -63,9 +64,9 @@ export const SettingsPanel = ({
         <Box
           css={{
             flexGrow: 1,
-            width: "$spacing$35",
-            background: "$loContrast",
-            borderRight: "1px solid $slate7",
+            width: theme.spacing[35],
+            background: theme.colors.loContrast,
+            borderRight: `1px solid ${theme.colors.slate7}`,
             position: "relative",
           }}
         >

--- a/apps/designer/app/designer/features/sidebar-left/panels/pages/settings.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/panels/pages/settings.tsx
@@ -34,10 +34,11 @@ import type {
 } from "~/shared/pages";
 import { restPagesPath } from "~/shared/router-utils";
 import slugify from "slugify";
+import { theme } from "@webstudio-is/design-system";
 
 const Group = styled(Flex, {
-  marginBottom: "$spacing$9",
-  gap: "$spacing$4",
+  marginBottom: theme.spacing[9],
+  gap: theme.spacing[4],
   defaultVariants: { direction: "column" },
 });
 
@@ -254,7 +255,7 @@ export const NewPageSettings = ({
 };
 
 const ButtonContainer = styled("div", {
-  ml: "$spacing$5",
+  ml: theme.spacing[5],
   display: "flex",
   alignItems: "center",
 });
@@ -297,7 +298,12 @@ const NewPageSettingsView = ({
           </>
         }
       />
-      <Box css={{ overflow: "auto", padding: "$spacing$5 $spacing$9" }}>
+      <Box
+        css={{
+          overflow: "auto",
+          padding: `${theme.spacing[5]} ${theme.spacing[9]}`,
+        }}
+      >
         <form
           onSubmit={(event) => {
             event.preventDefault();
@@ -478,7 +484,12 @@ const PageSettingsView = ({
           </>
         }
       />
-      <Box css={{ overflow: "auto", padding: "$spacing$5 $spacing$9" }}>
+      <Box
+        css={{
+          overflow: "auto",
+          padding: `${theme.spacing[5]} ${theme.spacing[9]}`,
+        }}
+      >
         <form
           onSubmit={(event) => {
             event.preventDefault();

--- a/apps/designer/app/designer/features/sidebar-left/sidebar-left.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/sidebar-left.tsx
@@ -12,6 +12,7 @@ import type { TabName } from "./types";
 import { isFeatureEnabled } from "~/shared/feature-flags";
 import { useClientSettings } from "~/designer/shared/client-settings";
 import { Flex } from "@webstudio-is/design-system";
+import { theme } from "@webstudio-is/design-system";
 
 const none = { TabContent: () => null };
 
@@ -65,7 +66,7 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
           value={activeTab === "none" ? "" : activeTab}
           css={{
             zIndex: theme.zIndices[1],
-            width: "$spacing$30",
+            width: theme.spacing[30],
             // We need the node to be rendered but hidden
             // to keep receiving the drag events.
             visibility:

--- a/apps/designer/app/designer/features/sidebar-left/sidebar-left.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/sidebar-left.tsx
@@ -64,7 +64,7 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
         <SidebarTabsContent
           value={activeTab === "none" ? "" : activeTab}
           css={{
-            zIndex: "$1",
+            zIndex: variables.zIndices[1],
             width: "$spacing$30",
             // We need the node to be rendered but hidden
             // to keep receiving the drag events.

--- a/apps/designer/app/designer/features/sidebar-left/sidebar-left.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/sidebar-left.tsx
@@ -64,7 +64,7 @@ export const SidebarLeft = ({ publish }: SidebarLeftProps) => {
         <SidebarTabsContent
           value={activeTab === "none" ? "" : activeTab}
           css={{
-            zIndex: variables.zIndices[1],
+            zIndex: theme.zIndices[1],
             width: "$spacing$30",
             // We need the node to be rendered but hidden
             // to keep receiving the drag events.

--- a/apps/designer/app/designer/features/style-panel/controls/font-weight/font-weight-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/font-weight/font-weight-control.tsx
@@ -4,6 +4,7 @@ import { toValue } from "@webstudio-is/css-engine";
 import { useMemo } from "react";
 import { useAssets } from "~/designer/shared/assets";
 import type { ControlProps } from "../../style-sections";
+import { theme } from "@webstudio-is/design-system";
 
 type FontWeightItem = {
   label: string;
@@ -105,10 +106,10 @@ export const FontWeightControl = ({
       ghost
       css={{
         // @todo this shouldn't be in design system by default
-        gap: "calc($spacing$3 / 2)",
-        paddingLeft: "calc($spacing$10 / 2)",
-        height: "calc($spacing$11 + $spacing$3)",
-        boxShadow: "inset 0 0 0 1px $colors$slate7",
+        gap: `calc(${theme.spacing[3]} / 2)`,
+        paddingLeft: `calc(${theme.spacing[10]} / 2)`,
+        height: `calc(${theme.spacing[11]} + ${theme.spacing[3]})`,
+        boxShadow: `inset 0 0 0 1px ${theme.colors.slate7}`,
         textTransform: "capitalize",
         fontWeight: "inherit",
         "&:hover": { background: "none" },

--- a/apps/designer/app/designer/features/style-panel/controls/toggle/toggle-control.tsx
+++ b/apps/designer/app/designer/features/style-panel/controls/toggle/toggle-control.tsx
@@ -6,6 +6,7 @@ import {
   ToggleGroupItem,
 } from "@webstudio-is/design-system";
 import type { StyleSource } from "../../shared/style-info";
+import { theme } from "@webstudio-is/design-system";
 
 export type ToggleGroupControlProps = {
   styleSource: StyleSource;
@@ -52,14 +53,14 @@ const ToggleGroupControlItem = styled(ToggleGroupItem, {
     state: {
       set: {
         "&[data-state=on]": {
-          color: "$colors$blue11",
-          backgroundColor: "$colors$blue4",
+          color: theme.colors.blue11,
+          backgroundColor: theme.colors.blue4,
         },
       },
       inherited: {
         "&[data-state=on]": {
-          color: "$colors$orange11",
-          backgroundColor: "$colors$orange4",
+          color: theme.colors.orange11,
+          backgroundColor: theme.colors.orange4,
         },
       },
     },

--- a/apps/designer/app/designer/features/style-panel/sections/flex-child/flex-child.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/flex-child/flex-child.tsx
@@ -19,10 +19,11 @@ import {
 } from "@webstudio-is/icons";
 import { FloatingPanel } from "~/designer/shared/floating-panel";
 import { getStyleSource } from "../../shared/style-info";
+import { theme } from "@webstudio-is/design-system";
 
 export const FlexChildSection = (props: RenderCategoryProps) => {
   return (
-    <Flex css={{ flexDirection: "column", gap: "$spacing$5" }}>
+    <Flex css={{ flexDirection: "column", gap: theme.spacing[5] }}>
       <FlexChildSectionAlign {...props} />
       <FlexChildSectionSizing {...props} />
       <FlexChildSectionOrder {...props} />
@@ -169,11 +170,11 @@ const FlexChildSectionSizingPopover = ({
         <Grid
           css={{
             gridTemplateColumns: "1.5fr 1fr 1fr",
-            gap: "$spacing$9",
-            padding: "$spacing$9",
+            gap: theme.spacing[9],
+            padding: theme.spacing[9],
           }}
         >
-          <Grid css={{ gridTemplateColumns: "auto", gap: "$spacing$3" }}>
+          <Grid css={{ gridTemplateColumns: "auto", gap: theme.spacing[3] }}>
             <PropertyName
               style={currentStyle}
               property="flexBasis"
@@ -187,7 +188,7 @@ const FlexChildSectionSizingPopover = ({
               deleteProperty={deleteProperty}
             />
           </Grid>
-          <Grid css={{ gridTemplateColumns: "auto", gap: "$spacing$3" }}>
+          <Grid css={{ gridTemplateColumns: "auto", gap: theme.spacing[3] }}>
             <PropertyName
               style={currentStyle}
               property="flexGrow"
@@ -201,7 +202,7 @@ const FlexChildSectionSizingPopover = ({
               deleteProperty={deleteProperty}
             />
           </Grid>
-          <Grid css={{ gridTemplateColumns: "auto", gap: "$spacing$3" }}>
+          <Grid css={{ gridTemplateColumns: "auto", gap: theme.spacing[3] }}>
             <PropertyName
               style={currentStyle}
               property="flexShrink"
@@ -283,7 +284,7 @@ const FlexChildSectionOrderPopover = (props: RenderCategoryProps) => {
     <FloatingPanel
       title="Order"
       content={
-        <Grid css={{ padding: "$spacing$9" }}>
+        <Grid css={{ padding: theme.spacing[9] }}>
           <Grid css={{ gridTemplateColumns: "4fr 6fr" }}>
             <PropertyName
               style={currentStyle}

--- a/apps/designer/app/designer/features/style-panel/sections/layout/layout.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/layout.tsx
@@ -27,6 +27,7 @@ import {
   type IntermediateStyleValue,
   CssValueInput,
 } from "../../shared/css-value-input";
+import { theme } from "@webstudio-is/design-system";
 
 const GapLinked = ({
   isLinked,
@@ -183,7 +184,7 @@ const FlexGap = ({
         />
       </Box>
 
-      <Box css={{ gridArea: "linked", px: "$spacing$3" }}>
+      <Box css={{ gridArea: "linked", px: theme.spacing[3] }}>
         <GapLinked
           isLinked={isLinked}
           onChange={(isLinked) => {
@@ -257,12 +258,12 @@ const LayoutSectionFlex = ({
     (flexWrapValue.value === "wrap" || flexWrapValue.value === "wrap-reverse");
 
   return (
-    <Flex css={{ flexDirection: "column", gap: "$spacing$5" }}>
+    <Flex css={{ flexDirection: "column", gap: theme.spacing[5] }}>
       <Grid
         css={{
-          gap: "$spacing$5",
-          gridTemplateColumns: "repeat(2, $spacing$13) repeat(3, $spacing$13)",
-          gridTemplateRows: "repeat(2, $spacing$13)",
+          gap: theme.spacing[5],
+          gridTemplateColumns: `repeat(2, ${theme.spacing[13]}) repeat(3, ${theme.spacing[13]})`,
+          gridTemplateRows: `repeat(2, ${theme.spacing[13]})`,
           gridTemplateAreas: `
             "grid grid flexDirection flexWrap ."
             "grid grid alignItems justifyContent alignContent"

--- a/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/layout/shared/flex-grid.tsx
@@ -8,6 +8,7 @@ import { toValue } from "@webstudio-is/css-engine";
 import { DotFilledIcon } from "@webstudio-is/icons";
 import type { CreateBatchUpdate } from "../../../shared/use-style-data";
 import { getStyleSource, StyleInfo } from "../../../shared/style-info";
+import { theme } from "@webstudio-is/design-system";
 
 export const FlexGrid = ({
   currentStyle,
@@ -33,12 +34,12 @@ export const FlexGrid = ({
   const isFlexDirectionColumn =
     flexDirection === "column" || flexDirection === "column-reverse";
 
-  let color = "$slate8";
+  let color = theme.colors.slate8;
   if (styleSource === "local") {
-    color = "$blue9";
+    color = theme.colors.blue9;
   }
   if (styleSource === "remote") {
-    color = "$orange9";
+    color = theme.colors.orange9;
   }
 
   return (
@@ -46,12 +47,12 @@ export const FlexGrid = ({
       css={{
         width: "100%",
         aspectRatio: "1 / 1",
-        padding: "$spacing$4",
+        padding: theme.spacing[4],
         borderRadius: "4px",
-        background: "$loContrast",
+        background: theme.colors.loContrast,
         border: "2px solid currentColor",
         alignItems: "center",
-        gap: "$spacing$1",
+        gap: theme.spacing[1],
         gridTemplateColumns: "repeat(3, 1fr)",
         gridTemplateRows: "repeat(3, 1fr)",
         color,
@@ -82,9 +83,9 @@ export const FlexGrid = ({
               css={{
                 width: "100%",
                 height: "100%",
-                color: "$colors$gray8",
+                color: theme.colors.gray8,
                 "&:hover": {
-                  bc: "$colors$slate4",
+                  bc: theme.colors.slate4,
                 },
                 "&:focus": {
                   background: "none",
@@ -126,7 +127,7 @@ export const FlexGrid = ({
           <Box
             key={size}
             css={{
-              borderRadius: "calc($borderRadius$4 / 2)",
+              borderRadius: `calc(${theme.borderRadius[4]} / 2)`,
               backgroundColor: "currentColor",
               ...(isFlexDirectionColumn
                 ? { minWidth: size, minHeight: 4 }

--- a/apps/designer/app/designer/features/style-panel/sections/size/size.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/size/size.tsx
@@ -13,6 +13,7 @@ import {
   AutoScrollIcon,
 } from "@webstudio-is/icons";
 import { getStyleSource } from "../../shared/style-info";
+import { theme } from "@webstudio-is/design-system";
 
 const SizeField = ({
   property,
@@ -50,7 +51,10 @@ export const SizeSection = ({
   deleteProperty,
 }: RenderCategoryProps) => {
   return (
-    <Grid columns={2} css={{ columnGap: "$spacing$5", rowGap: "$spacing$7" }}>
+    <Grid
+      columns={2}
+      css={{ columnGap: theme.spacing[5], rowGap: theme.spacing[7] }}
+    >
       <SizeField
         property="width"
         style={style}

--- a/apps/designer/app/designer/features/style-panel/sections/space/input-popover.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/space/input-popover.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../shared/css-value-input";
 import type { StyleSource } from "../../shared/style-info";
 import { StyleUpdateOptions } from "../../shared/use-style-data";
+import { theme } from "@webstudio-is/design-system";
 
 const slideUpAndFade = keyframes({
   "0%": { opacity: 0, transform: "scale(0.8)" },
@@ -91,14 +92,14 @@ const Trigger = styled("div", { position: "absolute", width: 0, height: 0 });
 const PopoverContentStyled = styled(PopoverContent, {
   minWidth: 0,
   minHeight: 0,
-  width: "$spacing$20",
-  border: "1px solid $colors$slate8",
-  borderRadius: "$borderRadius$7",
-  background: "$colors$gray2",
-  padding: "$spacing$5",
+  width: theme.spacing[20],
+  border: `1px solid ${theme.colors.slate8}`,
+  borderRadius: theme.borderRadius[7],
+  background: theme.colors.gray2,
+  padding: theme.spacing[5],
   boxShadow: "0px 2px 7px rgba(0, 0, 0, 0.1), 0px 5px 17px rgba(0, 0, 0, 0.15)",
   animationDuration: "200ms",
-  animationTimingFunction: "$easing$easeOut",
+  animationTimingFunction: theme.easing.easeOut,
   '&[data-state="open"]': { animationName: slideUpAndFade },
 });
 

--- a/apps/designer/app/designer/features/style-panel/sections/space/layout.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/space/layout.tsx
@@ -3,6 +3,7 @@ import { forwardRef } from "react";
 import type { ComponentProps, Ref } from "react";
 import type { HoverTagret, SpaceStyleProperty } from "./types";
 import { spacePropertiesNames } from "./types";
+import { theme } from "@webstudio-is/design-system";
 
 const VALUE_WIDTH = 34;
 const VALUE_HEIGHT = 24;
@@ -40,15 +41,15 @@ const emulateInnerStroke = ({
 });
 
 const ValueArea = styled("path", {
-  fill: "$slate2",
+  fill: theme.colors.slate2,
   variants: {
     side: {
       top: { cursor: "n-resize" },
       bottom: { cursor: "s-resize" },
-      right: { cursor: "e-resize", fill: "$slate3" },
-      left: { cursor: "w-resize", fill: "$slate3" },
+      right: { cursor: "e-resize", fill: theme.colors.slate3 },
+      left: { cursor: "w-resize", fill: theme.colors.slate3 },
     },
-    isActive: { true: { fill: "$slate5" } },
+    isActive: { true: { fill: theme.colors.slate5 } },
   },
 });
 
@@ -65,7 +66,7 @@ const OuterRect = styled(
       {...props}
     />
   ),
-  { stroke: "$slate8" }
+  { stroke: theme.colors.slate8 }
 );
 
 const InnerOuterRect = styled(
@@ -85,7 +86,7 @@ const InnerOuterRect = styled(
       />
     );
   },
-  { stroke: "$slate8", fill: "$loContrast" }
+  { stroke: theme.colors.slate8, fill: theme.colors.loContrast }
 );
 
 const InnerRect = styled(
@@ -101,7 +102,7 @@ const InnerRect = styled(
       {...props}
     />
   ),
-  { stroke: "$slate8" }
+  { stroke: theme.colors.slate8 }
 );
 
 const MostInnerRect = styled(
@@ -119,7 +120,7 @@ const MostInnerRect = styled(
       />
     );
   },
-  { stroke: "$slate8", fill: "$loContrast" }
+  { stroke: theme.colors.slate8, fill: theme.colors.loContrast }
 );
 
 const gap = `${INNER_MARGIN + BORDER}px`;
@@ -148,8 +149,8 @@ const Container = styled("div", {
   // Grid happens to be positioned perfectly for the focus outline
   // (both in z-order and in top/left)
   [`&:focus-visible > ${Grid}`]: {
-    borderRadius: "$borderRadius$3",
-    outline: "2px solid $colors$blue10",
+    borderRadius: theme.borderRadius[3],
+    outline: `2px solid ${theme.colors.blue10}`,
   },
 });
 
@@ -174,9 +175,9 @@ const Cell = styled("div", {
 });
 
 const Label = styled("div", {
-  color: "$colors$slate11",
+  color: theme.colors.slate11,
   textTransform: "uppercase",
-  fontSize: "$fontSize$1",
+  fontSize: theme.fontSize[1],
   lineHeight: 1,
   marginTop: 3,
   marginLeft: 4,

--- a/apps/designer/app/designer/features/style-panel/sections/space/value-text.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/space/value-text.tsx
@@ -1,6 +1,7 @@
 import { styled } from "@webstudio-is/design-system";
 import type { StyleValue } from "@webstudio-is/css-data";
 import { useLayoutEffect, useMemo, useRef, type ComponentProps } from "react";
+import { theme } from "@webstudio-is/design-system";
 
 const Container = styled("span", {
   boxSizing: "border-box",
@@ -10,15 +11,15 @@ const Container = styled("span", {
   alignItems: "end",
   justifyContent: "center",
   border: "1px solid transparent",
-  borderRadius: "$borderRadius$3",
-  padding: "0 $spacing$1",
+  borderRadius: theme.borderRadius[3],
+  padding: `0 ${theme.spacing[1]}`,
   variants: {
     origin: {
-      unset: { color: "$colors$slate11" },
+      unset: { color: theme.colors.slate11 },
       set: {
-        color: "$colors$blue11",
-        backgroundColor: "$colors$blue4",
-        borderColor: "$colors$blue6",
+        color: theme.colors.blue11,
+        backgroundColor: theme.colors.blue4,
+        borderColor: theme.colors.blue6,
       },
       preset: {
         // as I'm adding this Figma already uses new colors system,
@@ -28,28 +29,30 @@ const Container = styled("span", {
         borderColor: "#C1C8CD", // border/main
       },
       inherited: {
-        color: "$colors$orange11",
-        backgroundColor: "$colors$orange4",
-        borderColor: "$colors$orange6",
+        color: theme.colors.orange11,
+        backgroundColor: theme.colors.orange4,
+        borderColor: theme.colors.orange6,
       },
     },
     isActive: { true: {} },
   },
   compoundVariants: [
-    { origin: "unset", isActive: true, css: { color: "$colors$slate12" } },
+    { origin: "unset", isActive: true, css: { color: theme.colors.slate12 } },
   ],
 });
 
 const Span = styled("span", {
   display: "block",
-  fontSize: "$fontSize$2",
+  fontSize: theme.fontSize[2],
   lineHeight: 1,
   overflow: "hidden",
   maxWidth: "100%",
   whiteSpace: "nowrap",
   textOverflow: "ellipsis",
   variants: {
-    keyword: { true: { fontSize: "$fontSize$1", textTransform: "uppercase" } },
+    keyword: {
+      true: { fontSize: theme.fontSize[1], textTransform: "uppercase" },
+    },
   },
 });
 

--- a/apps/designer/app/designer/features/style-panel/sections/typography/typography.tsx
+++ b/apps/designer/app/designer/features/style-panel/sections/typography/typography.tsx
@@ -35,10 +35,11 @@ import {
 import { ToggleGroupControl } from "../../controls/toggle/toggle-control";
 import { FloatingPanel } from "~/designer/shared/floating-panel";
 import { getStyleSource } from "../../shared/style-info";
+import { theme } from "@webstudio-is/design-system";
 
 export const TypographySection = (props: RenderCategoryProps) => {
   return (
-    <Flex css={{ gap: "$spacing$7" }} direction="column">
+    <Flex css={{ gap: theme.spacing[7] }} direction="column">
       <TypographySectionFont {...props} />
       <TypographySectionSizing {...props} />
       <TypographySectionAdvanced {...props} />
@@ -52,7 +53,7 @@ export const TypographySectionFont = (props: RenderCategoryProps) => {
   return (
     <Grid
       css={{
-        gap: "$spacing$5",
+        gap: theme.spacing[5],
       }}
     >
       <Grid css={{ gridTemplateColumns: "4fr 6fr" }}>
@@ -108,10 +109,10 @@ export const TypographySectionSizing = (props: RenderCategoryProps) => {
     <Grid
       css={{
         gridTemplateColumns: "1fr 1fr 1fr",
-        gap: "$spacing$5",
+        gap: theme.spacing[5],
       }}
     >
-      <Grid css={{ gridTemplateColumns: "auto", gap: "$spacing$3" }}>
+      <Grid css={{ gridTemplateColumns: "auto", gap: theme.spacing[3] }}>
         <PropertyName
           style={currentStyle}
           property="fontSize"
@@ -125,7 +126,7 @@ export const TypographySectionSizing = (props: RenderCategoryProps) => {
           deleteProperty={deleteProperty}
         />
       </Grid>
-      <Grid css={{ gridTemplateColumns: "auto", gap: "$spacing$3" }}>
+      <Grid css={{ gridTemplateColumns: "auto", gap: theme.spacing[3] }}>
         <PropertyName
           style={currentStyle}
           property="lineHeight"
@@ -139,7 +140,7 @@ export const TypographySectionSizing = (props: RenderCategoryProps) => {
           deleteProperty={deleteProperty}
         />
       </Grid>
-      <Grid css={{ gridTemplateColumns: "auto", gap: "$spacing$3" }}>
+      <Grid css={{ gridTemplateColumns: "auto", gap: theme.spacing[3] }}>
         <PropertyName
           style={currentStyle}
           property="letterSpacing"
@@ -167,13 +168,13 @@ export const TypographySectionAdvanced = (props: RenderCategoryProps) => {
   return (
     <Grid
       css={{
-        gap: "$spacing$5",
+        gap: theme.spacing[5],
       }}
     >
       <Grid
         css={{
           gridTemplateColumns: "1fr 1fr",
-          gap: "$spacing$9",
+          gap: theme.spacing[9],
         }}
       >
         <ToggleGroupControl
@@ -229,7 +230,7 @@ export const TypographySectionAdvanced = (props: RenderCategoryProps) => {
       <Grid
         css={{
           gridTemplateColumns: "1fr 1fr auto",
-          gap: "$spacing$9",
+          gap: theme.spacing[9],
           alignItems: "center",
         }}
       >
@@ -294,7 +295,7 @@ export const TypographySectionAdvancedPopover = (
     <FloatingPanel
       title="Advanced Typography"
       content={
-        <Grid css={{ padding: "$spacing$9", gap: "$spacing$9" }}>
+        <Grid css={{ padding: theme.spacing[9], gap: theme.spacing[9] }}>
           <Grid css={{ gridTemplateColumns: "4fr 6fr" }}>
             <PropertyName
               style={currentStyle}

--- a/apps/designer/app/designer/features/style-panel/shared/color-picker.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/color-picker.tsx
@@ -13,15 +13,16 @@ import {
   css,
 } from "@webstudio-is/design-system";
 import { toValue } from "@webstudio-is/css-engine";
+import { theme } from "@webstudio-is/design-system";
 
 const pickerStyle = css({
-  padding: "$spacing$5",
-  background: "$panel",
+  padding: theme.spacing[5],
+  background: theme.colors.panel,
   // @todo this lib doesn't have another way to define styles for inputs
   // we should either submit a PR or replace it
   "& input": {
-    color: "$hiContrast",
-    background: "$loContrast",
+    color: theme.colors.hiContrast,
+    background: theme.colors.loContrast,
   },
 });
 
@@ -132,9 +133,9 @@ export const ColorPicker = ({
       >
         <Box
           css={{
-            margin: "$spacing$3",
-            width: "$spacing$10",
-            height: "$spacing$10",
+            margin: theme.spacing[3],
+            width: theme.spacing[10],
+            height: theme.spacing[10],
             borderRadius: 2,
             background: toValue(value),
           }}

--- a/apps/designer/app/designer/features/style-panel/shared/constants.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/constants.ts
@@ -1,2 +1,3 @@
+import { theme } from "@webstudio-is/design-system";
 // When a style value is defined on a selected breakpoint, we want to highlight the property name with this color.
-export const propertyNameColorForSelectedBreakpoint = "$blue11";
+export const propertyNameColorForSelectedBreakpoint = theme.colors.blue11;

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.stories.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.stories.tsx
@@ -4,6 +4,7 @@ import type { StyleValue } from "@webstudio-is/css-data";
 import { CssValueInput, type IntermediateStyleValue } from "./css-value-input";
 import { action } from "@storybook/addon-actions";
 import { toValue } from "@webstudio-is/css-engine";
+import { theme } from "@webstudio-is/design-system";
 
 export default {
   component: CssValueInput,
@@ -106,7 +107,7 @@ export const WithUnits = () => {
   >();
 
   return (
-    <Flex css={{ gap: "$spacing$9" }}>
+    <Flex css={{ gap: theme.spacing[9] }}>
       <CssValueInput
         styleSource="preset"
         property="rowGap"

--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -34,6 +34,7 @@ import { toValue } from "@webstudio-is/css-engine";
 import { useDebouncedCallback } from "use-debounce";
 import type { StyleSource } from "../style-info";
 import { toPascalCase } from "../keyword-utils";
+import { theme } from "@webstudio-is/design-system";
 
 // We increment by 10 when shift is pressed, by 0.1 when alt/option is pressed and by 1 by default.
 const calcNumberChange = (
@@ -517,20 +518,20 @@ const CssValueInputIconButton = styled(TextFieldIcon, {
   variants: {
     state: {
       set: {
-        backgroundColor: "$blue4",
-        color: "$blue11",
+        backgroundColor: theme.colors.blue4,
+        color: theme.colors.blue11,
         "&:hover": {
-          backgroundColor: "$blue4",
-          color: "$blue11",
+          backgroundColor: theme.colors.blue4,
+          color: theme.colors.blue11,
         },
       },
 
       inherited: {
-        backgroundColor: "$orange4",
-        color: "$orange11",
+        backgroundColor: theme.colors.orange4,
+        color: theme.colors.orange11,
         "&:hover": {
-          backgroundColor: "$orange4",
-          color: "$orange11",
+          backgroundColor: theme.colors.orange4,
+          color: theme.colors.orange11,
         },
       },
     },

--- a/apps/designer/app/designer/features/style-panel/shared/property-name.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/property-name.tsx
@@ -19,6 +19,7 @@ import { utils } from "@webstudio-is/project";
 import { isFeatureEnabled } from "~/shared/feature-flags";
 import { useBreakpoints, useRootInstance } from "~/shared/nano-states";
 import { type StyleInfo, type StyleSource, getStyleSource } from "./style-info";
+import { theme } from "@webstudio-is/design-system";
 
 const PropertyPopoverContent = ({
   properties,
@@ -37,13 +38,16 @@ const PropertyPopoverContent = ({
   if (styleSource === "local") {
     return (
       <>
-        <Flex align="start" css={{ px: "$spacing$4", py: "$spacing$3" }}>
+        <Flex
+          align="start"
+          css={{ px: theme.spacing[4], py: theme.spacing[3] }}
+        >
           <Button onClick={onReset} prefix={<UndoIcon />}>
             Reset
           </Button>
         </Flex>
         <Separator />
-        <Box css={{ px: "$spacing$4", py: "$spacing$3" }}>
+        <Box css={{ px: theme.spacing[4], py: theme.spacing[3] }}>
           {properties.map((property) => {
             const styleValueInfo = style[property];
 
@@ -86,7 +90,7 @@ const PropertyPopoverContent = ({
   }
 
   return (
-    <Box css={{ px: "$spacing$4", py: "$spacing$3" }}>
+    <Box css={{ px: theme.spacing[4], py: theme.spacing[3] }}>
       {properties.map((property) => {
         const styleValueInfo = style[property];
 
@@ -145,18 +149,18 @@ export const PropertyName = ({
     <Label
       css={{
         fontWeight: "inherit",
-        padding: "calc($spacing$3 / 2) $spacing$3",
-        borderRadius: "$borderRadius$4",
+        padding: `calc(${theme.spacing[3]} / 2) ${theme.spacing[3]}`,
+        borderRadius: theme.borderRadius[4],
         ...(styleSource === "local" && {
-          color: "$blue11",
-          backgroundColor: "$blue4",
+          color: theme.colors.blue11,
+          backgroundColor: theme.colors.blue4,
         }),
         ...(styleSource === "remote" && {
-          color: "$orange11",
-          backgroundColor: "$orange4",
+          color: theme.colors.orange11,
+          backgroundColor: theme.colors.orange4,
         }),
         ...(styleSource === "preset" && {
-          color: "$hiContrast",
+          color: theme.colors.hiContrast,
         }),
       }}
       htmlFor={property.toString()}

--- a/apps/designer/app/designer/features/style-panel/style-panel.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-panel.tsx
@@ -9,6 +9,7 @@ import {
   useCanvasWidth,
   useSelectedBreakpoint,
 } from "~/designer/shared/nano-states";
+import { theme } from "@webstudio-is/design-system";
 
 type StylePanelProps = {
   publish: Publish;
@@ -39,9 +40,9 @@ export const StylePanel = ({
 
   if (willRender(breakpoint, canvasWidth) === false) {
     return (
-      <Box css={{ p: "$spacing$5" }}>
-        <Card css={{ p: "$spacing$9", mt: "$spacing$9" }}>
-          <Paragraph css={{ marginBottom: "$spacing$5" }}>
+      <Box css={{ p: theme.spacing[5] }}>
+        <Card css={{ p: theme.spacing[9], mt: theme.spacing[9] }}>
+          <Paragraph css={{ marginBottom: theme.spacing[5] }}>
             {`Please increase the canvas width.`}
           </Paragraph>
           <Paragraph>
@@ -54,7 +55,7 @@ export const StylePanel = ({
 
   return (
     <>
-      <Box css={{ px: "$spacing$9", py: "$spacing$3" }}>
+      <Box css={{ px: theme.spacing[9], py: theme.spacing[3] }}>
         <SearchField
           placeholder="Search"
           onChange={(event) => {

--- a/apps/designer/app/designer/features/style-panel/style-source-input/style-source-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-source-input/style-source-input.tsx
@@ -21,6 +21,7 @@ import {
 import { mergeRefs } from "@react-aria/utils";
 import { ItemSource, StyleSource, type ItemState } from "./style-source";
 import { useSortable } from "./use-sortable";
+import { theme } from "@webstudio-is/design-system";
 
 type IntermediateItem = {
   id: string;
@@ -99,7 +100,7 @@ const TextFieldBase: ForwardRefRenderFunction<
       ref={mergeRefs(forwardedRef, containerRef ?? null, sortableRefCallback)}
       state={state}
       variant={textFieldVariant}
-      css={{ ...css, px: "$spacing$3", py: "$spacing$2" }}
+      css={{ ...css, px: theme.spacing[3], py: theme.spacing[2] }}
       onKeyDown={onKeyDown}
     >
       {value.map((item, index) => (

--- a/apps/designer/app/designer/features/style-panel/style-source-input/style-source.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-source-input/style-source.tsx
@@ -18,6 +18,7 @@ import {
   type KeyboardEventHandler,
   type FocusEvent,
 } from "react";
+import { theme } from "@webstudio-is/design-system";
 
 // Used to schedule function calls to be executed after at a later point in time.
 // Since menu is managing focus, we need to execute that callback when the management is done.
@@ -235,33 +236,33 @@ const useForceRecalcStyle = <Element extends HTMLElement>(
 
 const Item = styled("div", {
   display: "inline-flex",
-  borderRadius: "$borderRadius$3",
-  padding: "$spacing$4",
+  borderRadius: theme.borderRadius[3],
+  padding: theme.spacing[4],
   maxWidth: "100%",
   minWidth: 0,
   position: "relative",
-  color: "$colors$foregroundContrastMain",
+  color: theme.colors.foregroundContrastMain,
   ...menuCssVars({ show: false }),
   "&:hover": menuCssVars({ show: true }),
   variants: {
     source: {
       local: {
-        backgroundColor: "$colors$backgroundStyleSourceToken",
+        backgroundColor: theme.colors.backgroundStyleSourceToken,
       },
       token: {
-        backgroundColor: "$colors$backgroundStyleSourceToken",
+        backgroundColor: theme.colors.backgroundStyleSourceToken,
       },
       tag: {
-        backgroundColor: "$colors$backgroundStyleSourceTag",
+        backgroundColor: theme.colors.backgroundStyleSourceTag,
       },
       state: {
-        backgroundColor: "$colors$backgroundStyleSourceState",
+        backgroundColor: theme.colors.backgroundStyleSourceState,
       },
     },
     state: {
       selected: {},
       unselected: {
-        backgroundColor: "$colors$backgroundStyleSourceNeutral",
+        backgroundColor: theme.colors.backgroundStyleSourceNeutral,
       },
       disabled: {
         // @todo styling
@@ -269,7 +270,7 @@ const Item = styled("div", {
       },
       editing: {},
       dragging: {
-        backgroundColor: "$colors$backgroundStyleSourceDisabled",
+        backgroundColor: theme.colors.backgroundStyleSourceDisabled,
       },
     },
   },

--- a/apps/designer/app/designer/features/topbar/menu/menu.tsx
+++ b/apps/designer/app/designer/features/topbar/menu/menu.tsx
@@ -134,7 +134,7 @@ export const Menu = ({ publish }: MenuProps) => {
       </DropdownMenuTrigger>
       <DropdownMenuPortal>
         <DropdownMenuContent
-          css={{ zIndex: "$1" }}
+          css={{ zIndex: variables.zIndices[1] }}
           sideOffset={4}
           collisionPadding={4}
         >

--- a/apps/designer/app/designer/features/topbar/menu/menu.tsx
+++ b/apps/designer/app/designer/features/topbar/menu/menu.tsx
@@ -134,7 +134,7 @@ export const Menu = ({ publish }: MenuProps) => {
       </DropdownMenuTrigger>
       <DropdownMenuPortal>
         <DropdownMenuContent
-          css={{ zIndex: variables.zIndices[1] }}
+          css={{ zIndex: theme.zIndices[1] }}
           sideOffset={4}
           collisionPadding={4}
         >

--- a/apps/designer/app/designer/features/topbar/menu/menu.tsx
+++ b/apps/designer/app/designer/features/topbar/menu/menu.tsx
@@ -28,10 +28,11 @@ import {
 import { useClientSettings } from "~/designer/shared/client-settings";
 import { dashboardPath } from "~/shared/router-utils";
 import { isFeatureEnabled } from "~/shared/feature-flags";
+import { theme } from "@webstudio-is/design-system";
 
 const menuItemCss = {
   display: "flex",
-  gap: "$spacing$9",
+  gap: theme.spacing[9],
   justifyContent: "space-between",
   flexGrow: 1,
   minWidth: 140,
@@ -116,7 +117,7 @@ export const Menu = ({ publish }: MenuProps) => {
       <DropdownMenuTrigger asChild>
         <Box
           css={{
-            width: "$spacing$17",
+            width: theme.spacing[17],
             height: "100%",
             borderRadius: "0",
             outline: "none",

--- a/apps/designer/app/designer/features/topbar/publish.tsx
+++ b/apps/designer/app/designer/features/topbar/publish.tsx
@@ -59,7 +59,8 @@ const Content = ({ project }: PublishButtonProps) => {
               target="_blank"
               css={{
                 display: "flex",
-                gap: "$0",
+                // @todo: check that this works as before
+                gap: variables.spacing[0],
               }}
             >
               <Text truncate>{`${domain}.${getHost()}`}</Text>

--- a/apps/designer/app/designer/features/topbar/publish.tsx
+++ b/apps/designer/app/designer/features/topbar/publish.tsx
@@ -19,6 +19,7 @@ import { useIsPublishDialogOpen } from "../../shared/nano-states";
 import env from "~/shared/env";
 import type { Project } from "@webstudio-is/project";
 import { restPublishPath } from "~/shared/router-utils";
+import { theme } from "@webstudio-is/design-system";
 type PublishButtonProps = { project: Project };
 
 const getHost = () => {
@@ -44,7 +45,7 @@ const Content = ({ project }: PublishButtonProps) => {
 
   return (
     <PopoverContent
-      css={{ padding: "$spacing$9" }}
+      css={{ padding: theme.spacing[9] }}
       hideArrow={true}
       onFocusOutside={(event) => {
         // Used to prevent closing when opened from the main dropdown menu
@@ -88,7 +89,10 @@ export const PublishButton = ({ project }: PublishButtonProps) => {
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild aria-label="Publish">
-        <DeprecatedButton ghost css={{ display: "flex", gap: "$spacing$3" }}>
+        <DeprecatedButton
+          ghost
+          css={{ display: "flex", gap: theme.spacing[3] }}
+        >
           <RocketIcon />
           <Text>Publish</Text>
         </DeprecatedButton>

--- a/apps/designer/app/designer/features/topbar/publish.tsx
+++ b/apps/designer/app/designer/features/topbar/publish.tsx
@@ -59,7 +59,7 @@ const Content = ({ project }: PublishButtonProps) => {
               target="_blank"
               css={{
                 display: "flex",
-                gap: variables.spacing[0],
+                gap: theme.spacing[0],
               }}
             >
               <Text truncate>{`${domain}.${getHost()}`}</Text>

--- a/apps/designer/app/designer/features/topbar/publish.tsx
+++ b/apps/designer/app/designer/features/topbar/publish.tsx
@@ -59,7 +59,6 @@ const Content = ({ project }: PublishButtonProps) => {
               target="_blank"
               css={{
                 display: "flex",
-                // @todo: check that this works as before
                 gap: variables.spacing[0],
               }}
             >

--- a/apps/designer/app/designer/features/topbar/share.tsx
+++ b/apps/designer/app/designer/features/topbar/share.tsx
@@ -10,6 +10,7 @@ import {
 } from "@webstudio-is/design-system";
 import { Share1Icon } from "@webstudio-is/icons";
 import { useIsShareDialogOpen } from "../../shared/nano-states";
+import { theme } from "@webstudio-is/design-system";
 
 type ShareButtonProps = {
   url: string;
@@ -21,7 +22,7 @@ const Content = ({ url }: ShareButtonProps) => {
   }
   return (
     <PopoverContent
-      css={{ padding: "$spacing$9" }}
+      css={{ padding: theme.spacing[9] }}
       hideArrow={true}
       onFocusOutside={(event) => {
         // Used to prevent closing when opened from the main dropdown menu

--- a/apps/designer/app/designer/features/topbar/sync-status.tsx
+++ b/apps/designer/app/designer/features/topbar/sync-status.tsx
@@ -7,14 +7,15 @@ import {
 } from "@webstudio-is/design-system";
 import { CheckIcon, DotsHorizontalIcon } from "@webstudio-is/icons";
 import { useSyncStatus } from "../../shared/nano-states";
+import { theme } from "@webstudio-is/design-system";
 
 const iconSize = 15;
 
 const StyledCheckIcon = styled(CheckIcon, {
   width: iconSize,
   height: iconSize,
-  background: "$green9",
-  borderRadius: "$borderRadius$round",
+  background: theme.colors.green9,
+  borderRadius: theme.borderRadius.round,
 });
 
 const ellipsisKeyframes = keyframes({

--- a/apps/designer/app/designer/features/topbar/topbar.tsx
+++ b/apps/designer/app/designer/features/topbar/topbar.tsx
@@ -7,6 +7,7 @@ import { SyncStatus } from "./sync-status";
 import { Menu } from "./menu";
 import { Breakpoints } from "../breakpoints";
 import type { Project } from "@webstudio-is/project";
+import { theme } from "@webstudio-is/design-system";
 
 type TopbarProps = {
   css: CSS;
@@ -22,10 +23,10 @@ export const Topbar = ({ css, project, publish, previewUrl }: TopbarProps) => {
       align="center"
       justify="between"
       css={{
-        bc: "$loContrast",
-        height: "$spacing$17",
+        bc: theme.colors.loContrast,
+        height: theme.spacing[17],
         "[data-theme=dark] &": {
-          boxShadow: "inset 0 -1px 0 0 $colors$panelOutline",
+          boxShadow: `inset 0 -1px 0 0 ${theme.colors.panelOutline}`,
         },
         // @todo: uhh, setting this on any focused child element? lets see what's the use case and why its necessary to override vs. not having it in the first place
         "& :focus": {
@@ -48,7 +49,7 @@ export const Topbar = ({ css, project, publish, previewUrl }: TopbarProps) => {
           "& > *": {
             height: "inherit",
             width: "auto",
-            padding: "0 $spacing$5",
+            padding: `0 ${theme.spacing[5]}`,
           },
         }}
       >

--- a/apps/designer/app/designer/features/tree-preview/tree-preview.tsx
+++ b/apps/designer/app/designer/features/tree-preview/tree-preview.tsx
@@ -5,6 +5,7 @@ import { Flex } from "@webstudio-is/design-system";
 import { useRootInstance, useDragAndDropState } from "~/shared/nano-states";
 import { InstanceTreeNode } from "~/designer/shared/tree";
 import { utils } from "@webstudio-is/project";
+import { theme } from "@webstudio-is/design-system";
 
 export const TreePrevew = () => {
   const [rootInstance] = useRootInstance();
@@ -70,7 +71,7 @@ export const TreePrevew = () => {
     treeProps && (
       <Flex
         direction="column"
-        css={{ pt: "$spacing$3", pb: "$spacing$3", width: "100%" }}
+        css={{ pt: theme.spacing[3], pb: theme.spacing[3], width: "100%" }}
       >
         <InstanceTreeNode {...treeProps} />
       </Flex>

--- a/apps/designer/app/designer/features/workspace/canvas-tools/outline/label.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/outline/label.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { styled, type Rect } from "@webstudio-is/design-system";
 import { type Instance, getComponentMeta } from "@webstudio-is/react-sdk";
+import { theme } from "@webstudio-is/design-system";
 
 type LabelPosition = "top" | "inside" | "bottom";
 type LabelRefCallback = (element: HTMLElement | null) => void;
@@ -39,30 +40,30 @@ const LabelContainer = styled(
   {
     position: "absolute",
     display: "flex",
-    padding: "0 $spacing$3",
-    height: "$spacing$10",
+    padding: `0 ${theme.spacing[3]}`,
+    height: theme.spacing[10],
     color: "white",
     alignItems: "center",
     justifyContent: "center",
-    gap: "$spacing$3",
-    fontSize: "$fontSize$3",
-    fontFamily: "$sans",
+    gap: theme.spacing[3],
+    fontSize: theme.fontSize[3],
+    fontFamily: theme.fonts.sans,
     lineHeight: 1,
-    minWidth: "$spacing$13",
+    minWidth: theme.spacing[13],
     whiteSpace: "nowrap",
-    backgroundColor: "$blue9",
+    backgroundColor: theme.colors.blue9,
   },
   {
     variants: {
       position: {
         top: {
-          top: "-$spacing$10",
+          top: `-${theme.spacing[10]}`,
         },
         inside: {
           top: 0,
         },
         bottom: {
-          bottom: "-$spacing$10",
+          bottom: `-${theme.spacing[10]}`,
         },
       },
     },

--- a/apps/designer/app/designer/features/workspace/canvas-tools/outline/outline.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/outline/outline.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from "react";
 import { styled, type Rect } from "@webstudio-is/design-system";
+import { theme } from "@webstudio-is/design-system";
 
 const OutlineContainer = styled("div", {
   position: "absolute",
   pointerEvents: "none",
-  outline: "1px solid $blue9",
+  outline: `1px solid ${theme.colors.blue9}`,
   outlineOffset: -1,
   top: 0,
   left: 0,

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -17,6 +17,7 @@ import {
   CrossSmallIcon,
 } from "@webstudio-is/icons";
 import { useSubscribe } from "~/shared/pubsub";
+import { theme } from "@webstudio-is/design-system";
 
 type Format =
   | "bold"
@@ -99,10 +100,10 @@ const Toolbar = ({ state, onToggle }: ToolbarProps) => {
         top: 0,
         left: 0,
         pointerEvents: "auto",
-        background: "$loContrast",
-        padding: "$spacing$3",
-        borderRadius: "$borderRadius$6",
-        border: "1px solid $slate8",
+        background: theme.colors.loContrast,
+        padding: theme.spacing[3],
+        borderRadius: theme.borderRadius[6],
+        border: `1px solid ${theme.colors.slate8}`,
         filter:
           "drop-shadow(0px 2px 7px rgba(0, 0, 0, 0.1)) drop-shadow(0px 5px 17px rgba(0, 0, 0, 0.15))",
       }}

--- a/apps/designer/app/designer/features/workspace/workspace.tsx
+++ b/apps/designer/app/designer/features/workspace/workspace.tsx
@@ -2,10 +2,11 @@ import { Box, Flex, Toaster } from "@webstudio-is/design-system";
 import { useCanvasWidth, useZoom } from "~/designer/shared/nano-states";
 import { CanvasTools } from "./canvas-tools";
 import { type Publish } from "~/shared/pubsub";
+import { theme } from "@webstudio-is/design-system";
 
 const workspaceStyle = {
   flexGrow: 1,
-  background: "$gray3",
+  background: theme.colors.gray3,
   // scroll behaviour should be derived from the iframe
   overflow: "hidden",
   scrollbarGutter: "stable",

--- a/apps/designer/app/designer/shared/assets/assets-shell.tsx
+++ b/apps/designer/app/designer/shared/assets/assets-shell.tsx
@@ -4,6 +4,7 @@ import { Flex, SearchField } from "@webstudio-is/design-system";
 import { AssetUpload } from "./asset-upload";
 import { NotFound } from "./not-found";
 import { Separator } from "./separator";
+import { theme } from "@webstudio-is/design-system";
 
 type AssetsShellProps = {
   searchProps: ComponentProps<typeof SearchField>;
@@ -23,11 +24,11 @@ export const AssetsShell = ({
       direction="column"
       css={{
         overflow: "hidden",
-        py: "$spacing$5",
+        py: theme.spacing[5],
       }}
     >
       <Flex
-        css={{ py: "$spacing$5", px: "$spacing$9" }}
+        css={{ py: theme.spacing[5], px: theme.spacing[9] }}
         gap="2"
         direction="column"
         shrink={false}
@@ -40,7 +41,7 @@ export const AssetsShell = ({
       <Flex
         css={{
           flexDirection: "column",
-          px: "$spacing$9",
+          px: theme.spacing[9],
           overflow: "auto",
         }}
       >

--- a/apps/designer/app/designer/shared/assets/separator.tsx
+++ b/apps/designer/app/designer/shared/assets/separator.tsx
@@ -2,8 +2,9 @@ import {
   Separator as SeparatorPrimitive,
   styled,
 } from "@webstudio-is/design-system";
+import { theme } from "@webstudio-is/design-system";
 
 export const Separator = styled(SeparatorPrimitive, {
-  marginTop: "$spacing$3",
-  marginBottom: "$spacing$5",
+  marginTop: theme.spacing[3],
+  marginBottom: theme.spacing[5],
 });

--- a/apps/designer/app/designer/shared/design-tokens-manager/item-menu.tsx
+++ b/apps/designer/app/designer/shared/design-tokens-manager/item-menu.tsx
@@ -16,6 +16,7 @@ import {
   useEffect,
   type MouseEventHandler,
 } from "react";
+import { theme } from "@webstudio-is/design-system";
 
 const stopPropagation: MouseEventHandler = (event) => {
   // Prevent setting the current font to the item.
@@ -23,9 +24,9 @@ const stopPropagation: MouseEventHandler = (event) => {
 };
 
 const MenuButton = styled(DeprecatedIconButton, {
-  color: "$hint",
+  color: theme.colors.hint,
   "&:hover, &:focus-visible": {
-    color: "$hiContrast",
+    color: theme.colors.hiContrast,
   },
 });
 
@@ -78,7 +79,7 @@ const ItemMenu = ({
         </MenuButton>
       </DropdownMenuTrigger>
       <DropdownMenuPortal>
-        <DropdownMenuContent align="start" css={{ zIndex: "$zIndices$1" }}>
+        <DropdownMenuContent align="start" css={{ zIndex: theme.zIndices[1] }}>
           <DropdownMenuItem
             onClick={stopPropagation}
             onSelect={() => {

--- a/apps/designer/app/designer/shared/design-tokens-manager/token-editor.tsx
+++ b/apps/designer/app/designer/shared/design-tokens-manager/token-editor.tsx
@@ -17,6 +17,7 @@ import { PlusIcon } from "@webstudio-is/icons";
 import { DesignToken } from "@webstudio-is/design-tokens";
 import { useDesignTokens } from "~/shared/nano-states";
 import { findByName } from "./utils";
+import { theme } from "@webstudio-is/design-system";
 
 const validate = (
   tokens: Array<DesignToken>,
@@ -158,20 +159,24 @@ export const TokenEditor = ({
         )}
       </PopoverTrigger>
       <PopoverPortal>
-        <PopoverContent align="end" css={{ zIndex: "$zIndices$1" }}>
+        <PopoverContent align="end" css={{ zIndex: theme.zIndices[1] }}>
           <form onChange={handleChange} onSubmit={handleSubmit} ref={formRef}>
-            <Flex direction="column" gap="2" css={{ padding: "$spacing$7" }}>
+            <Flex
+              direction="column"
+              gap="2"
+              css={{ padding: theme.spacing[7] }}
+            >
               <Label htmlFor="name">Name</Label>
               <InputErrorsTooltip
                 errors={getErrors("name", validationResult)}
-                css={{ zIndex: "$zIndices$2" }}
+                css={{ zIndex: theme.zIndices[2] }}
               >
                 <TextField id="name" name="name" defaultValue={token?.name} />
               </InputErrorsTooltip>
               <Label htmlFor="value">Value</Label>
               <InputErrorsTooltip
                 errors={getErrors("value", validationResult)}
-                css={{ zIndex: "$zIndices$2" }}
+                css={{ zIndex: theme.zIndices[2] }}
               >
                 <TextField
                   id="value"

--- a/apps/designer/app/designer/shared/floating-panel/floating-panel.tsx
+++ b/apps/designer/app/designer/shared/floating-panel/floating-panel.tsx
@@ -13,6 +13,7 @@ import {
   useState,
 } from "react";
 import { FloatingPanelContext } from "./floating-panel-provider";
+import { theme } from "@webstudio-is/design-system";
 
 const useSideOffset = ({
   isOpen,
@@ -83,7 +84,7 @@ export const FloatingPanel = ({
           side="left"
           hideArrow
           align="start"
-          css={{ width: "$spacing$30" }}
+          css={{ width: theme.spacing[30] }}
         >
           {content}
           <PopoverHeader title={title} />

--- a/apps/designer/app/designer/shared/fonts-manager/item-menu.tsx
+++ b/apps/designer/app/designer/shared/fonts-manager/item-menu.tsx
@@ -10,11 +10,12 @@ import {
 } from "@webstudio-is/design-system";
 import { MenuIcon } from "@webstudio-is/icons";
 import { type FocusEventHandler, useState, useRef, useEffect } from "react";
+import { theme } from "@webstudio-is/design-system";
 
 const MenuButton = styled(DeprecatedIconButton, {
-  color: "$hint",
+  color: theme.colors.hint,
   "&:hover, &:focus-visible": {
-    color: "$hiContrast",
+    color: theme.colors.hiContrast,
   },
 });
 

--- a/apps/designer/app/designer/shared/image-manager/image-info-tigger.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-info-tigger.tsx
@@ -51,7 +51,7 @@ export const ImageInfoTrigger = ({
         </DeprecatedButton>
       </PopoverTrigger>
       <PopoverPortal>
-        <PopoverContent css={{ zIndex: variables.zIndices[1] }}>
+        <PopoverContent css={{ zIndex: theme.zIndices[1] }}>
           <PopoverHeader title="Asset Details" />
           <ImageInfo
             onDelete={(ids) => {

--- a/apps/designer/app/designer/shared/image-manager/image-info-tigger.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-info-tigger.tsx
@@ -51,7 +51,7 @@ export const ImageInfoTrigger = ({
         </DeprecatedButton>
       </PopoverTrigger>
       <PopoverPortal>
-        <PopoverContent css={{ zIndex: "$1" }}>
+        <PopoverContent css={{ zIndex: variables.zIndices[1] }}>
           <PopoverHeader title="Asset Details" />
           <ImageInfo
             onDelete={(ids) => {

--- a/apps/designer/app/designer/shared/image-manager/image-info-tigger.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-info-tigger.tsx
@@ -11,6 +11,7 @@ import { GearIcon, gearIconCssVars } from "@webstudio-is/icons";
 import { ImageInfo } from "./image-info";
 import { cssVars } from "@webstudio-is/css-vars";
 import { Asset } from "@webstudio-is/asset-uploader";
+import { theme } from "@webstudio-is/design-system";
 
 const triggerVisibilityVar = cssVars.define("trigger-visibility");
 
@@ -36,15 +37,15 @@ export const ImageInfoTrigger = ({
           css={{
             visibility: cssVars.use(triggerVisibilityVar, "hidden"),
             position: "absolute",
-            color: "$slate11",
-            top: "$spacing$3",
-            right: "$spacing$3",
+            color: theme.colors.slate11,
+            top: theme.spacing[3],
+            right: theme.spacing[3],
             cursor: "pointer",
             transition: "opacity 100ms ease",
             "&:hover": {
-              color: "$hiContrast",
+              color: theme.colors.hiContrast,
             },
-            ...gearIconCssVars({ fill: "$colors$loContrast" }),
+            ...gearIconCssVars({ fill: theme.colors.loContrast }),
           }}
         >
           <GearIcon />

--- a/apps/designer/app/designer/shared/image-manager/image-info.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-info.tsx
@@ -9,6 +9,7 @@ import {
 import prettyBytes from "pretty-bytes";
 import { Asset } from "@webstudio-is/asset-uploader";
 import { Filename } from "./filename";
+import { theme } from "@webstudio-is/design-system";
 
 type ImageInfoProps = {
   asset: Asset;
@@ -19,34 +20,34 @@ export const ImageInfo = ({ asset, onDelete }: ImageInfoProps) => {
   const { size, meta, id, name } = asset;
   return (
     <>
-      <Box css={{ p: "$spacing$5 $spacing$9" }}>
+      <Box css={{ p: `${theme.spacing[5]} ${theme.spacing[9]}` }}>
         <Grid columns={2} align="center" gap={2}>
           <Box css={{ width: 100 }}>
             <Filename variant="label">{name}</Filename>
           </Box>
-          <Flex align="center" css={{ gap: "$spacing$3" }}>
+          <Flex align="center" css={{ gap: theme.spacing[3] }}>
             <CloudIcon />
             <Text variant="label">{prettyBytes(size)}</Text>
           </Flex>
         </Grid>
       </Box>
       {"width" in meta && "height" in meta ? (
-        <Box css={{ p: "$spacing$5 $spacing$9" }}>
+        <Box css={{ p: `${theme.spacing[5]} ${theme.spacing[9]}` }}>
           <Grid columns={2} gap={2} align="center">
-            <Flex align="center" css={{ gap: "$spacing$3" }}>
+            <Flex align="center" css={{ gap: theme.spacing[3] }}>
               <SizeIcon />
               <Text variant="label">
                 {meta.width} x {meta.height}
               </Text>
             </Flex>{" "}
-            <Flex align="center" css={{ gap: "$spacing$3" }}>
+            <Flex align="center" css={{ gap: theme.spacing[3] }}>
               <AspectRatioIcon />
               <Text variant="label">{getFormattedAspectRatio(meta)}</Text>
             </Flex>
           </Grid>
         </Box>
       ) : null}
-      <Box css={{ p: "$spacing$5 $spacing$9" }}>
+      <Box css={{ p: `${theme.spacing[5]} ${theme.spacing[9]}` }}>
         <Button
           variant="destructive"
           onClick={() => onDelete([id])}

--- a/apps/designer/app/designer/shared/image-manager/image-thumbnail.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-thumbnail.tsx
@@ -5,6 +5,7 @@ import { ImageInfoTrigger, imageInfoTriggerCssVars } from "./image-info-tigger";
 import type { AssetContainer } from "~/designer/shared/assets";
 import { Filename } from "./filename";
 import { Image } from "./image";
+import { theme } from "@webstudio-is/design-system";
 
 const ThumbnailContainer = styled(Box, {
   position: "relative",
@@ -12,13 +13,13 @@ const ThumbnailContainer = styled(Box, {
   justifyContent: "center",
   alignItems: "center",
   flexDirection: "column",
-  margin: "$spacing$2",
+  margin: theme.spacing[2],
   border: "2px solid transparent",
-  borderRadius: "$borderRadius$4",
+  borderRadius: theme.borderRadius[4],
   outline: 0,
-  gap: "$spacing$3",
+  gap: theme.spacing[3],
   overflow: "hidden",
-  backgroundColor: "$slate4",
+  backgroundColor: theme.colors.slate4,
   "&:hover": imageInfoTriggerCssVars({ show: true }),
   variants: {
     status: {
@@ -28,8 +29,7 @@ const ThumbnailContainer = styled(Box, {
     },
     state: {
       selected: {
-        boxShadow:
-          "0px 0px 0px 2px $colors$blue10, 0px 0px 0px 2px $colors$blue10",
+        boxShadow: `0px 0px 0px 2px ${theme.colors.blue10}, 0px 0px 0px 2px ${theme.colors.blue10}`,
       },
     },
   },
@@ -37,7 +37,7 @@ const ThumbnailContainer = styled(Box, {
 
 const Thumbnail = styled(Box, {
   width: "100%",
-  height: "$spacing$19",
+  height: theme.spacing[19],
   flexShrink: 0,
   position: "relative",
 });

--- a/apps/designer/app/designer/shared/inspector/collapsible-section.tsx
+++ b/apps/designer/app/designer/shared/inspector/collapsible-section.tsx
@@ -2,6 +2,7 @@ import { atom } from "nanostores";
 import { useStore } from "@nanostores/react";
 import { Box, Flex, Text, Collapsible } from "@webstudio-is/design-system";
 import { ChevronLeftIcon, ChevronRightIcon } from "@webstudio-is/icons";
+import { theme } from "@webstudio-is/design-system";
 
 type CollapsibleSectionProps = {
   label: string;
@@ -39,7 +40,7 @@ export const CollapsibleSection = ({
     <Collapsible.Root open={isOpenFinal} onOpenChange={setIsOpenByUser}>
       <Box
         css={{
-          boxShadow: "0px 1px 0 $colors$panelOutline",
+          boxShadow: `0px 1px 0 ${theme.colors.panelOutline}`,
         }}
       >
         <Collapsible.Trigger asChild>
@@ -48,9 +49,9 @@ export const CollapsibleSection = ({
             gap="1"
             justify="between"
             css={{
-              py: "$spacing$9",
-              px: "$spacing$9",
-              color: "$hiContrast",
+              py: theme.spacing[9],
+              px: theme.spacing[9],
+              color: theme.colors.hiContrast,
               cursor: "default",
               userSelect: "none",
             }}
@@ -59,7 +60,10 @@ export const CollapsibleSection = ({
             <Flex
               align="center"
               justify="center"
-              css={{ marginRight: "-$spacing$3", color: "$slate9" }}
+              css={{
+                marginRight: `-${theme.spacing[3]}`,
+                color: theme.colors.slate9,
+              }}
             >
               {rightSlot}
               {isOpenFinal ? <ChevronLeftIcon /> : <ChevronRightIcon />}
@@ -71,7 +75,7 @@ export const CollapsibleSection = ({
             gap="3"
             direction="column"
             css={{
-              p: "$spacing$9",
+              p: theme.spacing[9],
               paddingTop: 0,
               "&:empty": {
                 display: "none",

--- a/apps/designer/app/designer/shared/inspector/component-info.tsx
+++ b/apps/designer/app/designer/shared/inspector/component-info.tsx
@@ -1,6 +1,7 @@
 import { getComponentMeta } from "@webstudio-is/react-sdk";
 import { Flex, Text } from "@webstudio-is/design-system";
 import type { SelectedInstanceData } from "@webstudio-is/project";
+import { theme } from "@webstudio-is/design-system";
 
 export const ComponentInfo = ({
   selectedInstanceData,
@@ -11,8 +12,8 @@ export const ComponentInfo = ({
     <Flex justify="between" align="center">
       <Text
         css={{
-          fontSize: "$fontSize$3",
-          color: "$colors$slate11",
+          fontSize: theme.fontSize[3],
+          color: theme.colors.slate11,
           fontWeight: "500",
         }}
       >{`Selected: ${

--- a/codemod/migrate-css-variables.ts
+++ b/codemod/migrate-css-variables.ts
@@ -155,6 +155,10 @@ const addImport = (code: string, filePath: string) => {
     nextLinesReverse.push(line);
   }
 
+  if (inserted === false) {
+    nextLinesReverse.push(importCode);
+  }
+
   return nextLinesReverse.reverse().join("\n");
 };
 

--- a/codemod/migrate-css-variables.ts
+++ b/codemod/migrate-css-variables.ts
@@ -145,7 +145,10 @@ const addImport = (code: string, filePath: string) => {
   let inserted = false;
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i];
-    if (line.startsWith("import") && inserted === false) {
+    if (
+      (line.startsWith("import") || line.startsWith("} from")) &&
+      inserted === false
+    ) {
       nextLinesReverse.push(importCode);
       inserted = true;
     }

--- a/codemod/migrate-css-variables.ts
+++ b/codemod/migrate-css-variables.ts
@@ -1,0 +1,154 @@
+/**
+ * To run it go to the root:
+ *    $ pnpm tsx ./codemod/migrate-css-variables.ts
+ *    $ pnpm run format
+ *    $ pnpm run checks
+ */
+/* eslint-disable no-console, @typescript-eslint/no-explicit-any  */
+/// <reference lib="es2021" />
+
+import fs from "fs/promises";
+import path from "path";
+
+const getRecursiveFileReads = async (dir: string) => {
+  const results: any = [];
+  const files = await fs.readdir(dir);
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    const stat = await fs.stat(filePath);
+    if (stat.isDirectory() && file !== "node_modules") {
+      results.push(...(await getRecursiveFileReads(filePath)));
+      continue;
+    }
+
+    if (path.extname(file) !== ".tsx" && path.extname(file) !== ".ts") {
+      continue;
+    }
+
+    const buffer = await fs.readFile(filePath);
+
+    results.push({
+      filePath,
+      buffer,
+    });
+  }
+  return results;
+};
+
+const readDirectory = async (dir: string) => {
+  const results = await getRecursiveFileReads(dir);
+  return results;
+};
+
+const printProperty = (name: string) => {
+  if (/^[0-9a-z]+$/i.test(name) && /^[0-9]/.test(name) === false) {
+    return `.${name}`;
+  }
+  return /^[0-9]+$/.test(name) ? `[${name}]` : `["${name}"]`;
+};
+
+const printVariable = (variableName: string, groupName: string) =>
+  `variables${printProperty(groupName)}${printProperty(variableName)}`;
+
+const guessGroupName = (variableName: string) => {
+  if (
+    /^(slate|yellow|orange|blue|sky|green|gray|red|mint|amber|lime|gold|cyan|indigo|grass|crimson|pink|purple|teal|violet|bronze|brown|tomato|plum)A?[0-9]+$/.test(
+      variableName
+    ) ||
+    [
+      "panel",
+      "loContrast",
+      "hiContrast",
+      "hint",
+      "muted",
+      "highContrast",
+      "transparentExtreme",
+      "background",
+    ].includes(variableName)
+  ) {
+    return "colors";
+  }
+  if (variableName === "sans" || variableName === "mono") {
+    return "fonts";
+  }
+  return undefined;
+};
+
+const migrateVariables = (originalCode: string, filePath: string) => {
+  let code = originalCode;
+
+  // "$bar$1" -> variables.bar[1]
+  code = code.replaceAll(
+    /"\$([a-z0-9]+)(?:\$([a-z0-9]+))?"/gi,
+    (orig, match1, match2) => {
+      if (match2 && match2) {
+        return printVariable(match2, match1);
+      }
+      const groupName = guessGroupName(match1);
+      if (groupName) {
+        return printVariable(match1, groupName);
+      }
+      return orig;
+    }
+  );
+
+  const replaceStringContent = (
+    string: string,
+    originalStringContent: string
+  ) => {
+    const stringContent = originalStringContent.replaceAll(
+      /\$([a-z0-9]+)(?:\$([a-z0-9]+))?/gi,
+      (orig, match1, match2) => {
+        if (match2 && match2) {
+          return `\${${printVariable(match2, match1)}}`;
+        }
+        const groupName = guessGroupName(match1);
+        if (groupName) {
+          return `\${${printVariable(match1, groupName)}}`;
+        }
+        return orig;
+      }
+    );
+
+    if (stringContent === originalStringContent) {
+      return string;
+    }
+    return `\`${stringContent}\``;
+  };
+
+  // "something $bar$1" -> `something ${variables.bar[1]}`
+  code = code.replaceAll(/"([^"]*)"/g, replaceStringContent);
+
+  // `something $bar$1` -> `something ${variables.bar[1]}`
+  code = code.replaceAll(/`([^`]*)`/g, replaceStringContent);
+
+  return code;
+};
+
+const update = async ({ filePath, buffer }) => {
+  if (filePath.endsWith("stitches.config.ts") || filePath.endsWith(".d.ts")) {
+    return;
+  }
+
+  const originalCode = buffer.toString("utf-8");
+
+  let code = originalCode;
+
+  code = migrateVariables(originalCode, filePath);
+
+  if (code === originalCode) {
+    return;
+  }
+
+  await fs.writeFile(filePath, code);
+};
+
+const main = async () => {
+  const files = [
+    ...(await readDirectory(path.resolve(__dirname, "..", "packages"))),
+    ...(await readDirectory(path.resolve(__dirname, "..", "apps"))),
+  ];
+  files.forEach(update);
+};
+
+main();

--- a/codemod/migrate-css-variables.ts
+++ b/codemod/migrate-css-variables.ts
@@ -1,6 +1,6 @@
 /**
  * To run it go to the root:
- *    $ pnpm tsx ./codemod/migrate-css-variables.ts
+ *    $ pnpm tsx ./codemod/migrate-css-theme.ts
  *    $ pnpm run format
  *    $ pnpm run checks
  */
@@ -48,7 +48,7 @@ const printProperty = (name: string) => {
 };
 
 const printVariable = (variableName: string, groupName: string) =>
-  `variables${printProperty(groupName)}${printProperty(variableName)}`;
+  `theme${printProperty(groupName)}${printProperty(variableName)}`;
 
 const guessGroupName = (variableName: string) => {
   if (
@@ -77,7 +77,7 @@ const guessGroupName = (variableName: string) => {
 const migrateVariables = (originalCode: string) => {
   let code = originalCode;
 
-  // "$bar$1" -> variables.bar[1]
+  // "$bar$1" -> theme.bar[1]
   code = code.replaceAll(
     /"\$([a-z0-9]+)(?:\$([a-z0-9]+))?"/gi,
     (orig, match1, match2) => {
@@ -93,7 +93,7 @@ const migrateVariables = (originalCode: string) => {
   );
 
   const replaceStringContent = (
-    string: string,
+    originalString: string,
     originalStringContent: string
   ) => {
     const stringContent = originalStringContent.replaceAll(
@@ -111,28 +111,28 @@ const migrateVariables = (originalCode: string) => {
     );
 
     if (stringContent === originalStringContent) {
-      return string;
+      return originalString;
     }
     return `\`${stringContent}\``;
   };
 
-  // "something $bar$1" -> `something ${variables.bar[1]}`
+  // "something $bar$1" -> `something ${theme.bar[1]}`
   code = code.replaceAll(/"([^"]*)"/g, replaceStringContent);
 
-  // `something $bar$1` -> `something ${variables.bar[1]}`
+  // `something $bar$1` -> `something ${theme.bar[1]}`
   code = code.replaceAll(/`([^`]*)`/g, replaceStringContent);
 
   return code;
 };
 
 const addImport = (code: string, filePath: string) => {
-  let importCode = `import { variables } from "@webstudio-is/design-system";`;
+  let importCode = `import { theme } from "@webstudio-is/design-system";`;
 
   const pathParts = filePath.split(path.sep);
   const designSystemIndex = pathParts.indexOf("design-system");
 
   if (designSystemIndex !== -1) {
-    importCode = `import { variables } from "${"../".repeat(
+    importCode = `import { theme } from "${"../".repeat(
       pathParts.length - designSystemIndex - 3
     )}stitches.config";`;
   }

--- a/packages/design-system/lostpixel.config.ts
+++ b/packages/design-system/lostpixel.config.ts
@@ -6,7 +6,7 @@ export const config: CustomProjectConfig = {
     storybookUrl: "packages/design-system/storybook-static",
   },
   lostPixelProjectId: "cl8a8xmx714904901m9oce4vhqc",
-  lostPixelUrl: 'https://app.gitbased.lost-pixel.com/api/callback',
+  lostPixelUrl: "https://app.gitbased.lost-pixel.com/api/callback",
   s3: {
     endPoint: "ams3.digitaloceanspaces.com",
     accessKey: process.env.S3_ACCESS_KEY,

--- a/packages/design-system/src/components/__DEPRECATED__/button.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/button.tsx
@@ -1,4 +1,5 @@
 import { styled } from "../../stitches.config";
+import { theme } from "../../stitches.config";
 
 export const DeprecatedButton = styled("button", {
   // Reset
@@ -24,125 +25,124 @@ export const DeprecatedButton = styled("button", {
   minWidth: 0,
 
   // Custom
-  height: "$spacing$11",
-  px: "$spacing$5",
-  fontFamily: "$sans",
-  fontSize: "$fontSize$3",
+  height: theme.spacing[11],
+  px: theme.spacing[5],
+  fontFamily: theme.fonts.sans,
+  fontSize: theme.fontSize[3],
   fontWeight: 500,
   fontVariantNumeric: "tabular-nums",
 
   "&:disabled": {
-    backgroundColor: "$slate2",
-    boxShadow: "inset 0 0 0 1px $colors$slate7",
-    color: "$slate8",
+    backgroundColor: theme.colors.slate2,
+    boxShadow: `inset 0 0 0 1px ${theme.colors.slate7}`,
+    color: theme.colors.slate8,
     pointerEvents: "none",
   },
 
   variants: {
     size: {
       "1": {
-        borderRadius: "$borderRadius$4",
-        height: "$spacing$11",
-        px: "$spacing$4",
-        fontSize: "$fontSize$3",
+        borderRadius: theme.borderRadius[4],
+        height: theme.spacing[11],
+        px: theme.spacing[4],
+        fontSize: theme.fontSize[3],
       },
       "2": {
-        borderRadius: "$borderRadius$6",
-        height: "$spacing$12",
-        px: "$spacing$9",
-        fontSize: "$fontSize$4",
+        borderRadius: theme.borderRadius[6],
+        height: theme.spacing[12],
+        px: theme.spacing[9],
+        fontSize: theme.fontSize[4],
       },
       "3": {
-        borderRadius: "$borderRadius$6",
-        height: "$spacing$17",
-        px: "$spacing$10",
-        fontSize: "$fontSize$4",
+        borderRadius: theme.borderRadius[6],
+        height: theme.spacing[17],
+        px: theme.spacing[10],
+        fontSize: theme.fontSize[4],
       },
     },
     variant: {
       gray: {
-        backgroundColor: "$loContrast",
-        boxShadow: "inset 0 0 0 1px $colors$slate7",
-        color: "$hiContrast",
+        backgroundColor: theme.colors.loContrast,
+        boxShadow: `inset 0 0 0 1px ${theme.colors.slate7}`,
+        color: theme.colors.hiContrast,
         "@hover": {
           "&:hover": {
-            boxShadow: "inset 0 0 0 1px $colors$slate8",
+            boxShadow: `inset 0 0 0 1px ${theme.colors.slate8}`,
           },
         },
         "&:active": {
-          backgroundColor: "$slate2",
-          boxShadow: "inset 0 0 0 1px $colors$slate8",
+          backgroundColor: theme.colors.slate2,
+          boxShadow: `inset 0 0 0 1px ${theme.colors.slate8}`,
         },
         "&:focus": {
-          boxShadow: "inset 0 0 0 1px $colors$slate8, 0 0 0 1px $colors$slate8",
+          boxShadow: `inset 0 0 0 1px ${theme.colors.slate8}, 0 0 0 1px ${theme.colors.slate8}`,
         },
         '&[data-state="open"]': {
-          backgroundColor: "$slate4",
-          boxShadow: "inset 0 0 0 1px $colors$slate8",
+          backgroundColor: theme.colors.slate4,
+          boxShadow: `inset 0 0 0 1px ${theme.colors.slate8}`,
         },
       },
       blue: {
-        backgroundColor: "$blue10",
+        backgroundColor: theme.colors.blue10,
         color: "white",
         "@hover": {
           "&:hover": {
-            backgroundColor: "$loContrast",
-            color: "$blue10",
-            boxShadow: "inset 0 0 0 1.5px $colors$blue10",
+            backgroundColor: theme.colors.loContrast,
+            color: theme.colors.blue10,
+            boxShadow: `inset 0 0 0 1.5px ${theme.colors.blue10}`,
           },
         },
         "&:active": {
-          boxShadow: "inset 0 0 0 1.5px $colors$blue8",
+          boxShadow: `inset 0 0 0 1.5px ${theme.colors.blue8}`,
         },
         "&:focus": {
-          boxShadow:
-            "inset 0 0 0 1.5px $colors$blue8, 0 0 0 1.5px $colors$blue8",
+          boxShadow: `inset 0 0 0 1.5px ${theme.colors.blue8}, 0 0 0 1.5px ${theme.colors.blue8}`,
         },
         '&[data-state="open"]': {
-          boxShadow: "inset 0 0 0 1.5px $colors$blue8",
+          boxShadow: `inset 0 0 0 1.5px ${theme.colors.blue8}`,
         },
       },
       green: {
-        backgroundColor: "$green2",
-        boxShadow: "inset 0 0 0 1px $colors$green7",
-        color: "$green11",
+        backgroundColor: theme.colors.green2,
+        boxShadow: `inset 0 0 0 1px ${theme.colors.green7}`,
+        color: theme.colors.green11,
         "@hover": {
           "&:hover": {
-            boxShadow: "inset 0 0 0 1px $colors$green8",
+            boxShadow: `inset 0 0 0 1px ${theme.colors.green8}`,
           },
         },
         "&:active": {
-          backgroundColor: "$green3",
-          boxShadow: "inset 0 0 0 1px $colors$green8",
+          backgroundColor: theme.colors.green3,
+          boxShadow: `inset 0 0 0 1px ${theme.colors.green8}`,
         },
         "&:focus": {
-          boxShadow: "inset 0 0 0 1px $colors$green8, 0 0 0 1px $colors$green8",
+          boxShadow: `inset 0 0 0 1px ${theme.colors.green8}, 0 0 0 1px ${theme.colors.green8}`,
         },
         '&[data-state="open"]': {
-          backgroundColor: "$green4",
-          boxShadow: "inset 0 0 0 1px $colors$green8",
+          backgroundColor: theme.colors.green4,
+          boxShadow: `inset 0 0 0 1px ${theme.colors.green8}`,
         },
       },
       red: {
-        backgroundColor: "$loContrast",
-        boxShadow: "inset 0 0 0 1px $colors$red10",
-        color: "$red10",
+        backgroundColor: theme.colors.loContrast,
+        boxShadow: `inset 0 0 0 1px ${theme.colors.red10}`,
+        color: theme.colors.red10,
         "@hover": {
           "&:hover": {
-            background: "$red10",
-            color: "$loContrast",
+            background: theme.colors.red10,
+            color: theme.colors.loContrast,
           },
         },
         "&:active": {
-          backgroundColor: "$red11",
-          color: "$loContrast",
+          backgroundColor: theme.colors.red11,
+          color: theme.colors.loContrast,
         },
         "&:focus": {
-          boxShadow: "inset 0 0 0 1px $colors$red8, 0 0 0 1px $colors$red8",
+          boxShadow: `inset 0 0 0 1px ${theme.colors.red8}, 0 0 0 1px ${theme.colors.red8}`,
         },
         '&[data-state="open"]': {
-          backgroundColor: "$red4",
-          boxShadow: "inset 0 0 0 1px $colors$red8",
+          backgroundColor: theme.colors.red4,
+          boxShadow: `inset 0 0 0 1px ${theme.colors.red8}`,
         },
       },
       transparentWhite: {
@@ -187,32 +187,32 @@ export const DeprecatedButton = styled("button", {
     },
     state: {
       active: {
-        backgroundColor: "$slate4",
-        boxShadow: "inset 0 0 0 1px $colors$slate8",
-        color: "$slate11",
+        backgroundColor: theme.colors.slate4,
+        boxShadow: `inset 0 0 0 1px ${theme.colors.slate8}`,
+        color: theme.colors.slate11,
         "@hover": {
           "&:hover": {
-            backgroundColor: "$slate6",
-            boxShadow: "inset 0 0 0 1px $colors$slate8",
+            backgroundColor: theme.colors.slate6,
+            boxShadow: `inset 0 0 0 1px ${theme.colors.slate8}`,
           },
         },
         "&:active": {
-          backgroundColor: "$slate6",
+          backgroundColor: theme.colors.slate6,
         },
         "&:focus": {
-          boxShadow: "inset 0 0 0 1px $colors$slate8, 0 0 0 1px $colors$slate8",
+          boxShadow: `inset 0 0 0 1px ${theme.colors.slate8}, 0 0 0 1px ${theme.colors.slate8}`,
         },
       },
       waiting: {
-        backgroundColor: "$slate4",
-        boxShadow: "inset 0 0 0 1px $colors$slate8",
-        color: "$colors$slate9",
+        backgroundColor: theme.colors.slate4,
+        boxShadow: `inset 0 0 0 1px ${theme.colors.slate8}`,
+        color: theme.colors.slate9,
         cursor: "wait",
         "&:hover, &:active": {
-          color: "$colors$slate9",
+          color: theme.colors.slate9,
         },
         "&:focus": {
-          boxShadow: "inset 0 0 0 1px $colors$slate8",
+          boxShadow: `inset 0 0 0 1px ${theme.colors.slate8}`,
         },
       },
     },
@@ -229,22 +229,21 @@ export const DeprecatedButton = styled("button", {
       ghost: "true",
       css: {
         backgroundColor: "transparent",
-        color: "$hiContrast",
+        color: theme.colors.hiContrast,
         "@hover": {
           "&:hover": {
-            backgroundColor: "$slateA3",
+            backgroundColor: theme.colors.slateA3,
             boxShadow: "none",
           },
         },
         "&:active": {
-          backgroundColor: "$slateA4",
+          backgroundColor: theme.colors.slateA4,
         },
         "&:focus": {
-          boxShadow:
-            "inset 0 0 0 1px $colors$slateA8, 0 0 0 1px $colors$slateA8",
+          boxShadow: `inset 0 0 0 1px ${theme.colors.slateA8}, 0 0 0 1px ${theme.colors.slateA8}`,
         },
         '&[data-state="open"]': {
-          backgroundColor: "$slateA4",
+          backgroundColor: theme.colors.slateA4,
           boxShadow: "none",
         },
       },
@@ -256,19 +255,18 @@ export const DeprecatedButton = styled("button", {
         backgroundColor: "transparent",
         "@hover": {
           "&:hover": {
-            backgroundColor: "$blueA3",
+            backgroundColor: theme.colors.blueA3,
             boxShadow: "none",
           },
         },
         "&:active": {
-          backgroundColor: "$blueA4",
+          backgroundColor: theme.colors.blueA4,
         },
         "&:focus": {
-          boxShadow:
-            "0px 0px 0px 2px $colors$blue10, 0px 0px 0px 2px $colors$blue10",
+          boxShadow: `0px 0px 0px 2px ${theme.colors.blue10}, 0px 0px 0px 2px ${theme.colors.blue10}`,
         },
         '&[data-state="open"]': {
-          backgroundColor: "$blueA4",
+          backgroundColor: theme.colors.blueA4,
           boxShadow: "none",
         },
       },
@@ -280,19 +278,18 @@ export const DeprecatedButton = styled("button", {
         backgroundColor: "transparent",
         "@hover": {
           "&:hover": {
-            backgroundColor: "$greenA3",
+            backgroundColor: theme.colors.greenA3,
             boxShadow: "none",
           },
         },
         "&:active": {
-          backgroundColor: "$greenA4",
+          backgroundColor: theme.colors.greenA4,
         },
         "&:focus": {
-          boxShadow:
-            "inset 0 0 0 1px $colors$greenA8, 0 0 0 1px $colors$greenA8",
+          boxShadow: `inset 0 0 0 1px ${theme.colors.greenA8}, 0 0 0 1px ${theme.colors.greenA8}`,
         },
         '&[data-state="open"]': {
-          backgroundColor: "$greenA4",
+          backgroundColor: theme.colors.greenA4,
           boxShadow: "none",
         },
       },
@@ -304,18 +301,18 @@ export const DeprecatedButton = styled("button", {
         backgroundColor: "transparent",
         "@hover": {
           "&:hover": {
-            backgroundColor: "$redA3",
+            backgroundColor: theme.colors.redA3,
             boxShadow: "none",
           },
         },
         "&:active": {
-          backgroundColor: "$redA4",
+          backgroundColor: theme.colors.redA4,
         },
         "&:focus": {
-          boxShadow: "inset 0 0 0 1px $colors$redA8, 0 0 0 1px $colors$redA8",
+          boxShadow: `inset 0 0 0 1px ${theme.colors.redA8}, 0 0 0 1px ${theme.colors.redA8}`,
         },
         '&[data-state="open"]': {
-          backgroundColor: "$redA4",
+          backgroundColor: theme.colors.redA4,
           boxShadow: "none",
         },
       },

--- a/packages/design-system/src/components/__DEPRECATED__/heading.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/heading.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { DeprecatedText } from "./text";
 import { VariantProps, CSS } from "../../stitches.config";
 import merge from "lodash.merge";
+import { theme } from "../../stitches.config";
 
 const DEFAULT_TAG = "h1";
 
@@ -32,7 +33,7 @@ export const DeprecatedHeading = React.forwardRef<
   const textCss: Record<HeadingSizeVariants, CSS> = {
     1: {
       fontWeight: 500,
-      lineHeight: "$lineHeight$4",
+      lineHeight: theme.lineHeight[4],
       "@bp2": { lineHeight: "23px" },
     },
     2: { fontWeight: 500, lineHeight: "25px", "@bp2": { lineHeight: "30px" } },

--- a/packages/design-system/src/components/__DEPRECATED__/icon-button.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/icon-button.tsx
@@ -1,4 +1,5 @@
 import { styled } from "../../stitches.config";
+import { theme } from "../../stitches.config";
 
 export const DeprecatedIconButton = styled("button", {
   // Reset
@@ -9,14 +10,14 @@ export const DeprecatedIconButton = styled("button", {
   display: "inline-flex",
   flexShrink: 0,
   fontFamily: "inherit",
-  fontSize: "$fontSize$4",
+  fontSize: theme.fontSize[4],
   justifyContent: "center",
   lineHeight: "1",
   padding: 0,
   textDecoration: "none",
   userSelect: "none",
   WebkitTapHighlightColor: "transparent",
-  color: "$hiContrast",
+  color: theme.colors.hiContrast,
   background: "none",
   outline: "2px solid transparent",
   outlineOffset: 2,
@@ -24,46 +25,46 @@ export const DeprecatedIconButton = styled("button", {
     boxSizing: "border-box",
   },
   "&:hover, &:active": {
-    backgroundColor: "$slate6",
+    backgroundColor: theme.colors.slate6,
     outline: "none",
   },
   "&:focus-visible": {
-    backgroundColor: "$slate6",
+    backgroundColor: theme.colors.slate6,
     outline: "none",
     border: "2px solid white",
-    boxShadow: "0px 0px 0px 2px $colors$blue10, 0px 0px 0px 2px $colors$blue10",
+    boxShadow: `0px 0px 0px 2px ${theme.colors.blue10}, 0px 0px 0px 2px ${theme.colors.blue10}`,
   },
   "&:disabled": {
     pointerEvents: "none",
     backgroundColor: "transparent",
-    color: "$slate6",
+    color: theme.colors.slate6,
   },
 
   variants: {
     size: {
       "1": {
         borderRadius: 2,
-        height: "$spacing$9",
-        width: "$spacing$9",
+        height: theme.spacing[9],
+        width: theme.spacing[9],
         "&:hover, &:focus-visible": {
           background: "none",
           border: "none",
         },
       },
       "2": {
-        borderRadius: "$borderRadius$4",
-        height: "$spacing$13",
-        width: "$spacing$13",
+        borderRadius: theme.borderRadius[4],
+        height: theme.spacing[13],
+        width: theme.spacing[13],
       },
       "3": {
-        borderRadius: "$borderRadius$4",
-        height: "$spacing$17",
-        width: "$spacing$17",
+        borderRadius: theme.borderRadius[4],
+        height: theme.spacing[17],
+        width: theme.spacing[17],
       },
       "4": {
-        borderRadius: "$borderRadius$6",
-        height: "$spacing$19",
-        width: "$spacing$19",
+        borderRadius: theme.borderRadius[6],
+        height: theme.spacing[19],
+        width: theme.spacing[19],
       },
     },
   },

--- a/packages/design-system/src/components/__DEPRECATED__/text.tsx
+++ b/packages/design-system/src/components/__DEPRECATED__/text.tsx
@@ -1,4 +1,5 @@
 import { styled } from "../../stitches.config";
+import { theme } from "../../stitches.config";
 
 export const DeprecatedText = styled("div", {
   // Reset
@@ -12,95 +13,95 @@ export const DeprecatedText = styled("div", {
   variants: {
     size: {
       "1": {
-        fontSize: "$fontSize$3",
+        fontSize: theme.fontSize[3],
       },
       "2": {
-        fontSize: "$fontSize$3",
+        fontSize: theme.fontSize[3],
       },
       "3": {
-        fontSize: "$fontSize$4",
+        fontSize: theme.fontSize[4],
       },
       "4": {
-        fontSize: "$fontSize$4",
+        fontSize: theme.fontSize[4],
       },
       "5": {
-        fontSize: "$fontSize$5",
+        fontSize: theme.fontSize[5],
         letterSpacing: "-.015em",
       },
       "6": {
-        fontSize: "$fontSize$6",
+        fontSize: theme.fontSize[6],
         letterSpacing: "-.016em",
       },
       "7": {
-        fontSize: "$fontSize$7",
+        fontSize: theme.fontSize[7],
         letterSpacing: "-.031em",
         textIndent: "-.005em",
       },
       "8": {
-        fontSize: "$fontSize$8",
+        fontSize: theme.fontSize[8],
         letterSpacing: "-.034em",
         textIndent: "-.018em",
       },
       "9": {
-        fontSize: "$fontSize$9",
+        fontSize: theme.fontSize[9],
         letterSpacing: "-.055em",
         textIndent: "-.025em",
       },
     },
     variant: {
       red: {
-        color: "$red11",
+        color: theme.colors.red11,
       },
       crimson: {
-        color: "$crimson11",
+        color: theme.colors.crimson11,
       },
       pink: {
-        color: "$pink11",
+        color: theme.colors.pink11,
       },
       purple: {
-        color: "$purple11",
+        color: theme.colors.purple11,
       },
       violet: {
-        color: "$violet11",
+        color: theme.colors.violet11,
       },
       indigo: {
-        color: "$indigo11",
+        color: theme.colors.indigo11,
       },
       blue: {
-        color: "$blue11",
+        color: theme.colors.blue11,
       },
       cyan: {
-        color: "$cyan11",
+        color: theme.colors.cyan11,
       },
       teal: {
-        color: "$teal11",
+        color: theme.colors.teal11,
       },
       green: {
-        color: "$green11",
+        color: theme.colors.green11,
       },
       lime: {
-        color: "$lime11",
+        color: theme.colors.lime11,
       },
       yellow: {
-        color: "$yellow11",
+        color: theme.colors.yellow11,
       },
       orange: {
-        color: "$orange11",
+        color: theme.colors.orange11,
       },
       gold: {
-        color: "$gold11",
+        color: theme.colors.gold11,
       },
       bronze: {
-        color: "$bronze11",
+        color: theme.colors.bronze11,
       },
       gray: {
-        color: "$slate11",
+        color: theme.colors.slate11,
       },
       contrast: {
-        color: "$hiContrast",
+        color: theme.colors.hiContrast,
       },
       loContrast: {
-        color: "$loContrast",
+        color: theme.colors.loContrast,
       },
     },
     gradient: {
@@ -115,119 +116,119 @@ export const DeprecatedText = styled("div", {
       variant: "red",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $red11, $crimson11)",
+        background: `linear-gradient(to right, ${theme.colors.red11}, ${theme.colors.crimson11})`,
       },
     },
     {
       variant: "crimson",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $crimson11, $pink11)",
+        background: `linear-gradient(to right, ${theme.colors.crimson11}, ${theme.colors.pink11})`,
       },
     },
     {
       variant: "pink",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $pink11, $purple11)",
+        background: `linear-gradient(to right, ${theme.colors.pink11}, ${theme.colors.purple11})`,
       },
     },
     {
       variant: "purple",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $purple11, $violet11)",
+        background: `linear-gradient(to right, ${theme.colors.purple11}, ${theme.colors.violet11})`,
       },
     },
     {
       variant: "violet",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $violet11, $indigo11)",
+        background: `linear-gradient(to right, ${theme.colors.violet11}, ${theme.colors.indigo11})`,
       },
     },
     {
       variant: "indigo",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $indigo11, $blue11)",
+        background: `linear-gradient(to right, ${theme.colors.indigo11}, ${theme.colors.blue11})`,
       },
     },
     {
       variant: "blue",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $blue11, $cyan11)",
+        background: `linear-gradient(to right, ${theme.colors.blue11}, ${theme.colors.cyan11})`,
       },
     },
     {
       variant: "cyan",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $cyan11, $teal11)",
+        background: `linear-gradient(to right, ${theme.colors.cyan11}, ${theme.colors.teal11})`,
       },
     },
     {
       variant: "teal",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $teal11, $green11)",
+        background: `linear-gradient(to right, ${theme.colors.teal11}, ${theme.colors.green11})`,
       },
     },
     {
       variant: "green",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $green11, $lime11)",
+        background: `linear-gradient(to right, ${theme.colors.green11}, ${theme.colors.lime11})`,
       },
     },
     {
       variant: "lime",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $lime11, $yellow11)",
+        background: `linear-gradient(to right, ${theme.colors.lime11}, ${theme.colors.yellow11})`,
       },
     },
     {
       variant: "yellow",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $yellow11, $orange11)",
+        background: `linear-gradient(to right, ${theme.colors.yellow11}, ${theme.colors.orange11})`,
       },
     },
     {
       variant: "orange",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $orange11, $red11)",
+        background: `linear-gradient(to right, ${theme.colors.orange11}, ${theme.colors.red11})`,
       },
     },
     {
       variant: "gold",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $gold11, $gold9)",
+        background: `linear-gradient(to right, ${theme.colors.gold11}, ${theme.colors.gold9})`,
       },
     },
     {
       variant: "bronze",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $bronze11, $bronze9)",
+        background: `linear-gradient(to right, ${theme.colors.bronze11}, ${theme.colors.bronze9})`,
       },
     },
     {
       variant: "gray",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $gray11, $gray12)",
+        background: `linear-gradient(to right, ${theme.colors.gray11}, ${theme.colors.gray12})`,
       },
     },
     {
       variant: "contrast",
       gradient: "true",
       css: {
-        background: "linear-gradient(to right, $hiContrast, $gray12)",
+        background: `linear-gradient(to right, ${theme.colors.hiContrast}, ${theme.colors.gray12})`,
       },
     },
   ],

--- a/packages/design-system/src/components/avatar.tsx
+++ b/packages/design-system/src/components/avatar.tsx
@@ -3,6 +3,7 @@ import { styled, VariantProps, CSS } from "../stitches.config";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import { Box } from "./box";
 import { Status } from "./status";
+import { theme } from "../stitches.config";
 
 const StyledAvatar = styled(AvatarPrimitive.Root, {
   alignItems: "center",
@@ -21,7 +22,7 @@ const StyledAvatar = styled(AvatarPrimitive.Root, {
   outline: "none",
   padding: "0",
   fontWeight: "500",
-  color: "$hiContrast",
+  color: theme.colors.hiContrast,
 
   "&::before": {
     content: '""',
@@ -37,108 +38,108 @@ const StyledAvatar = styled(AvatarPrimitive.Root, {
   variants: {
     size: {
       "1": {
-        width: "$spacing$9",
-        height: "$spacing$9",
+        width: theme.spacing[9],
+        height: theme.spacing[9],
       },
       "2": {
-        width: "$spacing$11",
-        height: "$spacing$11",
+        width: theme.spacing[11],
+        height: theme.spacing[11],
       },
       "3": {
-        width: "$spacing$13",
-        height: "$spacing$13",
+        width: theme.spacing[13],
+        height: theme.spacing[13],
       },
       "4": {
-        width: "$spacing$17",
-        height: "$spacing$17",
+        width: theme.spacing[17],
+        height: theme.spacing[17],
       },
       "5": {
-        width: "$spacing$19",
-        height: "$spacing$19",
+        width: theme.spacing[19],
+        height: theme.spacing[19],
       },
       "6": {
-        width: "$spacing$20",
-        height: "$spacing$20",
+        width: theme.spacing[20],
+        height: theme.spacing[20],
       },
     },
     variant: {
       hiContrast: {
-        backgroundColor: "$hiContrast",
-        color: "$loContrast",
+        backgroundColor: theme.colors.hiContrast,
+        color: theme.colors.loContrast,
       },
       gray: {
-        backgroundColor: "$slate6",
+        backgroundColor: theme.colors.slate6,
       },
       tomato: {
-        backgroundColor: "$tomato5",
+        backgroundColor: theme.colors.tomato5,
       },
       red: {
-        backgroundColor: "$red5",
+        backgroundColor: theme.colors.red5,
       },
       crimson: {
-        backgroundColor: "$crimson5",
+        backgroundColor: theme.colors.crimson5,
       },
       pink: {
-        backgroundColor: "$pink5",
+        backgroundColor: theme.colors.pink5,
       },
       plum: {
-        backgroundColor: "$plum5",
+        backgroundColor: theme.colors.plum5,
       },
       purple: {
-        backgroundColor: "$purple5",
+        backgroundColor: theme.colors.purple5,
       },
       violet: {
-        backgroundColor: "$violet5",
+        backgroundColor: theme.colors.violet5,
       },
       indigo: {
-        backgroundColor: "$indigo5",
+        backgroundColor: theme.colors.indigo5,
       },
       blue: {
-        backgroundColor: "$blue5",
+        backgroundColor: theme.colors.blue5,
       },
       cyan: {
-        backgroundColor: "$cyan5",
+        backgroundColor: theme.colors.cyan5,
       },
       teal: {
-        backgroundColor: "$teal5",
+        backgroundColor: theme.colors.teal5,
       },
       green: {
-        backgroundColor: "$green5",
+        backgroundColor: theme.colors.green5,
       },
       grass: {
-        backgroundColor: "$grass5",
+        backgroundColor: theme.colors.grass5,
       },
       brown: {
-        backgroundColor: "$brown5",
+        backgroundColor: theme.colors.brown5,
       },
       bronze: {
-        backgroundColor: "$bronze5",
+        backgroundColor: theme.colors.bronze5,
       },
       gold: {
-        backgroundColor: "$gold5",
+        backgroundColor: theme.colors.gold5,
       },
       sky: {
-        backgroundColor: "$sky5",
+        backgroundColor: theme.colors.sky5,
       },
       mint: {
-        backgroundColor: "$mint5",
+        backgroundColor: theme.colors.mint5,
       },
       lime: {
-        backgroundColor: "$lime5",
+        backgroundColor: theme.colors.lime5,
       },
       yellow: {
-        backgroundColor: "$yellow5",
+        backgroundColor: theme.colors.yellow5,
       },
       amber: {
-        backgroundColor: "$amber5",
+        backgroundColor: theme.colors.amber5,
       },
       orange: {
-        backgroundColor: "$orange5",
+        backgroundColor: theme.colors.orange5,
       },
     },
     shape: {
       square: {
-        borderRadius: "$borderRadius$6",
+        borderRadius: theme.borderRadius[6],
       },
       circle: {
         borderRadius: "50%",
@@ -201,23 +202,23 @@ const StyledAvatarFallback = styled(AvatarPrimitive.Fallback, {
   variants: {
     size: {
       "1": {
-        fontSize: "$fontSize$2",
-        lineHeight: "$lineHeight$3",
+        fontSize: theme.fontSize[2],
+        lineHeight: theme.lineHeight[3],
       },
       "2": {
-        fontSize: "$fontSize$4",
+        fontSize: theme.fontSize[4],
       },
       "3": {
-        fontSize: "$fontSize$6",
+        fontSize: theme.fontSize[6],
       },
       "4": {
-        fontSize: "$fontSize$7",
+        fontSize: theme.fontSize[7],
       },
       "5": {
-        fontSize: "$fontSize$8",
+        fontSize: theme.fontSize[8],
       },
       "6": {
-        fontSize: "$fontSize$9",
+        fontSize: theme.fontSize[9],
       },
     },
   },
@@ -227,7 +228,7 @@ const StyledAvatarFallback = styled(AvatarPrimitive.Fallback, {
 });
 
 export const AvatarNestedItem = styled("div", {
-  boxShadow: "0 0 0 2px $colors$loContrast",
+  boxShadow: `0 0 0 2px ${theme.colors.loContrast}`,
   borderRadius: "50%",
 });
 
@@ -235,7 +236,7 @@ export const AvatarGroup = styled("div", {
   display: "flex",
   flexDirection: "row-reverse",
   [`& ${AvatarNestedItem}:nth-child(n+2)`]: {
-    marginRight: "-$spacing$3",
+    marginRight: `-${theme.spacing[3]}`,
   },
 });
 
@@ -286,10 +287,10 @@ export const Avatar = React.forwardRef<
               position: "absolute",
               bottom: "0",
               right: "0",
-              boxShadow: "0 0 0 3px $colors$loContrast",
-              borderRadius: "$borderRadius$round",
-              mr: "-$spacing$2",
-              mb: "-$spacing$2",
+              boxShadow: `0 0 0 3px ${theme.colors.loContrast}`,
+              borderRadius: theme.borderRadius.round,
+              mr: `-${theme.spacing[2]}`,
+              mb: `-${theme.spacing[2]}`,
             }}
           >
             <Status size={size && size > 2 ? "2" : "1"} variant={status} />

--- a/packages/design-system/src/components/button.tsx
+++ b/packages/design-system/src/components/button.tsx
@@ -6,6 +6,7 @@
 import React, { forwardRef, type Ref, type ComponentProps } from "react";
 import { Text } from "./text";
 import { styled } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 // CSS supports multiple gradients as backgrounds but not multiple colors
 const backgroundColors = ({
@@ -22,13 +23,13 @@ const backgroundStyle = (baseColor: string) => ({
   "&:hover": {
     background: backgroundColors({
       base: baseColor,
-      overlay: "$colors$backgroundButtonHover",
+      overlay: theme.colors.backgroundButtonHover,
     }),
   },
   "&:active": {
     background: backgroundColors({
       base: baseColor,
-      overlay: "$colors$backgroundButtonPressed",
+      overlay: theme.colors.backgroundButtonPressed,
     }),
   },
 });
@@ -40,14 +41,14 @@ const StyledButton = styled("button", {
   display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
-  gap: "$spacing$2",
-  color: "$colors$foregroundContrastMain",
-  padding: "0 $spacing$4",
-  height: "$spacing$12",
-  borderRadius: "$borderRadius$4",
+  gap: theme.spacing[2],
+  color: theme.colors.foregroundContrastMain,
+  padding: `0 ${theme.spacing[4]}`,
+  height: theme.spacing[12],
+  borderRadius: theme.borderRadius[4],
 
   "&:focus-visible": {
-    outline: "2px solid $colors$borderFocus",
+    outline: `2px solid ${theme.colors.borderFocus}`,
     outlineOffset: "1px",
   },
 
@@ -55,17 +56,19 @@ const StyledButton = styled("button", {
     // "variant" is used instead of "type" as in Figma,
     // because type is already taken for type=submit etc.
     variant: {
-      primary: { ...backgroundStyle("$colors$backgroundPrimary") },
+      primary: { ...backgroundStyle(theme.colors.backgroundPrimary) },
       neutral: {
-        ...backgroundStyle("$colors$backgroundNeutralMain"),
-        color: "$colors$foregroundMain",
+        ...backgroundStyle(theme.colors.backgroundNeutralMain),
+        color: theme.colors.foregroundMain,
       },
-      destructive: { ...backgroundStyle("$colors$backgroundDestructiveMain") },
-      positive: { ...backgroundStyle("$colors$backgroundSuccessMain") },
+      destructive: {
+        ...backgroundStyle(theme.colors.backgroundDestructiveMain),
+      },
+      positive: { ...backgroundStyle(theme.colors.backgroundSuccessMain) },
       ghost: {
-        ...backgroundStyle("$colors$backgroundHover"),
+        ...backgroundStyle(theme.colors.backgroundHover),
         background: "transparent",
-        color: "$colors$foregroundMain",
+        color: theme.colors.foregroundMain,
       },
     },
     pending: {
@@ -74,8 +77,8 @@ const StyledButton = styled("button", {
       },
       false: {
         "&[disabled]": {
-          background: "$colors$backgroundButtonDisabled",
-          color: "$colors$foregroundDisabled",
+          background: theme.colors.backgroundButtonDisabled,
+          color: theme.colors.foregroundDisabled,
         },
       },
     },
@@ -87,11 +90,11 @@ const StyledButton = styled("button", {
 });
 
 const TextContainer = styled(Text, {
-  padding: "0 $spacing$2",
+  padding: `0 ${theme.spacing[2]}`,
   // <Text> incorrectly sets lineHeight to 1 for all variants
   // here we set lineHeight as it's defined for "label" in Figma
   // @todo: fix <Text>
-  lineHeight: "$lineHeight$3",
+  lineHeight: theme.lineHeight[3],
   defaultVariants: { variant: "label" },
 });
 

--- a/packages/design-system/src/components/card.tsx
+++ b/packages/design-system/src/components/card.tsx
@@ -1,4 +1,5 @@
 import { styled } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 export const Card = styled("div", {
   appearance: "none",
@@ -10,12 +11,12 @@ export const Card = styled("div", {
   textAlign: "inherit",
   verticalAlign: "middle",
   WebkitTapHighlightColor: "rgba(0, 0, 0, 0)",
-  backgroundColor: "$panel",
+  backgroundColor: theme.colors.panel,
   display: "block",
   textDecoration: "none",
   color: "inherit",
   flexShrink: 0,
-  borderRadius: "$borderRadius$7",
+  borderRadius: theme.borderRadius[7],
   position: "relative",
 
   "&::before": {
@@ -27,19 +28,19 @@ export const Card = styled("div", {
     bottom: 0,
     left: 0,
     boxShadow: "inset 0 0 0 1px rgba(0,0,0,.1)",
-    borderRadius: "$borderRadius$7",
+    borderRadius: theme.borderRadius[7],
     pointerEvents: "none",
   },
 
   variants: {
     size: {
       1: {
-        width: "$spacing$30",
-        padding: "$spacing$11",
+        width: theme.spacing[30],
+        padding: theme.spacing[11],
       },
       2: {
-        width: "$spacing$34",
-        padding: "$spacing$17",
+        width: theme.spacing[34],
+        padding: theme.spacing[17],
       },
     },
     variant: {
@@ -53,7 +54,7 @@ export const Card = styled("div", {
         },
         "&:focus": {
           "&::before": {
-            boxShadow: "inset 0 0 0 1px $colors$blue8, 0 0 0 1px $colors$blue8",
+            boxShadow: `inset 0 0 0 1px ${theme.colors.blue8}, 0 0 0 1px ${theme.colors.blue8}`,
           },
         },
       },
@@ -70,8 +71,8 @@ export const Card = styled("div", {
         },
         "@hover": {
           "&:hover": {
-            backgroundColor: "$panel",
-            transform: "translateY(-$spacing$2)",
+            backgroundColor: theme.colors.panel,
+            transform: `translateY(-${theme.spacing[2]})`,
             "&::before": {
               opacity: "1",
             },
@@ -87,7 +88,7 @@ export const Card = styled("div", {
           },
         },
         "&:focus": {
-          boxShadow: "inset 0 0 0 1px $colors$blue8, 0 0 0 1px $colors$blue8",
+          boxShadow: `inset 0 0 0 1px ${theme.colors.blue8}, 0 0 0 1px ${theme.colors.blue8}`,
         },
       },
       active: {
@@ -99,7 +100,7 @@ export const Card = styled("div", {
           opacity: "1",
         },
         "&:focus": {
-          boxShadow: "inset 0 0 0 1px $colors$blue8, 0 0 0 1px $colors$blue8",
+          boxShadow: `inset 0 0 0 1px ${theme.colors.blue8}, 0 0 0 1px ${theme.colors.blue8}`,
         },
       },
     },

--- a/packages/design-system/src/components/checkbox.tsx
+++ b/packages/design-system/src/components/checkbox.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { styled, CSS, VariantProps } from "../stitches.config";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { CheckIcon } from "@webstudio-is/icons";
+import { theme } from "../stitches.config";
 
 const StyledCheckbox = styled(CheckboxPrimitive.Root, {
   all: "unset",
@@ -24,31 +25,31 @@ const StyledCheckbox = styled(CheckboxPrimitive.Root, {
   padding: "0",
   WebkitTapHighlightColor: "rgba(0,0,0,0)",
 
-  color: "$hiContrast",
-  boxShadow: "inset 0 0 0 1px $colors$slate7",
+  color: theme.colors.hiContrast,
+  boxShadow: `inset 0 0 0 1px ${theme.colors.slate7}`,
   overflow: "hidden",
   "@hover": {
     "&:hover": {
-      boxShadow: "inset 0 0 0 1px $colors$slate8",
+      boxShadow: `inset 0 0 0 1px ${theme.colors.slate8}`,
     },
   },
   "&:focus": {
     outline: "none",
-    borderColor: "$red7",
-    boxShadow: "inset 0 0 0 1px $colors$blue9, 0 0 0 1px $colors$blue9",
+    borderColor: theme.colors.red7,
+    boxShadow: `inset 0 0 0 1px ${theme.colors.blue9}, 0 0 0 1px ${theme.colors.blue9}`,
   },
 
   variants: {
     size: {
       "1": {
-        width: "$spacing$9",
-        height: "$spacing$9",
-        borderRadius: "$borderRadius$4",
+        width: theme.spacing[9],
+        height: theme.spacing[9],
+        borderRadius: theme.borderRadius[4],
       },
       "2": {
-        width: "$spacing$11",
-        height: "$spacing$11",
-        borderRadius: "$borderRadius$6",
+        width: theme.spacing[11],
+        height: theme.spacing[11],
+        borderRadius: theme.borderRadius[6],
       },
     },
   },

--- a/packages/design-system/src/components/combobox.stories.tsx
+++ b/packages/design-system/src/components/combobox.stories.tsx
@@ -9,6 +9,7 @@ import {
   comboboxStateChangeTypes,
 } from "./combobox";
 import { Flex } from "./flex";
+import { theme } from "../stitches.config";
 
 export default {
   component: Combobox,
@@ -82,7 +83,7 @@ export const Complex: ComponentStory<typeof Combobox> = () => {
   return (
     <Flex
       {...getComboboxProps()}
-      css={{ flexDirection: "column", gap: "$spacing$9" }}
+      css={{ flexDirection: "column", gap: theme.spacing[9] }}
     >
       <TextField
         type="search"

--- a/packages/design-system/src/components/combobox.tsx
+++ b/packages/design-system/src/components/combobox.tsx
@@ -25,9 +25,10 @@ import { panelStyles } from "./panel";
 import { TextField } from "./text-field";
 import { Box } from "./box";
 import { Grid } from "./grid";
+import { theme } from "../stitches.config";
 
 const Listbox = styled("ul", panelStyles, {
-  p: "$spacing$3",
+  p: theme.spacing[3],
   margin: 0,
   overflow: "auto",
   // @todo need some non-hardcoded value
@@ -49,9 +50,9 @@ const Listbox = styled("ul", panelStyles, {
 });
 
 const ListboxItem = styled("li", itemCss, {
-  padding: "0 $spacing$5",
+  padding: `0 ${theme.spacing[5]}`,
   margin: 0,
-  borderRadius: "$borderRadius$4",
+  borderRadius: theme.borderRadius[4],
 });
 
 const ListboxItemBase: ForwardRefRenderFunction<
@@ -70,7 +71,10 @@ const ListboxItemBase: ForwardRefRenderFunction<
       {...(selected ? { "aria-current": true } : {})}
       {...rest}
     >
-      <Grid align="center" css={{ gridTemplateColumns: "$spacing$10 1fr" }}>
+      <Grid
+        align="center"
+        css={{ gridTemplateColumns: `${theme.spacing[10]} 1fr` }}
+      >
         {selected && <CheckIcon />}
         <Box css={{ gridColumn: 2 }}>{children}</Box>
       </Grid>

--- a/packages/design-system/src/components/dropdown-menu.tsx
+++ b/packages/design-system/src/components/dropdown-menu.tsx
@@ -5,11 +5,12 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { menuCss, separatorCss, itemCss, labelCss } from "./menu";
 import { Box } from "./box";
 import { panelStyles } from "./panel";
+import { theme } from "../stitches.config";
 
 export const DropdownMenu = DropdownMenuPrimitive.Root;
 export const DropdownMenuArrow = styled(DropdownMenuPrimitive.Arrow, {
-  fill: "$colors$slate4",
-  stroke: "$colors$slate1",
+  fill: theme.colors.slate4,
+  stroke: theme.colors.slate1,
 });
 export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 
@@ -54,7 +55,7 @@ export const DropdownMenuRadioItem = React.forwardRef<
   DialogMenuRadioItemProps
 >(({ children, ...props }, forwardedRef) => (
   <StyledDropdownMenuRadioItem {...props} ref={forwardedRef}>
-    <Box as="span" css={{ position: "absolute", left: "$spacing$3" }}>
+    <Box as="span" css={{ position: "absolute", left: theme.spacing[3] }}>
       <DropdownMenuPrimitive.ItemIndicator>
         <CheckIcon />
       </DropdownMenuPrimitive.ItemIndicator>
@@ -82,7 +83,7 @@ export const DropdownMenuCheckboxItem = React.forwardRef<
   DialogMenuCheckboxItemProps
 >(({ children, ...props }, forwardedRef) => (
   <StyledDropdownMenuCheckboxItem {...props} ref={forwardedRef}>
-    <Box as="span" css={{ position: "absolute", left: "$spacing$3" }}>
+    <Box as="span" css={{ position: "absolute", left: theme.spacing[3] }}>
       <DropdownMenuPrimitive.ItemIndicator>
         <CheckIcon />
       </DropdownMenuPrimitive.ItemIndicator>

--- a/packages/design-system/src/components/flex.tsx
+++ b/packages/design-system/src/components/flex.tsx
@@ -1,4 +1,5 @@
 import { styled } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 export const Flex = styled("div", {
   boxSizing: "border-box",
@@ -65,31 +66,31 @@ export const Flex = styled("div", {
     },
     gap: {
       1: {
-        gap: "$spacing$3",
+        gap: theme.spacing[3],
       },
       2: {
-        gap: "$spacing$5",
+        gap: theme.spacing[5],
       },
       3: {
-        gap: "$spacing$9",
+        gap: theme.spacing[9],
       },
       4: {
-        gap: "$spacing$10",
+        gap: theme.spacing[10],
       },
       5: {
-        gap: "$spacing$11",
+        gap: theme.spacing[11],
       },
       6: {
-        gap: "$spacing$13",
+        gap: theme.spacing[13],
       },
       7: {
-        gap: "$spacing$17",
+        gap: theme.spacing[17],
       },
       8: {
-        gap: "$spacing$19",
+        gap: theme.spacing[19],
       },
       9: {
-        gap: "$spacing$20",
+        gap: theme.spacing[20],
       },
     },
     shrink: {

--- a/packages/design-system/src/components/grid.tsx
+++ b/packages/design-system/src/components/grid.tsx
@@ -1,4 +1,5 @@
 import { styled } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 export const Grid = styled("div", {
   boxSizing: "border-box",
@@ -69,89 +70,89 @@ export const Grid = styled("div", {
     },
     gap: {
       1: {
-        gap: "$spacing$3",
+        gap: theme.spacing[3],
       },
       2: {
-        gap: "$spacing$5",
+        gap: theme.spacing[5],
       },
       3: {
-        gap: "$spacing$9",
+        gap: theme.spacing[9],
       },
       4: {
-        gap: "$spacing$10",
+        gap: theme.spacing[10],
       },
       5: {
-        gap: "$spacing$11",
+        gap: theme.spacing[11],
       },
       6: {
-        gap: "$spacing$13",
+        gap: theme.spacing[13],
       },
       7: {
-        gap: "$spacing$17",
+        gap: theme.spacing[17],
       },
       8: {
-        gap: "$spacing$19",
+        gap: theme.spacing[19],
       },
       9: {
-        gap: "$spacing$20",
+        gap: theme.spacing[20],
       },
     },
     gapX: {
       1: {
-        columnGap: "$spacing$3",
+        columnGap: theme.spacing[3],
       },
       2: {
-        columnGap: "$spacing$5",
+        columnGap: theme.spacing[5],
       },
       3: {
-        columnGap: "$spacing$9",
+        columnGap: theme.spacing[9],
       },
       4: {
-        columnGap: "$spacing$10",
+        columnGap: theme.spacing[10],
       },
       5: {
-        columnGap: "$spacing$11",
+        columnGap: theme.spacing[11],
       },
       6: {
-        columnGap: "$spacing$13",
+        columnGap: theme.spacing[13],
       },
       7: {
-        columnGap: "$spacing$17",
+        columnGap: theme.spacing[17],
       },
       8: {
-        columnGap: "$spacing$19",
+        columnGap: theme.spacing[19],
       },
       9: {
-        columnGap: "$spacing$20",
+        columnGap: theme.spacing[20],
       },
     },
     gapY: {
       1: {
-        rowGap: "$spacing$3",
+        rowGap: theme.spacing[3],
       },
       2: {
-        rowGap: "$spacing$5",
+        rowGap: theme.spacing[5],
       },
       3: {
-        rowGap: "$spacing$9",
+        rowGap: theme.spacing[9],
       },
       4: {
-        rowGap: "$spacing$10",
+        rowGap: theme.spacing[10],
       },
       5: {
-        rowGap: "$spacing$11",
+        rowGap: theme.spacing[11],
       },
       6: {
-        rowGap: "$spacing$13",
+        rowGap: theme.spacing[13],
       },
       7: {
-        rowGap: "$spacing$17",
+        rowGap: theme.spacing[17],
       },
       8: {
-        rowGap: "$spacing$19",
+        rowGap: theme.spacing[19],
       },
       9: {
-        rowGap: "$spacing$20",
+        rowGap: theme.spacing[20],
       },
     },
   },

--- a/packages/design-system/src/components/icon-button-with-menu.tsx
+++ b/packages/design-system/src/components/icon-button-with-menu.tsx
@@ -3,37 +3,37 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { styled } from "../stitches.config";
 import { Tooltip } from "./tooltip";
 import { IconButton } from "./icon-button";
+import { theme } from "../stitches.config";
 
 const StyledContent = styled(DropdownMenuPrimitive.Content, {
   width: 192,
   maxHeight: 238,
   overflow: "auto",
-  backgroundColor: "$colors$slate4",
-  borderRadius: "$borderRadius$4",
-  padding: "$spacing$5",
-  boxShadow:
-    "0px 2px 7px rgba(0, 0, 0, 0.1), 0px 5px 17px rgba(0, 0, 0, 0.15), inset 0 0 1px 1px $colors$gray1, 0 0 0 1px $colors$gray8",
+  backgroundColor: theme.colors.slate4,
+  borderRadius: theme.borderRadius[4],
+  padding: theme.spacing[5],
+  boxShadow: `0px 2px 7px rgba(0, 0, 0, 0.1), 0px 5px 17px rgba(0, 0, 0, 0.15), inset 0 0 1px 1px ${theme.colors.gray1}, 0 0 0 1px ${theme.colors.gray8}`,
 });
 
 const itemStyles = {
   all: "unset",
-  fontSize: "$fontSize$3",
+  fontSize: theme.fontSize[3],
   lineHeight: 1,
-  color: "$colors$slate12",
-  borderRadius: "$borderRadius$4",
+  color: theme.colors.slate12,
+  borderRadius: theme.borderRadius[4],
   display: "flex",
   alignItems: "center",
-  height: "$spacing$11",
-  padding: "0 $spacing$11",
+  height: theme.spacing[11],
+  padding: `0 ${theme.spacing[11]}`,
   position: "relative",
-  paddingLeft: "$spacing$11",
-  paddingRight: "$spacing$11",
+  paddingLeft: theme.spacing[11],
+  paddingRight: theme.spacing[11],
   userSelect: "none",
-  gap: "$spacing$5",
+  gap: theme.spacing[5],
   "&[data-highlighted]": {
-    background: "$colors$blue10",
-    color: "$colors$blue1",
-    "& *": { fill: "$colors$blue1" },
+    background: theme.colors.blue10,
+    color: theme.colors.blue1,
+    "& *": { fill: theme.colors.blue1 },
   },
 };
 
@@ -48,8 +48,8 @@ const itemIndicatorStyle = {
 
 const arrowStyle = {
   "& *": {
-    fill: "$colors$gray4",
-    stroke: "$colors$gray8",
+    fill: theme.colors.gray4,
+    stroke: theme.colors.gray8,
   },
 };
 

--- a/packages/design-system/src/components/icon-button.tsx
+++ b/packages/design-system/src/components/icon-button.tsx
@@ -1,4 +1,5 @@
 import { styled } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 export const IconButton = styled("button", {
   // reset styles
@@ -16,10 +17,10 @@ export const IconButton = styled("button", {
   // set size and shape
   width: 28,
   height: 28,
-  borderRadius: "$borderRadius$3",
+  borderRadius: theme.borderRadius[3],
 
   "&:focus-visible": {
-    outline: "2px solid $blue10",
+    outline: `2px solid ${theme.colors.blue10}`,
   },
   "&:disabled": {
     borderColor: "transparent",
@@ -29,49 +30,49 @@ export const IconButton = styled("button", {
   variants: {
     variant: {
       default: {
-        color: "$slate12",
+        color: theme.colors.slate12,
         "&:hover": {
-          backgroundColor: "$slate6",
+          backgroundColor: theme.colors.slate6,
         },
         "&:disabled": {
-          color: "$slate8",
+          color: theme.colors.slate8,
         },
       },
       preset: {
-        backgroundColor: "$slate6",
-        borderColor: "$slate8",
-        color: "$slate12",
+        backgroundColor: theme.colors.slate6,
+        borderColor: theme.colors.slate8,
+        color: theme.colors.slate12,
         "&:hover": {
-          backgroundColor: "$slate8",
+          backgroundColor: theme.colors.slate8,
         },
         "&:disabled": {
-          color: "$slate8",
+          color: theme.colors.slate8,
         },
       },
       set: {
-        backgroundColor: "$blue4",
-        borderColor: "$blue6",
-        color: "$blue11",
+        backgroundColor: theme.colors.blue4,
+        borderColor: theme.colors.blue6,
+        color: theme.colors.blue11,
         "&:hover": {
-          backgroundColor: "$blue6",
+          backgroundColor: theme.colors.blue6,
         },
         "&:disabled": {
-          color: "$blue6",
+          color: theme.colors.blue6,
         },
       },
       inherited: {
-        backgroundColor: "$orange4",
-        borderColor: "$orange6",
-        color: "$orange11",
+        backgroundColor: theme.colors.orange4,
+        borderColor: theme.colors.orange6,
+        color: theme.colors.orange11,
         "&:hover": {
-          backgroundColor: "$orange6",
+          backgroundColor: theme.colors.orange6,
         },
         "&:disabled": {
-          color: "$orange6",
+          color: theme.colors.orange6,
         },
       },
       active: {
-        backgroundColor: "$blue10",
+        backgroundColor: theme.colors.blue10,
         color: "White",
         // non-interactive state because usually covered with overlay
       },

--- a/packages/design-system/src/components/link.tsx
+++ b/packages/design-system/src/components/link.tsx
@@ -1,14 +1,15 @@
 import { styled } from "../stitches.config";
 import { DeprecatedText } from "./__DEPRECATED__/text";
+import { theme } from "../stitches.config";
 
 export const Link = styled("a", {
   alignItems: "center",
-  gap: "$spacing$3",
+  gap: theme.spacing[3],
   flexShrink: 0,
   outline: "none",
   textDecorationLine: "none",
   textUnderlineOffset: "3px",
-  textDecorationColor: "$slate4",
+  textDecorationColor: theme.colors.slate4,
   WebkitTapHighlightColor: "rgba(0,0,0,0)",
   lineHeight: "inherit",
   "@hover": {
@@ -28,30 +29,30 @@ export const Link = styled("a", {
   variants: {
     variant: {
       blue: {
-        color: "$blue11",
-        textDecorationColor: "$blue4",
+        color: theme.colors.blue11,
+        textDecorationColor: theme.colors.blue4,
         "&:focus": {
-          outlineColor: "$blue8",
+          outlineColor: theme.colors.blue8,
         },
       },
       subtle: {
-        color: "$slate11",
-        textDecorationColor: "$slate4",
+        color: theme.colors.slate11,
+        textDecorationColor: theme.colors.slate4,
         "&:focus": {
-          outlineColor: "$slate8",
+          outlineColor: theme.colors.slate8,
         },
       },
       contrast: {
-        color: "$hiContrast",
+        color: theme.colors.hiContrast,
         textDecoration: "underline",
-        textDecorationColor: "$slate4",
+        textDecorationColor: theme.colors.slate4,
         "@hover": {
           "&:hover": {
-            textDecorationColor: "$slate7",
+            textDecorationColor: theme.colors.slate7,
           },
         },
         "&:focus": {
-          outlineColor: "$slate8",
+          outlineColor: theme.colors.slate8,
         },
       },
     },

--- a/packages/design-system/src/components/list.tsx
+++ b/packages/design-system/src/components/list.tsx
@@ -7,6 +7,7 @@ import {
 import { styled } from "../stitches.config";
 import { Flex } from "./flex";
 import { Text } from "./text";
+import { theme } from "../stitches.config";
 
 const ListBase = styled("ul", {
   display: "flex",
@@ -17,13 +18,13 @@ const ListBase = styled("ul", {
 
 const ListItemBase = styled("li", {
   display: "grid",
-  gridTemplateColumns: "$spacing$10 1fr",
+  gridTemplateColumns: `${theme.spacing[10]} 1fr`,
   alignItems: "center",
   justifyContent: "space-between",
-  height: "$spacing$11",
-  px: "$spacing$3",
+  height: theme.spacing[11],
+  px: theme.spacing[3],
   listStyle: "none",
-  borderRadius: "$borderRadius$4",
+  borderRadius: theme.borderRadius[4],
   outline: 0,
   variants: {
     state: {
@@ -31,8 +32,7 @@ const ListItemBase = styled("li", {
         pointerEvents: "none",
       },
       selected: {
-        boxShadow:
-          "0px 0px 0px 2px $colors$blue10, 0px 0px 0px 2px $colors$blue10",
+        boxShadow: `0px 0px 0px 2px ${theme.colors.blue10}, 0px 0px 0px 2px ${theme.colors.blue10}`,
       },
     },
   },

--- a/packages/design-system/src/components/menu.tsx
+++ b/packages/design-system/src/components/menu.tsx
@@ -4,49 +4,50 @@ import { CheckIcon } from "@webstudio-is/icons";
 import { styled, css, CSS } from "../stitches.config";
 import { Box } from "./box";
 import { panelStyles } from "./panel";
+import { theme } from "../stitches.config";
 
 export const baseItemCss = css({
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
-  fontFamily: "$sans",
-  fontSize: "$fontSize$3",
+  fontFamily: theme.fonts.sans,
+  fontSize: theme.fontSize[3],
   fontVariantNumeric: "tabular-nums",
   lineHeight: "1",
   cursor: "default",
   userSelect: "none",
   whiteSpace: "nowrap",
-  height: "$spacing$11",
-  px: "$spacing$11",
+  height: theme.spacing[11],
+  px: theme.spacing[11],
 });
 
 export const itemCss = css(baseItemCss, {
   position: "relative",
-  color: "$hiContrast",
+  color: theme.colors.hiContrast,
   "&:focus, &[data-found], &[aria-selected=true]": {
     outline: "none",
-    backgroundColor: "$blue10",
+    backgroundColor: theme.colors.blue10,
     color: "white",
   },
   "&[data-disabled], &[aria-disabled]": {
-    color: "$slate9",
+    color: theme.colors.slate9,
   },
 });
 
 export const labelCss = css(baseItemCss, {
-  color: "$slate11",
+  color: theme.colors.slate11,
 });
 
 export const menuCss = css({
   boxSizing: "border-box",
   minWidth: 120,
-  py: "$spacing$3",
+  py: theme.spacing[3],
 });
 
 export const separatorCss = css({
   height: 1,
-  my: "$spacing$3",
-  backgroundColor: "$slate6",
+  my: theme.spacing[3],
+  backgroundColor: theme.colors.slate6,
 });
 
 export const Menu = styled(MenuPrimitive.Root, menuCss);
@@ -68,7 +69,7 @@ export const MenuRadioItem = React.forwardRef<
   MenuRadioItemProps
 >(({ children, ...props }, forwardedRef) => (
   <StyledMenuRadioItem {...props} ref={forwardedRef}>
-    <Box as="span" css={{ position: "absolute", left: "$spacing$3" }}>
+    <Box as="span" css={{ position: "absolute", left: theme.spacing[3] }}>
       <MenuPrimitive.ItemIndicator>
         <CheckIcon />
       </MenuPrimitive.ItemIndicator>
@@ -90,7 +91,7 @@ export const MenuCheckboxItem = React.forwardRef<
   MenuCheckboxItemProps
 >(({ children, ...props }, forwardedRef) => (
   <StyledMenuCheckboxItem {...props} ref={forwardedRef}>
-    <Box as="span" css={{ position: "absolute", left: "$spacing$3" }}>
+    <Box as="span" css={{ position: "absolute", left: theme.spacing[3] }}>
       <MenuPrimitive.ItemIndicator>
         <CheckIcon />
       </MenuPrimitive.ItemIndicator>

--- a/packages/design-system/src/components/panel.tsx
+++ b/packages/design-system/src/components/panel.tsx
@@ -1,11 +1,11 @@
 import { css, styled } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 export const panelStyles = css({
   overflow: "auto",
-  backgroundColor: "$slate4",
-  borderRadius: "$borderRadius$4",
-  boxShadow:
-    "0px 2px 7px rgba(0, 0, 0, 0.1), 0px 5px 17px rgba(0, 0, 0, 0.15), inset 0 0 1px 1px $colors$slate1, 0 0 0 1px $colors$slate7",
+  backgroundColor: theme.colors.slate4,
+  borderRadius: theme.borderRadius[4],
+  boxShadow: `0px 2px 7px rgba(0, 0, 0, 0.1), 0px 5px 17px rgba(0, 0, 0, 0.15), inset 0 0 1px 1px ${theme.colors.slate1}, 0 0 0 1px ${theme.colors.slate7}`,
 });
 
 export const Panel = styled("div", panelStyles);

--- a/packages/design-system/src/components/popover.tsx
+++ b/packages/design-system/src/components/popover.tsx
@@ -8,6 +8,7 @@ import { DeprecatedIconButton } from "./__DEPRECATED__/icon-button";
 import { Text } from "./text";
 import { Separator } from "./separator";
 import { styled, CSS } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 type PopoverProps = React.ComponentProps<typeof PopoverPrimitive.Root> & {
   children: React.ReactNode;
@@ -20,7 +21,7 @@ export const Popover = ({ children, ...props }: PopoverProps) => {
 const StyledContent = styled(PopoverPrimitive.Content, panelStyles, {
   backgroundColor: "white",
   minWidth: 200,
-  minHeight: "$spacing$13",
+  minHeight: theme.spacing[13],
   maxWidth: 265,
   "&:focus": {
     outline: "none",
@@ -50,7 +51,7 @@ export const PopoverContent = React.forwardRef<
   >
     {children}
     {!hideArrow && (
-      <Box css={{ color: "$panel" }}>
+      <Box css={{ color: theme.colors.panel }}>
         <PopoverPrimitive.Arrow
           width={11}
           height={5}
@@ -71,7 +72,7 @@ export const PopoverHeader = ({ title }: PopoverHeaderProps) => {
   return (
     <Box css={{ order: -1 }}>
       <Flex
-        css={{ height: 40, paddingLeft: "$spacing$9" }}
+        css={{ height: 40, paddingLeft: theme.spacing[9] }}
         align="center"
         justify="between"
       >
@@ -80,7 +81,7 @@ export const PopoverHeader = ({ title }: PopoverHeaderProps) => {
           <DeprecatedIconButton
             size="2"
             css={{
-              marginRight: "$spacing$5",
+              marginRight: theme.spacing[5],
             }}
             aria-label="Close"
           >

--- a/packages/design-system/src/components/primitives/dnd/canvas.stories.tsx
+++ b/packages/design-system/src/components/primitives/dnd/canvas.stories.tsx
@@ -5,6 +5,7 @@ import { useDrop, type DropTarget } from "./use-drop";
 import { useDrag } from "./use-drag";
 import { PlacementIndicator } from "./placement-indicator";
 import { useAutoScroll } from "./use-auto-scroll";
+import { theme } from "../../../stitches.config";
 
 const ROOT_ID = "root";
 
@@ -30,8 +31,8 @@ const Item = ({
         minHeight: 100,
         margin: 10,
         padding: 10,
-        background: "$mint5",
-        border: "1px solid $mint9",
+        background: theme.colors.mint5,
+        border: `1px solid ${theme.colors.mint9}`,
       }}
       style={data.style}
       data-id={data.id}

--- a/packages/design-system/src/components/primitives/dnd/placement-indicator.tsx
+++ b/packages/design-system/src/components/primitives/dnd/placement-indicator.tsx
@@ -1,10 +1,11 @@
 import { Box } from "../../box";
 import { type Placement } from "./geometry-utils";
+import { theme } from "../../../stitches.config";
 
 const placementStyle = {
   boxSizing: "content-box",
   position: "absolute",
-  background: "$blue10",
+  background: theme.colors.blue10,
   pointerEvents: "none",
 };
 

--- a/packages/design-system/src/components/primitives/dnd/sortable-list.stories.tsx
+++ b/packages/design-system/src/components/primitives/dnd/sortable-list.stories.tsx
@@ -6,13 +6,14 @@ import { useDrop, type DropTarget } from "./use-drop";
 import { useDrag } from "./use-drag";
 import { PlacementIndicator } from "./placement-indicator";
 import { useAutoScroll } from "./use-auto-scroll";
+import { theme } from "../../../stitches.config";
 
 type ItemData = { id: string; text: string };
 
 const ListItem = styled("li", {
   display: "block",
   margin: 10,
-  background: "$mint5",
+  background: theme.colors.mint5,
   padding: 10,
   userSelect: "none",
 });

--- a/packages/design-system/src/components/radio.tsx
+++ b/packages/design-system/src/components/radio.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { styled, CSS, VariantProps } from "../stitches.config";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { theme } from "../stitches.config";
 
 export const RadioGroup = styled(RadioGroupPrimitive.Root, {
   display: "flex",
@@ -16,10 +17,10 @@ const StyledIndicator = styled(RadioGroupPrimitive.Indicator, {
   "&::after": {
     content: '""',
     display: "block",
-    width: "$spacing$4",
-    height: "$spacing$4",
+    width: theme.spacing[4],
+    height: theme.spacing[4],
     borderRadius: "50%",
-    backgroundColor: "$blue9",
+    backgroundColor: theme.colors.blue9,
   },
 });
 
@@ -45,34 +46,34 @@ const StyledRadio = styled(RadioGroupPrimitive.Item, {
   WebkitTapHighlightColor: "rgba(0,0,0,0)",
 
   borderRadius: "50%",
-  color: "$hiContrast",
-  boxShadow: "inset 0 0 0 1px $colors$slate7",
+  color: theme.colors.hiContrast,
+  boxShadow: `inset 0 0 0 1px ${theme.colors.slate7}`,
   overflow: "hidden",
   "@hover": {
     "&:hover": {
-      boxShadow: "inset 0 0 0 1px $colors$slate8",
+      boxShadow: `inset 0 0 0 1px ${theme.colors.slate8}`,
     },
   },
   "&:focus": {
     outline: "none",
-    borderColor: "$red7",
-    boxShadow: "inset 0 0 0 1px $colors$blue9, 0 0 0 1px $colors$blue9",
+    borderColor: theme.colors.red7,
+    boxShadow: `inset 0 0 0 1px ${theme.colors.blue9}, 0 0 0 1px ${theme.colors.blue9}`,
   },
 
   variants: {
     size: {
       "1": {
-        width: "$spacing$9",
-        height: "$spacing$9",
+        width: theme.spacing[9],
+        height: theme.spacing[9],
       },
       "2": {
-        width: "$spacing$11",
-        height: "$spacing$11",
+        width: theme.spacing[11],
+        height: theme.spacing[11],
 
         [`& ${StyledIndicator}`]: {
           "&::after": {
-            width: "$spacing$9",
-            height: "$spacing$9",
+            width: theme.spacing[9],
+            height: theme.spacing[9],
           },
         },
       },

--- a/packages/design-system/src/components/search-field.tsx
+++ b/packages/design-system/src/components/search-field.tsx
@@ -13,14 +13,15 @@ import {
 import { TextField } from "./text-field";
 import { DeprecatedIconButton } from "./__DEPRECATED__/icon-button";
 import { styled } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 const SearchIcon = styled(MagnifyingGlassIcon, {
-  color: "$hint",
-  padding: "$spacing$3",
+  color: theme.colors.hint,
+  padding: theme.spacing[3],
 });
 
 const AbortButton = styled(DeprecatedIconButton, {
-  marginRight: "$spacing$3",
+  marginRight: theme.spacing[3],
 });
 
 const SearchFieldBase: ForwardRefRenderFunction<

--- a/packages/design-system/src/components/select.tsx
+++ b/packages/design-system/src/components/select.tsx
@@ -4,6 +4,7 @@ import { Grid } from "./grid";
 import { Box } from "./box";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "@webstudio-is/icons";
 import { styled } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 const StyledTrigger = styled(SelectPrimitive.SelectTrigger, {
   all: "unset",
@@ -11,21 +12,20 @@ const StyledTrigger = styled(SelectPrimitive.SelectTrigger, {
   alignItems: "center",
   justifyContent: "space-between",
   fontVariantNumeric: "tabular-nums",
-  gap: "$spacing$5",
+  gap: theme.spacing[5],
   flexShrink: 0,
-  borderRadius: "$borderRadius$4",
-  backgroundColor: "$loContrast",
-  color: "$hiContrast",
-  boxShadow: "inset 0 0 0 1px $colors$slate7",
+  borderRadius: theme.borderRadius[4],
+  backgroundColor: theme.colors.loContrast,
+  color: theme.colors.hiContrast,
+  boxShadow: `inset 0 0 0 1px ${theme.colors.slate7}`,
   height: 28, // @todo waiting for the sizing scale
-  px: "$spacing$5",
-  fontSize: "$fontSize$3",
+  px: theme.spacing[5],
+  fontSize: theme.fontSize[3],
   "&:focus": {
-    boxShadow:
-      "inset 0px 0px 0px 1px $colors$blue8, 0px 0px 0px 1px $colors$blue8",
+    boxShadow: `inset 0px 0px 0px 1px ${theme.colors.blue8}, 0px 0px 0px 1px ${theme.colors.blue8}`,
   },
   paddingRight: 0,
-  paddingLeft: "$spacing$5",
+  paddingLeft: theme.spacing[5],
   textTransform: "capitalize",
   fontWeight: "inherit",
 
@@ -56,41 +56,40 @@ const StyledIcon = styled(SelectPrimitive.Icon, {
   alignItems: "center",
   justifyContent: "center",
   height: "100%",
-  padding: "$spacing$2 $spacing$2 $spacing$2 0px",
+  padding: `${theme.spacing[2]} ${theme.spacing[2]} ${theme.spacing[2]} 0px`,
 });
 
 export const SelectContent = styled(SelectPrimitive.Content, {
   overflow: "hidden",
-  backgroundColor: "$colors$slate4",
-  borderRadius: "$borderRadius$4",
-  boxShadow:
-    "0px 2px 7px rgba(0, 0, 0, 0.1), 0px 5px 17px rgba(0, 0, 0, 0.15), inset 0 0 1px 1px $colors$slate1, 0 0 0 1px $colors$slate8",
+  backgroundColor: theme.colors.slate4,
+  borderRadius: theme.borderRadius[4],
+  boxShadow: `0px 2px 7px rgba(0, 0, 0, 0.1), 0px 5px 17px rgba(0, 0, 0, 0.15), inset 0 0 1px 1px ${theme.colors.slate1}, 0 0 0 1px ${theme.colors.slate8}`,
 });
 
 export const SelectViewport = styled(SelectPrimitive.Viewport, {
-  p: "$spacing$3",
+  p: theme.spacing[3],
 });
 
 const StyledItem = styled(SelectPrimitive.Item, {
   all: "unset",
-  fontSize: "$fontSize$3",
+  fontSize: theme.fontSize[3],
   lineHeight: 1,
-  color: "$hiContrast",
+  color: theme.colors.hiContrast,
   display: "flex",
   alignItems: "center",
-  height: "$spacing$11",
-  padding: "0 $spacing$5",
+  height: theme.spacing[11],
+  padding: `0 ${theme.spacing[5]}`,
   position: "relative",
   userSelect: "none",
-  borderRadius: "$borderRadius$4",
+  borderRadius: theme.borderRadius[4],
 
   "&[data-disabled]": {
-    color: "$muted",
+    color: theme.colors.muted,
     pointerEvents: "none",
   },
 
   "&:focus": {
-    backgroundColor: "$blue10",
+    backgroundColor: theme.colors.blue10,
     color: "white",
   },
 });
@@ -100,7 +99,7 @@ const scrollButtonStyles = {
   alignItems: "center",
   justifyContent: "center",
   height: 25,
-  color: "$hiContrast",
+  color: theme.colors.hiContrast,
   cursor: "default",
 };
 
@@ -120,7 +119,10 @@ const SelectItemBase = (
 ) => {
   return (
     <StyledItem {...props} ref={forwardedRef}>
-      <Grid align="center" css={{ gridTemplateColumns: "$spacing$10 1fr" }}>
+      <Grid
+        align="center"
+        css={{ gridTemplateColumns: `${theme.spacing[10]} 1fr` }}
+      >
         <SelectPrimitive.ItemIndicator>
           <CheckIcon />
         </SelectPrimitive.ItemIndicator>

--- a/packages/design-system/src/components/separator.tsx
+++ b/packages/design-system/src/components/separator.tsx
@@ -1,44 +1,45 @@
 import { styled } from "../stitches.config";
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import { theme } from "../stitches.config";
 
 export const Separator = styled(SeparatorPrimitive.Root, {
   border: "none",
   margin: 0,
   flexShrink: 0,
-  backgroundColor: "$slate7",
+  backgroundColor: theme.colors.slate7,
   cursor: "default",
 
   variants: {
     size: {
       "1": {
         '&[data-orientation="horizontal"]': {
-          height: "$spacing$1",
-          width: "$spacing$9",
+          height: theme.spacing[1],
+          width: theme.spacing[9],
         },
 
         '&[data-orientation="vertical"]': {
-          width: "$spacing$1",
-          height: "$spacing$9",
+          width: theme.spacing[1],
+          height: theme.spacing[9],
         },
       },
       "2": {
         '&[data-orientation="horizontal"]': {
-          height: "$spacing$2",
-          width: "$spacing$17",
+          height: theme.spacing[2],
+          width: theme.spacing[17],
         },
 
         '&[data-orientation="vertical"]': {
-          width: "$spacing$2",
-          height: "$spacing$17",
+          width: theme.spacing[2],
+          height: theme.spacing[17],
         },
       },
       auto: {
         '&[data-orientation="horizontal"]': {
-          height: "$spacing$1",
+          height: theme.spacing[1],
         },
 
         '&[data-orientation="vertical"]': {
-          width: "$spacing$1",
+          width: theme.spacing[1],
         },
       },
     },

--- a/packages/design-system/src/components/sidebar-tabs.tsx
+++ b/packages/design-system/src/components/sidebar-tabs.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { CSS, styled } from "../stitches.config";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { theme } from "../stitches.config";
 
 export const SidebarTabs = styled(TabsPrimitive.Root, {
   display: "flex",
@@ -13,27 +14,27 @@ export const SidebarTabs = styled(TabsPrimitive.Root, {
 export const SidebarTabsTrigger = styled(TabsPrimitive.Trigger, {
   flexShrink: 0,
   display: "flex",
-  size: "$spacing$17",
+  size: theme.spacing[17],
   m: 0,
   userSelect: "none",
   outline: "none",
   alignItems: "center",
   justifyContent: "center",
-  color: "$slate11",
+  color: theme.colors.slate11,
   border: "1px solid transparent",
   backgroundColor: "transparent",
 
   "@hover": {
     "&:hover": {
-      backgroundColor: "$slateA3",
-      color: "$hiContrast",
+      backgroundColor: theme.colors.slateA3,
+      color: theme.colors.hiContrast,
     },
   },
 
   '&[data-state="active"]': {
-    color: "$hiContrast",
-    backgroundColor: "$slateA4",
-    borderColor: "$slate6",
+    color: theme.colors.hiContrast,
+    backgroundColor: theme.colors.slateA4,
+    borderColor: theme.colors.slate6,
   },
 });
 
@@ -44,7 +45,7 @@ const StyledTabsList = styled(TabsPrimitive.List, {
   alignItems: "center",
   outline: "none",
   '&[data-state="active"]': {
-    borderRight: "1px solid $slate7",
+    borderRight: `1px solid ${theme.colors.slate7}`,
   },
 });
 
@@ -68,9 +69,9 @@ export const SidebarTabsContent = styled(TabsPrimitive.Content, {
   top: 0,
   left: "100%",
   height: "100%",
-  bc: "$loContrast",
+  bc: theme.colors.loContrast,
   outline: "none",
   '&[data-state="active"]': {
-    borderRight: "1px solid $slate7",
+    borderRight: `1px solid ${theme.colors.slate7}`,
   },
 });

--- a/packages/design-system/src/components/slider.tsx
+++ b/packages/design-system/src/components/slider.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { styled, CSS } from "../stitches.config";
 import * as SliderPrimitive from "@radix-ui/react-slider";
+import { theme } from "../stitches.config";
 
 const SliderTrack = styled(SliderPrimitive.Track, {
   position: "relative",
   flexGrow: 1,
-  backgroundColor: "$slate7",
-  borderRadius: "$borderRadius$pill",
+  backgroundColor: theme.colors.slate7,
+  borderRadius: theme.borderRadius.pill,
   '&[data-orientation="horizontal"]': {
     height: 2,
   },
@@ -18,7 +19,7 @@ const SliderTrack = styled(SliderPrimitive.Track, {
 
 const SliderRange = styled(SliderPrimitive.Range, {
   position: "absolute",
-  background: "$blue9",
+  background: theme.colors.blue9,
   borderRadius: "inherit",
   '&[data-orientation="horizontal"]': {
     height: "100%",
@@ -36,7 +37,7 @@ const SliderThumb = styled(SliderPrimitive.Thumb, {
   outline: "none",
   backgroundColor: "white",
   boxShadow: "0 0 1px rgba(0,0,0,.3), 0 1px 4px rgba(0,0,0,.15)",
-  borderRadius: "$borderRadius$round",
+  borderRadius: theme.borderRadius.round,
 
   "&::after": {
     content: '""',
@@ -48,7 +49,7 @@ const SliderThumb = styled(SliderPrimitive.Thumb, {
     zIndex: -2,
     backgroundColor: "hsla(0,0%,0%,.035)",
     transform: "scale(1)",
-    borderRadius: "$borderRadius$round",
+    borderRadius: theme.borderRadius.round,
     transition: "transform 200ms cubic-bezier(0.22, 1, 0.36, 1)",
   },
 
@@ -77,7 +78,7 @@ export const StyledSlider = styled(SliderPrimitive.Root, {
   "@hover": {
     "&:hover": {
       [`& ${SliderTrack}`]: {
-        backgroundColor: "$slate8",
+        backgroundColor: theme.colors.slate8,
       },
     },
   },

--- a/packages/design-system/src/components/status.tsx
+++ b/packages/design-system/src/components/status.tsx
@@ -1,4 +1,5 @@
 import { styled } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 export const Status = styled("div", {
   borderRadius: "50%",
@@ -17,19 +18,19 @@ export const Status = styled("div", {
     },
     variant: {
       gray: {
-        backgroundColor: "$slate7",
+        backgroundColor: theme.colors.slate7,
       },
       blue: {
-        backgroundColor: "$blue9",
+        backgroundColor: theme.colors.blue9,
       },
       green: {
-        backgroundColor: "$green9",
+        backgroundColor: theme.colors.green9,
       },
       yellow: {
-        backgroundColor: "$yellow9",
+        backgroundColor: theme.colors.yellow9,
       },
       red: {
-        backgroundColor: "$red9",
+        backgroundColor: theme.colors.red9,
       },
     },
   },

--- a/packages/design-system/src/components/switch.tsx
+++ b/packages/design-system/src/components/switch.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { styled, VariantProps, CSS } from "../stitches.config";
 import * as SwitchPrimitive from "@radix-ui/react-switch";
+import { theme } from "../stitches.config";
 
 const StyledThumb = styled(SwitchPrimitive.Thumb, {
   position: "absolute",
@@ -8,14 +9,14 @@ const StyledThumb = styled(SwitchPrimitive.Thumb, {
   width: 13,
   height: 13,
   backgroundColor: "white",
-  borderRadius: "$borderRadius$round",
+  borderRadius: theme.borderRadius.round,
   boxShadow: "rgba(0, 0, 0, 0.3) 0px 0px 1px, rgba(0, 0, 0, 0.2) 0px 1px 2px;",
   transition: "transform 100ms cubic-bezier(0.22, 1, 0.36, 1)",
-  transform: "translateX($spacing$1)",
+  transform: `translateX(${theme.spacing[1]})`,
   willChange: "transform",
 
   '&[data-state="checked"]': {
-    transform: "translateX($spacing$6)",
+    transform: `translateX(${theme.spacing[6]})`,
   },
 });
 
@@ -40,35 +41,35 @@ const StyledSwitch = styled(SwitchPrimitive.Root, {
   outline: "none",
   WebkitTapHighlightColor: "rgba(0,0,0,0)",
 
-  backgroundColor: "$slate6",
-  borderRadius: "$borderRadius$pill",
+  backgroundColor: theme.colors.slate6,
+  borderRadius: theme.borderRadius.pill,
   position: "relative",
   "&:focus": {
-    boxShadow: "0 0 0 2px $colors$slate8",
+    boxShadow: `0 0 0 2px ${theme.colors.slate8}`,
   },
 
   '&[data-state="checked"]': {
-    backgroundColor: "$blue9",
+    backgroundColor: theme.colors.blue9,
     "&:focus": {
-      boxShadow: "0 0 0 2px $colors$blue8",
+      boxShadow: `0 0 0 2px ${theme.colors.blue8}`,
     },
   },
 
   variants: {
     size: {
       "1": {
-        width: "$spacing$11",
-        height: "$spacing$9",
+        width: theme.spacing[11],
+        height: theme.spacing[9],
       },
       "2": {
-        width: "$spacing$17",
-        height: "$spacing$11",
+        width: theme.spacing[17],
+        height: theme.spacing[11],
         [`& ${StyledThumb}`]: {
           width: 21,
           height: 21,
-          transform: "translateX($spacing$2)",
+          transform: `translateX(${theme.spacing[2]})`,
           '&[data-state="checked"]': {
-            transform: "translateX(2$spacing$2)",
+            transform: `translateX(2${theme.spacing[2]})`,
           },
         },
       },

--- a/packages/design-system/src/components/tabs.tsx
+++ b/packages/design-system/src/components/tabs.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { styled, CSS } from "../stitches.config";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { Text } from "./text";
+import { theme } from "../stitches.config";
 
 export const Tabs = styled(TabsPrimitive.Root, {
   display: "flex",
@@ -12,12 +13,12 @@ export const Tabs = styled(TabsPrimitive.Root, {
 
 export const TabsTrigger = styled(TabsPrimitive.Trigger, {
   flexShrink: 0,
-  height: "$spacing$17",
+  height: theme.spacing[17],
   display: "inline-flex",
   lineHeight: 1,
   fontFamily: "inherit",
-  fontSize: "$fontSize$3",
-  px: "$spacing$5",
+  fontSize: theme.fontSize[3],
+  px: theme.spacing[5],
   userSelect: "none",
   outline: "none",
   alignItems: "center",
@@ -25,22 +26,22 @@ export const TabsTrigger = styled(TabsPrimitive.Trigger, {
   border: "none",
   backgroundColor: "transparent",
   ["&:first-child"]: {
-    paddingLeft: "$spacing$9",
+    paddingLeft: theme.spacing[9],
   },
   [`& > ${Text}`]: {
-    color: "$gray9",
-    fontSize: "$fontSize$3",
+    color: theme.colors.gray9,
+    fontSize: theme.fontSize[3],
     fontWeight: "500",
   },
   "@hover": {
     "&:hover": {
-      color: "$hiContrast",
+      color: theme.colors.hiContrast,
     },
   },
 
   '&[data-state="active"]': {
     [`& > ${Text}`]: {
-      color: "$hiContrast",
+      color: theme.colors.hiContrast,
     },
   },
 

--- a/packages/design-system/src/components/text-area.tsx
+++ b/packages/design-system/src/components/text-area.tsx
@@ -1,4 +1,5 @@
 import { styled } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 export const TextArea = styled("textarea", {
   // Reset
@@ -7,75 +8,72 @@ export const TextArea = styled("textarea", {
   fontFamily: "inherit",
   margin: "0",
   outline: "none",
-  padding: "$spacing$3",
+  padding: theme.spacing[3],
   WebkitTapHighlightColor: "rgba(0,0,0,0)",
-  backgroundColor: "$loContrast",
-  boxShadow: "inset 0 0 0 1px $colors$muted",
-  color: "$hiContrast",
+  backgroundColor: theme.colors.loContrast,
+  boxShadow: `inset 0 0 0 1px ${theme.colors.muted}`,
+  color: theme.colors.hiContrast,
   fontVariantNumeric: "tabular-nums",
   position: "relative",
   minHeight: 80,
   resize: "vertical",
 
   "&:focus": {
-    boxShadow:
-      "inset 0px 0px 0px 1px $colors$blue8, 0px 0px 0px 1px $colors$blue8",
+    boxShadow: `inset 0px 0px 0px 1px ${theme.colors.blue8}, 0px 0px 0px 1px ${theme.colors.blue8}`,
     zIndex: "1",
   },
   "&::placeholder": {
-    color: "$slate9",
+    color: theme.colors.slate9,
   },
   "&:disabled": {
     pointerEvents: "none",
-    backgroundColor: "$slate2",
-    color: "$slate8",
+    backgroundColor: theme.colors.slate2,
+    color: theme.colors.slate8,
     cursor: "not-allowed",
     resize: "none",
     "&::placeholder": {
-      color: "$slate7",
+      color: theme.colors.slate7,
     },
   },
   "&:read-only": {
-    backgroundColor: "$slate2",
+    backgroundColor: theme.colors.slate2,
     "&:focus": {
-      boxShadow: "inset 0px 0px 0px 1px $colors$slate7",
+      boxShadow: `inset 0px 0px 0px 1px ${theme.colors.slate7}`,
     },
   },
 
   variants: {
     size: {
       "1": {
-        borderRadius: "$borderRadius$4",
-        fontSize: "$fontSize$3",
-        lineHeight: "$lineHeight$3",
-        px: "$spacing$3",
+        borderRadius: theme.borderRadius[4],
+        fontSize: theme.fontSize[3],
+        lineHeight: theme.lineHeight[3],
+        px: theme.spacing[3],
       },
       "2": {
-        borderRadius: "$borderRadius$4",
-        fontSize: "$fontSize$3",
-        lineHeight: "$lineHeight$4",
-        px: "$spacing$3",
+        borderRadius: theme.borderRadius[4],
+        fontSize: theme.fontSize[3],
+        lineHeight: theme.lineHeight[4],
+        px: theme.spacing[3],
       },
       "3": {
-        borderRadius: "$borderRadius$6",
-        fontSize: "$fontSize$4",
+        borderRadius: theme.borderRadius[6],
+        fontSize: theme.fontSize[4],
         lineHeight: "23px",
-        px: "$spacing$5",
+        px: theme.spacing[5],
       },
     },
     state: {
       invalid: {
-        boxShadow: "inset 0 0 0 1px $colors$red7",
+        boxShadow: `inset 0 0 0 1px ${theme.colors.red7}`,
         "&:focus": {
-          boxShadow:
-            "inset 0px 0px 0px 1px $colors$red8, 0px 0px 0px 1px $colors$red8",
+          boxShadow: `inset 0px 0px 0px 1px ${theme.colors.red8}, 0px 0px 0px 1px ${theme.colors.red8}`,
         },
       },
       valid: {
-        boxShadow: "inset 0 0 0 1px $colors$green7",
+        boxShadow: `inset 0 0 0 1px ${theme.colors.green7}`,
         "&:focus": {
-          boxShadow:
-            "inset 0px 0px 0px 1px $colors$green8, 0px 0px 0px 1px $colors$green8",
+          boxShadow: `inset 0px 0px 0px 1px ${theme.colors.green8}, 0px 0px 0px 1px ${theme.colors.green8}`,
         },
       },
     },

--- a/packages/design-system/src/components/text-field.stories.tsx
+++ b/packages/design-system/src/components/text-field.stories.tsx
@@ -10,6 +10,7 @@ import { TextField } from "./text-field";
 import { Box } from "./box";
 import { Grid } from "./grid";
 import { Text } from "./text";
+import { theme } from "../stitches.config";
 
 export default {
   component: TextField,
@@ -108,7 +109,7 @@ export const Layout: ComponentStory<typeof TextField> = () => {
             maxWidth: "25%",
           }}
         />
-        <Box css={{ background: "$muted" }}>Content</Box>
+        <Box css={{ background: theme.colors.muted }}>Content</Box>
         <TextField
           state="invalid"
           value="Long content comes here and it doesn't wrap"
@@ -123,19 +124,19 @@ export const Layout: ComponentStory<typeof TextField> = () => {
           border: "1px solid",
         }}
       >
-        <Box css={{ background: "$muted" }}>
+        <Box css={{ background: theme.colors.muted }}>
           <Text as="label" htmlFor="field">
             This is a label
           </Text>
         </Box>
-        <Box css={{ background: "$muted" }}>
+        <Box css={{ background: theme.colors.muted }}>
           <TextField
             id="field"
             value="Long content comes here and it doesn't wrap"
             prefix={<RowGapIcon />}
           />
         </Box>
-        <Box css={{ background: "$muted" }}>
+        <Box css={{ background: theme.colors.muted }}>
           <Text as="label" htmlFor="field2">
             This is a label
           </Text>

--- a/packages/design-system/src/components/text-field.tsx
+++ b/packages/design-system/src/components/text-field.tsx
@@ -8,6 +8,7 @@ import { useFocusWithin } from "@react-aria/interactions";
 import { css, styled } from "../stitches.config";
 import { ChevronLeftIcon } from "@webstudio-is/icons";
 import { cssVars } from "@webstudio-is/css-vars";
+import { theme } from "../stitches.config";
 
 const backgroundColorVar = cssVars.define("background-color");
 const colorVar = cssVars.define("color");
@@ -15,20 +16,20 @@ const colorVar = cssVars.define("color");
 const getTextFieldSuffixCssVars = (state: "focus" | "hover") => {
   if (state === "focus") {
     return {
-      [backgroundColorVar]: "$colors$blue10",
+      [backgroundColorVar]: theme.colors.blue10,
       [colorVar]: "white",
     };
   }
 
   return {
-    [backgroundColorVar]: "$colors$slate7",
-    [colorVar]: "$colors$hiContrast",
+    [backgroundColorVar]: theme.colors.slate7,
+    [colorVar]: theme.colors.hiContrast,
   };
 };
 
 const textFieldIconBaseStyle = css({
-  height: "$spacing$11",
-  minWidth: "$spacing$5",
+  height: theme.spacing[11],
+  minWidth: theme.spacing[5],
   display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
@@ -49,20 +50,20 @@ export const TextFieldIconButton = styled(
     padding: 0,
     margin: 0,
     "&:hover": {
-      backgroundColor: "$slate7",
-      color: "$hiContrast",
+      backgroundColor: theme.colors.slate7,
+      color: theme.colors.hiContrast,
     },
     "&:focus": {
-      backgroundColor: "$blue10",
+      backgroundColor: theme.colors.blue10,
       color: "white",
     },
     variants: {
       state: {
         active: {
-          backgroundColor: "$blue10",
+          backgroundColor: theme.colors.blue10,
           color: "white",
           "&:hover": {
-            backgroundColor: "$blue10",
+            backgroundColor: theme.colors.blue10,
             color: "white",
           },
         },
@@ -88,10 +89,10 @@ export const TextFieldInput = styled("input", {
   fontSize: "inherit",
   color: "inherit",
   padding: "0",
-  height: "$spacing$9",
+  height: theme.spacing[9],
   flexGrow: 1,
   flexShrink: 1,
-  flexBasis: "$spacing$10",
+  flexBasis: theme.spacing[10],
   minWidth: 0,
   textOverflow: "ellipsis",
   outline: "none",
@@ -121,19 +122,19 @@ export const TextFieldInput = styled("input", {
   },
 
   "&:-webkit-autofill::first-line": {
-    fontFamily: "$sans",
-    color: "$hiContrast",
+    fontFamily: theme.fonts.sans,
+    color: theme.colors.hiContrast,
   },
 
   "&::placeholder": {
-    color: "$hint",
+    color: theme.colors.hint,
   },
 
   "&:disabled": {
-    color: "$slate8",
+    color: theme.colors.slate8,
     cursor: "not-allowed",
     "&::placeholder": {
-      color: "$slate7",
+      color: theme.colors.slate7,
     },
   },
 });
@@ -143,30 +144,29 @@ export const TextFieldContainer = styled("div", {
   display: "flex",
   flexWrap: "wrap",
   alignItems: "center",
-  backgroundColor: "$loContrast",
-  boxShadow: "inset 0 0 0 1px $colors$slate7",
-  color: "$hiContrast",
+  backgroundColor: theme.colors.loContrast,
+  boxShadow: `inset 0 0 0 1px ${theme.colors.slate7}`,
+  color: theme.colors.hiContrast,
   fontVariantNumeric: "tabular-nums",
-  gap: "$spacing$3",
-  px: "$spacing$4",
-  borderRadius: "$borderRadius$4",
-  fontFamily: "$sans",
-  fontSize: "$fontSize$3",
-  minHeight: "$spacing$12",
+  gap: theme.spacing[3],
+  px: theme.spacing[4],
+  borderRadius: theme.borderRadius[4],
+  fontFamily: theme.fonts.sans,
+  fontSize: theme.fontSize[3],
+  minHeight: theme.spacing[12],
   lineHeight: 1,
   minWidth: 0,
   "&:focus-within": {
-    boxShadow:
-      "inset 0px 0px 0px 1px $colors$blue10, 0px 0px 0px 1px $colors$blue10",
+    boxShadow: `inset 0px 0px 0px 1px ${theme.colors.blue10}, 0px 0px 0px 1px ${theme.colors.blue10}`,
   },
   "&[aria-disabled=true]": {
     pointerEvents: "none",
-    backgroundColor: "$slate2",
+    backgroundColor: theme.colors.slate2,
   },
   "&:has(input:read-only)": {
-    backgroundColor: "$slate2",
+    backgroundColor: theme.colors.slate2,
     "&:focus": {
-      boxShadow: "inset 0px 0px 0px 1px $colors$slate7",
+      boxShadow: `inset 0px 0px 0px 1px ${theme.colors.slate7}`,
     },
   },
   variants: {
@@ -176,13 +176,12 @@ export const TextFieldContainer = styled("div", {
         backgroundColor: "transparent",
         "@hover": {
           "&:hover": {
-            boxShadow: "inset 0 0 0 1px $colors$slateA7",
+            boxShadow: `inset 0 0 0 1px ${theme.colors.slateA7}`,
           },
         },
         "&:focus": {
-          backgroundColor: "$loContrast",
-          boxShadow:
-            "inset 0px 0px 0px 1px $colors$blue10, 0px 0px 0px 1px $colors$blue10",
+          backgroundColor: theme.colors.loContrast,
+          boxShadow: `inset 0px 0px 0px 1px ${theme.colors.blue10}, 0px 0px 0px 1px ${theme.colors.blue10}`,
         },
         "&:disabled": {
           backgroundColor: "transparent",
@@ -198,22 +197,19 @@ export const TextFieldContainer = styled("div", {
     },
     state: {
       invalid: {
-        boxShadow: "inset 0 0 0 1px $colors$red8",
+        boxShadow: `inset 0 0 0 1px ${theme.colors.red8}`,
         "&:focus-within": {
-          boxShadow:
-            "inset 0px 0px 0px 1px $colors$red8, 0px 0px 0px 1px $colors$red8",
+          boxShadow: `inset 0px 0px 0px 1px ${theme.colors.red8}, 0px 0px 0px 1px ${theme.colors.red8}`,
         },
       },
       valid: {
-        boxShadow: "inset 0 0 0 1px $colors$green7",
+        boxShadow: `inset 0 0 0 1px ${theme.colors.green7}`,
         "&:focus-within": {
-          boxShadow:
-            "inset 0px 0px 0px 1px $colors$green8, 0px 0px 0px 1px $colors$green8",
+          boxShadow: `inset 0px 0px 0px 1px ${theme.colors.green8}, 0px 0px 0px 1px ${theme.colors.green8}`,
         },
       },
       active: {
-        boxShadow:
-          "inset 0px 0px 0px 1px $colors$blue10, 0px 0px 0px 1px $colors$blue10",
+        boxShadow: `inset 0px 0px 0px 1px ${theme.colors.blue10}, 0px 0px 0px 1px ${theme.colors.blue10}`,
         ...getTextFieldSuffixCssVars("focus"),
       },
     },

--- a/packages/design-system/src/components/text.tsx
+++ b/packages/design-system/src/components/text.tsx
@@ -1,58 +1,59 @@
 import { css, styled } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 export const textStyles = css({
   // Reset
   margin: 0,
   lineHeight: 1,
   userSelect: "none",
-  fontFamily: "$sans",
+  fontFamily: theme.fonts.sans,
 
   variants: {
     variant: {
       regular: {
         fontWeight: 400,
-        fontSize: "$fontSize$3",
+        fontSize: theme.fontSize[3],
         letterSpacing: "0.005em",
       },
       label: {
         fontWeight: 500,
-        fontSize: "$fontSize$3",
+        fontSize: theme.fontSize[3],
         letterSpacing: "0.005em",
       },
       tiny: {
         fontWeight: 400,
-        fontSize: "$fontSize$1",
+        fontSize: theme.fontSize[1],
         letterSpacing: "0.01em",
       },
       title: {
         fontWeight: 700,
-        fontSize: "$fontSize$3",
+        fontSize: theme.fontSize[3],
         letterSpacing: "0.01em",
       },
       mono: {
-        fontFamily: "$mono",
+        fontFamily: theme.fonts.mono,
         fontWeight: 400,
-        fontSize: "$fontSize$3",
+        fontSize: theme.fontSize[3],
         textTransform: "uppercase",
       },
       unit: {
         fontWeight: 500,
-        fontSize: "$fontSize$2",
+        fontSize: theme.fontSize[2],
         textTransform: "uppercase",
       },
     },
     color: {
       contrast: {
-        color: "$hiContrast",
+        color: theme.colors.hiContrast,
       },
       loContrast: {
-        color: "$loContrast",
+        color: theme.colors.loContrast,
       },
       hint: {
-        color: "$hint",
+        color: theme.colors.hint,
       },
       error: {
-        color: "$red10",
+        color: theme.colors.red10,
       },
     },
     align: {

--- a/packages/design-system/src/components/toast.tsx
+++ b/packages/design-system/src/components/toast.tsx
@@ -8,7 +8,8 @@ import {
 } from "@webstudio-is/icons";
 import { Box } from "./box";
 
-const VIEWPORT_PADDING = "$2";
+// @todo: check that this works as before
+const VIEWPORT_PADDING = variables.spacing[2];
 
 const hide = keyframes({
   "0%": { opacity: 1 },
@@ -38,7 +39,7 @@ const StyledViewport = styled(ToastPrimitive.Viewport, {
   maxWidth: "100vw",
   margin: 0,
   listStyle: "none",
-  zIndex: "$max",
+  zIndex: variables.zIndices.max,
   outline: "none",
 });
 

--- a/packages/design-system/src/components/toast.tsx
+++ b/packages/design-system/src/components/toast.tsx
@@ -8,7 +8,7 @@ import {
 } from "@webstudio-is/icons";
 import { Box } from "./box";
 
-const VIEWPORT_PADDING = variables.spacing[2];
+const VIEWPORT_PADDING = theme.spacing[2];
 
 const hide = keyframes({
   "0%": { opacity: 1 },
@@ -38,7 +38,7 @@ const StyledViewport = styled(ToastPrimitive.Viewport, {
   maxWidth: "100vw",
   margin: 0,
   listStyle: "none",
-  zIndex: variables.zIndices.max,
+  zIndex: theme.zIndices.max,
   outline: "none",
 });
 

--- a/packages/design-system/src/components/toast.tsx
+++ b/packages/design-system/src/components/toast.tsx
@@ -7,6 +7,7 @@ import {
   InfoCircledIcon,
 } from "@webstudio-is/icons";
 import { Box } from "./box";
+import { theme } from "../stitches.config";
 
 const VIEWPORT_PADDING = theme.spacing[2];
 
@@ -45,15 +46,15 @@ const StyledViewport = styled(ToastPrimitive.Viewport, {
 const StyledToast = styled(ToastPrimitive.Root, {
   borderRadius: 6,
   boxShadow: "0px 2px 7px rgba(0, 0, 0, 0.1), 0px 5px 17px rgba(0, 0, 0, 0.15)",
-  padding: "$spacing$9",
+  padding: theme.spacing[9],
   display: "flex",
   maxWidth: 250,
-  gap: "$spacing$9",
+  gap: theme.spacing[9],
   alignItems: "center",
-  color: "$hiContrast",
+  color: theme.colors.hiContrast,
   fontWeight: 500,
-  fontSize: "$fontSize$3",
-  background: "$loContrast",
+  fontSize: theme.fontSize[3],
+  background: theme.colors.loContrast,
 
   "@media (prefers-reduced-motion: no-preference)": {
     '&[data-state="open"]': {
@@ -76,16 +77,16 @@ const StyledToast = styled(ToastPrimitive.Root, {
   variants: {
     variant: {
       error: {
-        background: "$red9",
-        color: "$loContrast",
+        background: theme.colors.red9,
+        color: theme.colors.loContrast,
       },
       success: {
-        background: "$green10",
-        color: "$loContrast",
+        background: theme.colors.green10,
+        color: theme.colors.loContrast,
       },
       blank: {
-        background: "$blue11",
-        color: "$loContrast",
+        background: theme.colors.blue11,
+        color: theme.colors.loContrast,
       },
       custom: {},
       loading: {},
@@ -94,7 +95,7 @@ const StyledToast = styled(ToastPrimitive.Root, {
 });
 
 const StyledTitle = styled(ToastPrimitive.Title, {
-  marginBottom: "$spacing$3",
+  marginBottom: theme.spacing[3],
 });
 
 export const Toaster = () => {
@@ -112,8 +113,8 @@ export const Toaster = () => {
           <Box
             css={{
               svg: {
-                width: "$spacing$11",
-                height: "$spacing$11",
+                width: theme.spacing[11],
+                height: theme.spacing[11],
               },
             }}
           >

--- a/packages/design-system/src/components/toast.tsx
+++ b/packages/design-system/src/components/toast.tsx
@@ -8,7 +8,6 @@ import {
 } from "@webstudio-is/icons";
 import { Box } from "./box";
 
-// @todo: check that this works as before
 const VIEWPORT_PADDING = variables.spacing[2];
 
 const hide = keyframes({
@@ -51,7 +50,7 @@ const StyledToast = styled(ToastPrimitive.Root, {
   maxWidth: 250,
   gap: "$spacing$9",
   alignItems: "center",
-  color: "$highContrast",
+  color: "$hiContrast",
   fontWeight: 500,
   fontSize: "$fontSize$3",
   background: "$loContrast",

--- a/packages/design-system/src/components/toggle-group.tsx
+++ b/packages/design-system/src/components/toggle-group.tsx
@@ -1,29 +1,30 @@
 import { styled } from "../stitches.config";
 import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import { theme } from "../stitches.config";
 
 export const ToggleGroup = styled(ToggleGroupPrimitive.Root, {
   display: "inline-flex",
-  borderRadius: "$spacing$3",
-  boxShadow: `0 0 0 $spacing$1 $colors$slate7`,
+  borderRadius: theme.spacing[3],
+  boxShadow: `0 0 0 ${theme.spacing[1]} ${theme.colors.slate7}`,
   padding: 2,
 });
 
 export const ToggleGroupItem = styled(ToggleGroupPrimitive.Item, {
   // all: "unset", // @note weird bug, this somehow gets into weird specifity issues with how styles are inserted
   border: "none",
-  backgroundColor: "$loContrast",
-  color: "$hiContrast",
+  backgroundColor: theme.colors.loContrast,
+  color: theme.colors.hiContrast,
   display: "flex",
   whiteSpace: "nowrap",
-  fontSize: "$fontSize$4",
+  fontSize: theme.fontSize[4],
   lineHeight: 1,
   alignItems: "center",
   justifyContent: "center",
   marginLeft: 1,
   borderRadius: 2,
-  height: "$spacing$11",
+  height: theme.spacing[11],
   "&": {
-    px: "$spacing$3",
+    px: theme.spacing[3],
   },
   "&:first-child": {
     marginLeft: 0,
@@ -31,8 +32,11 @@ export const ToggleGroupItem = styled(ToggleGroupPrimitive.Item, {
     borderBottomLeftRadius: 4,
   },
   "&:last-child": { borderTopRightRadius: 4, borderBottomRightRadius: 4 },
-  "&:hover": { backgroundColor: "$slateA3" },
+  "&:hover": { backgroundColor: theme.colors.slateA3 },
   // @note because the outline is outside of the element others can end up covering it
-  "&:focus": { boxShadow: "0 0 0 $spacing$2 $colors$blue10", zIndex: 1 },
-  "&[data-state=on]": { backgroundColor: "$slate5" },
+  "&:focus": {
+    boxShadow: `0 0 0 ${theme.spacing[2]} ${theme.colors.blue10}`,
+    zIndex: 1,
+  },
+  "&[data-state=on]": { backgroundColor: theme.colors.slate5 },
 });

--- a/packages/design-system/src/components/toggle.tsx
+++ b/packages/design-system/src/components/toggle.tsx
@@ -1,5 +1,6 @@
 import { styled } from "../stitches.config";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { theme } from "../stitches.config";
 
 export const Toggle = styled(TogglePrimitive.Root, {
   // Reset
@@ -10,7 +11,7 @@ export const Toggle = styled(TogglePrimitive.Root, {
   display: "inline-flex",
   flexShrink: 0,
   fontFamily: "inherit",
-  fontSize: "$fontSize$4",
+  fontSize: theme.fontSize[4],
   justifyContent: "center",
   lineHeight: "1",
   outline: "none",
@@ -18,48 +19,48 @@ export const Toggle = styled(TogglePrimitive.Root, {
   textDecoration: "none",
   userSelect: "none",
   WebkitTapHighlightColor: "transparent",
-  color: "$hiContrast",
+  color: theme.colors.hiContrast,
   "&::before": {
     boxSizing: "border-box",
   },
   "&::after": {
     boxSizing: "border-box",
   },
-  height: "$spacing$11",
-  width: "$spacing$11",
+  height: theme.spacing[11],
+  width: theme.spacing[11],
   backgroundColor: "transparent",
   "@hover": {
     "&:hover": {
-      backgroundColor: "$slateA3",
+      backgroundColor: theme.colors.slateA3,
     },
   },
   "&:active": {
-    backgroundColor: "$slateA4",
+    backgroundColor: theme.colors.slateA4,
   },
   "&:focus": {
-    boxShadow: "inset 0 0 0 1px $slateA8, 0 0 0 1px $slateA8",
+    boxShadow: `inset 0 0 0 1px ${theme.colors.slateA8}, 0 0 0 1px ${theme.colors.slateA8}`,
     zIndex: 1,
   },
 
   '&[data-state="on"]': {
-    backgroundColor: "$slateA5",
+    backgroundColor: theme.colors.slateA5,
     "@hover": {
       "&:hover": {
-        backgroundColor: "$slateA5",
+        backgroundColor: theme.colors.slateA5,
       },
     },
     "&:active": {
-      backgroundColor: "$slateA7",
+      backgroundColor: theme.colors.slateA7,
     },
   },
 
   variants: {
     shape: {
       circle: {
-        borderRadius: "$borderRadius$round",
+        borderRadius: theme.borderRadius.round,
       },
       square: {
-        borderRadius: "$borderRadius$4",
+        borderRadius: theme.borderRadius[4],
       },
     },
   },

--- a/packages/design-system/src/components/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip.tsx
@@ -20,7 +20,7 @@ const Content = styled(TooltipPrimitive.Content, {
   color: "$loContrast",
   borderRadius: "$borderRadius$4",
   padding: "$spacing$3 $spacing$5",
-  zIndex: variables.zIndices[1],
+  zIndex: theme.zIndices[1],
   position: "relative",
 
   variants: {

--- a/packages/design-system/src/components/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip.tsx
@@ -36,8 +36,6 @@ const Content = styled(TooltipPrimitive.Content, {
 
 const Arrow = styled(TooltipPrimitive.Arrow, {
   fill: "$hiContrast",
-  // @todo: check that this works as before
-  strokeWidth: variables.spacing[1],
   marginTop: -0.5,
 });
 

--- a/packages/design-system/src/components/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip.tsx
@@ -20,7 +20,7 @@ const Content = styled(TooltipPrimitive.Content, {
   color: "$loContrast",
   borderRadius: "$borderRadius$4",
   padding: "$spacing$3 $spacing$5",
-  zIndex: "$1",
+  zIndex: variables.zIndices[1],
   position: "relative",
 
   variants: {
@@ -36,7 +36,8 @@ const Content = styled(TooltipPrimitive.Content, {
 
 const Arrow = styled(TooltipPrimitive.Arrow, {
   fill: "$hiContrast",
-  strokeWidth: "$1",
+  // @todo: check that this works as before
+  strokeWidth: variables.spacing[1],
   marginTop: -0.5,
 });
 

--- a/packages/design-system/src/components/tooltip.tsx
+++ b/packages/design-system/src/components/tooltip.tsx
@@ -4,6 +4,7 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { Box } from "./box";
 import { Paragraph } from "./paragraph";
 import type { CSS } from "../stitches.config";
+import { theme } from "../stitches.config";
 
 export type TooltipProps = ComponentProps<typeof TooltipPrimitive.Root> &
   ComponentProps<typeof TooltipPrimitive.Content> & {
@@ -16,10 +17,10 @@ export type TooltipProps = ComponentProps<typeof TooltipPrimitive.Root> &
   };
 
 const Content = styled(TooltipPrimitive.Content, {
-  backgroundColor: "$hiContrast",
-  color: "$loContrast",
-  borderRadius: "$borderRadius$4",
-  padding: "$spacing$3 $spacing$5",
+  backgroundColor: theme.colors.hiContrast,
+  color: theme.colors.loContrast,
+  borderRadius: theme.borderRadius[4],
+  padding: `${theme.spacing[3]} ${theme.spacing[5]}`,
   zIndex: theme.zIndices[1],
   position: "relative",
 
@@ -35,7 +36,7 @@ const Content = styled(TooltipPrimitive.Content, {
 });
 
 const Arrow = styled(TooltipPrimitive.Arrow, {
-  fill: "$hiContrast",
+  fill: theme.colors.hiContrast,
   marginTop: -0.5,
 });
 
@@ -82,7 +83,7 @@ export const Tooltip = React.forwardRef(
             multiline={multiline}
           >
             <Paragraph>{content}</Paragraph>
-            <Box css={{ color: "$transparentExtreme" }}>
+            <Box css={{ color: theme.colors.transparentExtreme }}>
               <Arrow offset={5} width={11} height={5} />
             </Box>
           </Content>

--- a/packages/design-system/src/components/tree/placement-indicator.tsx
+++ b/packages/design-system/src/components/tree/placement-indicator.tsx
@@ -1,6 +1,7 @@
 import { styled } from "../../stitches.config";
 import { Box } from "../box";
 import { Placement } from "../primitives/dnd";
+import { theme } from "../../stitches.config";
 
 const CIRCLE_SIZE = 8;
 const LINE_THICKNESS = 2;
@@ -16,14 +17,14 @@ const CircleOutline = styled(Box, {
   position: "absolute",
   borderRadius: "50%",
   pointerEvents: "none",
-  bc: "$loContrast",
+  bc: theme.colors.loContrast,
 });
 
 const Circle = styled(Box, {
   width: CIRCLE_SIZE,
   height: CIRCLE_SIZE,
   position: "absolute",
-  border: "solid $blue10",
+  border: `solid ${theme.colors.blue10}`,
   borderWidth: 2,
   borderRadius: "50%",
   pointerEvents: "none",
@@ -32,9 +33,9 @@ const Circle = styled(Box, {
 const Line = styled(Box, {
   boxSizing: "content-box",
   position: "absolute",
-  background: "$blue10",
+  background: theme.colors.blue10,
   pointerEvents: "none",
-  outline: "solid $loContrast",
+  outline: `solid ${theme.colors.loContrast}`,
   outlineWidth: OUTLINE_WIDTH,
 });
 

--- a/packages/design-system/src/components/tree/tree-node.tsx
+++ b/packages/design-system/src/components/tree/tree-node.tsx
@@ -6,6 +6,7 @@ import * as Collapsible from "@radix-ui/react-collapsible";
 import { Flex } from "../flex";
 import { Text } from "../text";
 import { keyframes, styled } from "../../stitches.config";
+import { theme } from "../../stitches.config";
 
 export const INDENT = 16;
 const ITEM_HEIGHT = 32;
@@ -64,9 +65,9 @@ const NestingLine = styled(Box, {
   height: ITEM_HEIGHT,
   borderRight: "solid",
   borderRightWidth: 1,
-  borderColor: "$slate9",
+  borderColor: theme.colors.slate9,
   variants: {
-    isSelected: { true: { borderColor: "$blue7" } },
+    isSelected: { true: { borderColor: theme.colors.blue7 } },
   },
 });
 
@@ -118,8 +119,8 @@ const CollapsibleTrigger = styled(Collapsible.Trigger, {
   position: "absolute",
 
   // We want the button to take extra space so it's easier to hit
-  ml: "-$spacing$3",
-  pl: "$spacing$3",
+  ml: `-${theme.spacing[3]}`,
+  pl: theme.spacing[3],
 });
 
 const TriggerPlaceholder = styled(Box, { width: INDENT });
@@ -164,15 +165,15 @@ const hoverStyle = {
   left: 2,
   right: 2,
   height: ITEM_HEIGHT,
-  border: "solid $blue10",
+  border: `solid ${theme.colors.blue10}`,
   borderWidth: 2,
-  borderRadius: "$borderRadius$6",
+  borderRadius: theme.borderRadius[6],
   pointerEvents: "none",
   boxSizing: "border-box",
 };
 
 const ItemContainer = styled(Flex, {
-  color: "$hiContrast",
+  color: theme.colors.hiContrast,
   alignItems: "center",
   position: "relative",
   ...getItemButtonCssVars({ suffixVisible: false }),
@@ -180,10 +181,10 @@ const ItemContainer = styled(Flex, {
 
   variants: {
     isSelected: {
-      true: { color: "$loContrast", bc: "$blue10" },
+      true: { color: theme.colors.loContrast, bc: theme.colors.blue10 },
     },
     parentIsSelected: {
-      true: { bc: "$blue4" },
+      true: { bc: theme.colors.blue4 },
     },
     suffixVisible: {
       true: {
@@ -236,7 +237,7 @@ export const TreeItemBody = <Data extends { id: string }>({
   isExpanded,
   children,
   suffix,
-  suffixWidth = suffix ? "$spacing$11" : "0",
+  suffixWidth = suffix ? theme.spacing[11] : "0",
   alwaysShowSuffix = false,
   forceFocus = false,
   selectionEvent = "click",
@@ -340,7 +341,7 @@ export const TreeItemLabel = ({
 }) => (
   <>
     {prefix}
-    <Text truncate css={{ ml: prefix ? "$spacing$3" : 0 }}>
+    <Text truncate css={{ ml: prefix ? theme.spacing[3] : 0 }}>
       {children}
     </Text>
   </>

--- a/packages/design-system/src/stitches.config.ts
+++ b/packages/design-system/src/stitches.config.ts
@@ -161,7 +161,6 @@ const spacing = {
 const {
   styled,
   css,
-  theme,
   createTheme,
   getCssText,
   globalCss,
@@ -409,11 +408,11 @@ const toVariblesNames = (values: VariblesValues): VariblesNames => {
   return result as VariblesNames;
 };
 
-export const variables = toVariblesNames(config.theme);
+export const theme = toVariblesNames(config.theme);
 
 export type CSS = Stitches.CSS<typeof config>;
 
-export { styled, css, theme, globalCss, keyframes, config };
+export { styled, css, globalCss, keyframes, config };
 
 export const flushCss = () => {
   const css = getCssText();

--- a/packages/design-system/src/stitches.config.ts
+++ b/packages/design-system/src/stitches.config.ts
@@ -387,6 +387,29 @@ const {
   },
 });
 
+type VariblesValues = typeof config.theme;
+
+type VariblesNames = {
+  [GroupKey in keyof VariblesValues]: {
+    [VariableKey in keyof VariblesValues[GroupKey]]: string;
+  };
+};
+
+const toVariblesNames = (values: VariblesValues): VariblesNames => {
+  const result: Record<string, Record<string, string>> = {};
+  for (const groupKey in values) {
+    const group = values[groupKey as keyof VariblesValues];
+    const groupResult: Record<string, string> = {};
+    for (const variableKey in group) {
+      groupResult[variableKey] = `$${groupKey}$${variableKey}`;
+    }
+    result[groupKey] = groupResult;
+  }
+  return result as VariblesNames;
+};
+
+export const variables = toVariblesNames(config.theme);
+
 export type CSS = Stitches.CSS<typeof config>;
 
 export { styled, css, theme, globalCss, keyframes, config };

--- a/packages/design-system/src/stitches.config.ts
+++ b/packages/design-system/src/stitches.config.ts
@@ -248,6 +248,7 @@ const {
       shadowDark: "hsl(206 22% 7% / 20%)",
       background: "$slate1",
       text: "$slate12",
+      transparentExtreme: "transparent",
     },
     fonts: {
       sans: "Inter, -apple-system, system-ui, sans-serif",

--- a/packages/icons/src/index.stories.tsx
+++ b/packages/icons/src/index.stories.tsx
@@ -34,7 +34,7 @@ export const Icons = () => {
                     textAlign: "center",
                     wordWrap: "break-word",
                     width: "100%",
-                    fontSize: "$fontSize$4",
+                    fontSize: "14px",
                     color: "#5a5a5a",
                   }}
                 >


### PR DESCRIPTION
## Description

I've replaced all `"$something$something"` CSS variables with `variables.something.something`. Now we have autocomplete and type-safety: if a variable is removed or renamed w/o fixing the usage the build will fail. 

This will allow designers to change design tokens and either make sure nothing is broken or if something is broken we'll know exactly what and it will be easy to fix.

Discussed here: https://discord.com/channels/955905230107738152/1061992022665334837

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
