### PR TITLE
Transform styles without zod

### DIFF
--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -22,7 +22,6 @@
     "@webstudio-is/prisma-client": "workspace:^",
     "@webstudio-is/react-sdk": "workspace:^",
     "bson-objectid": "^2.0.4",
-    "dataloader": "^2.1.0",
     "immer": "^9.0.12",
     "nanoid": "^3.2.0",
     "react": "^17.0.2",

--- a/packages/project/src/db/styles.ts
+++ b/packages/project/src/db/styles.ts
@@ -39,10 +39,11 @@ export const parseStyles = async (stylesString: string) => {
   const assetIds: string[] = [];
   for (const { value: styleValue } of storedStyles) {
     if (styleValue.type === "image") {
-      for (const item of styleValue.value)
+      for (const item of styleValue.value) {
         if (item.type === "asset") {
           assetIds.push(item.value);
         }
+      }
     }
   }
 

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -17,7 +17,7 @@ import {
   type Tree as DbTree,
 } from "@webstudio-is/prisma-client";
 import { utils } from "../index";
-import { StylesDbIn, StylesDbOut } from "./styles";
+import { parseStyles, serializeStyles } from "./styles";
 
 type TreeData = Omit<Tree, "id">;
 
@@ -69,7 +69,7 @@ export const create = async (
       instances: JSON.stringify(instances),
       props: JSON.stringify(treeData.props),
       presetStyles: JSON.stringify(treeData.presetStyles),
-      styles: JSON.stringify(await StylesDbIn.parseAsync(treeData.styles)),
+      styles: serializeStyles(treeData.styles),
     },
   });
 };
@@ -119,9 +119,7 @@ export const loadById = async (
 
   const props = Props.parse(JSON.parse(tree.props));
   const presetStyles = PresetStyles.parse(JSON.parse(tree.presetStyles));
-  const styles = Styles.parse(
-    await StylesDbOut.parseAsync(JSON.parse(tree.styles))
-  );
+  const styles = await parseStyles(tree.styles);
 
   return {
     ...tree,

--- a/packages/react-sdk/src/db/style.ts
+++ b/packages/react-sdk/src/db/style.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
-import type { StyleProperty, StyleValue } from "@webstudio-is/css-data";
-import { SharedStyleValue } from "@webstudio-is/css-data";
+import {
+  type StyleProperty,
+  StyleValue,
+  SharedStyleValue,
+  ImageValue,
+} from "@webstudio-is/css-data";
 import {
   type ComponentName,
   getComponentMeta,
@@ -48,12 +52,31 @@ export const findMissingPresetStyles = (
   return missingPresetStyles;
 };
 
+const StoredImageValue = z.object({
+  type: z.literal("image"),
+  value: z.array(z.object({ type: z.literal("asset"), value: z.string() })),
+});
+
+export const StoredStylesItem = z.object({
+  breakpointId: z.string(),
+  instanceId: z.string(),
+  // @todo can't figure out how to make property to be enum
+  property: z.string() as z.ZodType<StyleProperty>,
+  value: z.union([StoredImageValue, SharedStyleValue]),
+});
+
+export type StoredStylesItem = z.infer<typeof StoredStylesItem>;
+
+export const StoredStyles = z.array(StoredStylesItem);
+
+export type StoredStyles = z.infer<typeof StoredStyles>;
+
 export const StylesItem = z.object({
   breakpointId: z.string(),
   instanceId: z.string(),
   // @todo can't figure out how to make property to be enum
   property: z.string() as z.ZodType<StyleProperty>,
-  value: SharedStyleValue as z.ZodType<StyleValue>,
+  value: z.union([ImageValue, SharedStyleValue]),
 });
 
 export type StylesItem = z.infer<typeof StylesItem>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,7 +745,6 @@ importers:
       '@webstudio-is/scripts': workspace:^
       '@webstudio-is/tsconfig': workspace:^
       bson-objectid: ^2.0.4
-      dataloader: ^2.1.0
       immer: ^9.0.12
       jest: ^29.3.1
       nanoid: ^3.2.0
@@ -764,7 +763,6 @@ importers:
       '@webstudio-is/prisma-client': link:../prisma-client
       '@webstudio-is/react-sdk': link:../react-sdk
       bson-objectid: 2.0.4
-      dataloader: 2.1.0
       immer: 9.0.15
       nanoid: 3.3.4
       react: 17.0.2
@@ -12446,10 +12444,6 @@ packages:
   /data-uri-to-buffer/3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
     engines: {node: '>= 6'}
-
-  /dataloader/2.1.0:
-    resolution: {integrity: sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==}
-    dev: false
 
   /deasync/0.1.28:
     resolution: {integrity: sha512-QqLF6inIDwiATrfROIyQtwOQxjZuek13WRYZ7donU5wJPLoP67MnYxA6QtqdvdBy2mMqv5m3UefBVdJjvevOYg==}


### PR DESCRIPTION
Found zod allows to pass anything in transform without type checking. This means we can easily get unexpected result. In this case we could get undefined as asset.

As a solution I defined two versions of types, client side and stored in db. Conversion is implemented on db routes side.

This makes data flow more clear and let us describe only two versions of types instead of tree (in, out, client side).

## Code Review

- [ ] hi @kof, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
