### PR TITLE
Synchronize non-immerhin stores

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -36,7 +36,6 @@ import {
   useSetRootInstance,
   useSetStyles,
   useSubscribeScrollState,
-  useSubscribeSelectedInstance,
 } from "~/shared/nano-states";
 import { usePublishScrollState } from "./shared/use-publish-scroll-state";
 import { useDragAndDrop } from "./shared/use-drag-drop";
@@ -127,7 +126,6 @@ const useCopyPaste = () => {
 const DesignMode = () => {
   useManageDesignModeStyles();
   usePublishSelectedInstanceData();
-  useSubscribeSelectedInstance();
   useInsertInstance();
   useReparentInstance();
   useDeleteInstance();

--- a/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
@@ -18,7 +18,6 @@ import {
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
 import { useCssRules } from "~/canvas/shared/styles";
-import { publish } from "~/shared/pubsub";
 import { SelectedInstanceConnector } from "./selected-instance-connector";
 
 const TextEditor = lazy(() => import("../text-editor"));
@@ -155,10 +154,7 @@ export const WrapperComponentDev = ({
         }}
         onSelectInstance={(instanceId) => {
           setTextEditingInstanceId(undefined);
-          publish({
-            type: "selectInstanceById",
-            payload: instanceId,
-          });
+          selectedInstanceIdStore.set(instanceId);
         }}
       />
     </Suspense>

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -37,7 +37,6 @@ import {
   useDragAndDropState,
   useIsPreviewMode,
   useRootInstance,
-  useSubscribeSelectedInstance,
 } from "~/shared/nano-states";
 import { useClientSettings } from "./shared/client-settings";
 import { Navigator } from "./features/sidebar-left";
@@ -312,7 +311,6 @@ export const Designer = ({
   const [dragAndDropState] = useDragAndDropState();
   useSubscribeCanvasReady(publish);
   useCopyPaste(publish);
-  useSubscribeSelectedInstance();
 
   const iframeRefCallback = useCallback(
     (ref) => {
@@ -383,7 +381,7 @@ export const Designer = ({
             <Inspector publish={publish} />
           )}
         </SidePanel>
-        <Footer publish={publish} />
+        <Footer />
       </ChromeWrapper>
     </AssetsProvider>
   );

--- a/apps/designer/app/designer/features/footer/breadcrumbs.tsx
+++ b/apps/designer/app/designer/features/footer/breadcrumbs.tsx
@@ -1,9 +1,9 @@
 import { ChevronRightIcon } from "@webstudio-is/icons";
 import { DeprecatedButton, Flex, Text } from "@webstudio-is/design-system";
-import { type Publish } from "~/shared/pubsub";
 import { useSelectedInstancePath } from "~/designer/shared/instance/use-selected-instance-path";
 import { useSelectedInstanceData } from "~/designer/shared/nano-states";
 import { theme } from "@webstudio-is/design-system";
+import { selectedInstanceIdStore } from "~/shared/nano-states";
 
 type BreadcrumbProps = {
   children: JSX.Element | string;
@@ -30,10 +30,7 @@ const Breadcrumb = ({ children, onClick }: BreadcrumbProps) => {
   );
 };
 
-type BreadcrumbsProps = {
-  publish: Publish;
-};
-export const Breadcrumbs = ({ publish }: BreadcrumbsProps) => {
+export const Breadcrumbs = () => {
   const [selectedInstanceData] = useSelectedInstanceData();
   const selectedInstancePath = useSelectedInstancePath(
     selectedInstanceData?.id
@@ -49,10 +46,7 @@ export const Breadcrumbs = ({ publish }: BreadcrumbsProps) => {
           <Breadcrumb
             key={instance.id}
             onClick={() => {
-              publish({
-                type: "selectInstanceById",
-                payload: instance.id,
-              });
+              selectedInstanceIdStore.set(instance.id);
             }}
           >
             {instance.component}

--- a/apps/designer/app/designer/features/footer/footer.tsx
+++ b/apps/designer/app/designer/features/footer/footer.tsx
@@ -1,9 +1,8 @@
 import { Box, Flex, darkTheme } from "@webstudio-is/design-system";
-import { type Publish } from "~/shared/pubsub";
 import { Breadcrumbs } from "./breadcrumbs";
 import { theme } from "@webstudio-is/design-system";
 
-export const Footer = ({ publish }: { publish: Publish }) => {
+export const Footer = () => {
   return (
     <Flex
       className={darkTheme}
@@ -17,7 +16,7 @@ export const Footer = ({ publish }: { publish: Publish }) => {
       }}
     >
       <Box css={{ height: "100%", p: theme.spacing[3] }}>
-        <Breadcrumbs publish={publish} />
+        <Breadcrumbs />
       </Box>
     </Flex>
   );

--- a/apps/designer/app/designer/features/sidebar-left/lib/navigator/navigator.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/lib/navigator/navigator.tsx
@@ -3,13 +3,12 @@ import { type Instance } from "@webstudio-is/react-sdk";
 import { type Publish } from "~/shared/pubsub";
 import { useCallback } from "react";
 import { useSelectedInstanceData } from "~/designer/shared/nano-states";
-import { useRootInstance } from "~/shared/nano-states";
+import { selectedInstanceIdStore, useRootInstance } from "~/shared/nano-states";
 import { Header, CloseButton } from "../header";
 import { InstanceTree } from "~/designer/shared/tree";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
-    selectInstanceById: Instance["id"];
     reparentInstance: {
       instanceId: Instance["id"];
       dropTarget: { instanceId: Instance["id"]; position: number | "end" };
@@ -29,15 +28,9 @@ export const Navigator = ({ publish, isClosable, onClose }: NavigatorProps) => {
   const [selectedInstanceData] = useSelectedInstanceData();
   const [rootInstance] = useRootInstance();
 
-  const handleSelect = useCallback(
-    (instanceId: Instance["id"]) => {
-      publish({
-        type: "selectInstanceById",
-        payload: instanceId,
-      });
-    },
-    [publish]
-  );
+  const handleSelect = useCallback((instanceId: Instance["id"]) => {
+    selectedInstanceIdStore.set(instanceId);
+  }, []);
 
   const handleDragEnd = useCallback(
     (payload: {

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { atom, computed, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
 import { Instance, PresetStyles, Styles } from "@webstudio-is/react-sdk";
@@ -8,7 +7,6 @@ import type {
 } from "~/canvas/shared/use-drag-drop";
 import type { Breakpoint } from "@webstudio-is/css-data";
 import type { DesignToken } from "@webstudio-is/design-tokens";
-import { subscribe } from "~/shared/pubsub";
 import { useSyncInitializeOnce } from "../hook-utils";
 
 const useValue = <T>(atom: WritableAtom<T>) => {
@@ -113,13 +111,6 @@ export const selectedInstanceStore = computed(
     return instancesIndex.instancesById.get(selectedInstanceId);
   }
 );
-export const useSubscribeSelectedInstance = () => {
-  useEffect(() => {
-    return subscribe("selectInstanceById", (id) => {
-      selectedInstanceIdStore.set(id);
-    });
-  }, []);
-};
 
 const isPreviewModeContainer = atom<boolean>(false);
 export const useIsPreviewMode = () => useValue(isPreviewModeContainer);

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -33,7 +33,7 @@ declare module "~/shared/pubsub" {
   }
 }
 
-const clientOnlyStores = new Map<string, WritableAtom<unknown>>();
+const clientStores = new Map<string, WritableAtom<unknown>>();
 
 export const registerContainers = () => {
   // synchronize patches
@@ -43,7 +43,7 @@ export const registerContainers = () => {
   store.register("props", allUserPropsContainer);
   store.register("designTokens", designTokensContainer);
   // synchronize whole states
-  clientOnlyStores.set("selectedInstanceId", selectedInstanceIdStore);
+  clientStores.set("selectedInstanceId", selectedInstanceIdStore);
 };
 
 const syncStoresChanges = (name: SyncEventSource, publish: Publish) => {
@@ -97,7 +97,7 @@ const syncStoresState = (name: SyncEventSource, publish: Publish) => {
           container.set(value);
         }
         // apply state stores data
-        const stateStore = clientOnlyStores.get(namespace);
+        const stateStore = clientStores.get(namespace);
         if (stateStore) {
           // should be called before store set
           // to be accessible in listen callback
@@ -109,7 +109,7 @@ const syncStoresState = (name: SyncEventSource, publish: Publish) => {
   );
 
   const unsubscribes: Array<() => void> = [];
-  for (const [namespace, store] of clientOnlyStores) {
+  for (const [namespace, store] of clientStores) {
     unsubscribes.push(
       // use listen to not invoke initially
       store.listen((value) => {

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -33,7 +33,7 @@ declare module "~/shared/pubsub" {
   }
 }
 
-const stateStores = new Map<string, WritableAtom<unknown>>();
+const clientOnlyStores = new Map<string, WritableAtom<unknown>>();
 
 export const registerContainers = () => {
   // synchronize patches
@@ -43,7 +43,7 @@ export const registerContainers = () => {
   store.register("props", allUserPropsContainer);
   store.register("designTokens", designTokensContainer);
   // synchronize whole states
-  stateStores.set("selectedInstanceId", selectedInstanceIdStore);
+  clientOnlyStores.set("selectedInstanceId", selectedInstanceIdStore);
 };
 
 const syncStoresChanges = (name: SyncEventSource, publish: Publish) => {
@@ -97,7 +97,7 @@ const syncStoresState = (name: SyncEventSource, publish: Publish) => {
           container.set(value);
         }
         // apply state stores data
-        const stateStore = stateStores.get(namespace);
+        const stateStore = clientOnlyStores.get(namespace);
         if (stateStore) {
           // should be called before store set
           // to be accessible in listen callback
@@ -109,7 +109,7 @@ const syncStoresState = (name: SyncEventSource, publish: Publish) => {
   );
 
   const unsubscribes: Array<() => void> = [];
-  for (const [namespace, store] of stateStores) {
+  for (const [namespace, store] of clientOnlyStores) {
     unsubscribes.push(
       // use listen to not invoke initially
       store.listen((value) => {

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -1,4 +1,5 @@
 import store, { type Change } from "immerhin";
+import type { WritableAtom } from "nanostores";
 import { useEffect } from "react";
 import { allUserPropsContainer } from "@webstudio-is/react-sdk";
 import { type Publish, subscribe } from "~/shared/pubsub";
@@ -7,6 +8,7 @@ import {
   breakpointsContainer,
   designTokensContainer,
   stylesContainer,
+  selectedInstanceIdStore,
 } from "~/shared/nano-states";
 
 type StoreData = {
@@ -18,7 +20,11 @@ type SyncEventSource = "canvas" | "designer";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
-    sendStoreData: StoreData[];
+    sendStoreData: {
+      // distinct source to avoid infinite loop
+      source: SyncEventSource;
+      data: StoreData[];
+    };
     sendStoreChanges: {
       // distinct source to avoid infinite loop
       source: SyncEventSource;
@@ -27,15 +33,20 @@ declare module "~/shared/pubsub" {
   }
 }
 
+const stateStores = new Map<string, WritableAtom<unknown>>();
+
 export const registerContainers = () => {
+  // synchronize patches
   store.register("breakpoints", breakpointsContainer);
   store.register("root", rootInstanceContainer);
   store.register("styles", stylesContainer);
   store.register("props", allUserPropsContainer);
   store.register("designTokens", designTokensContainer);
+  // synchronize whole states
+  stateStores.set("selectedInstanceId", selectedInstanceIdStore);
 };
 
-const syncChanges = (name: SyncEventSource, publish: Publish) => {
+const syncStoresChanges = (name: SyncEventSource, publish: Publish) => {
   const unsubscribeRemoteChanges = subscribe(
     "sendStoreChanges",
     ({ source, changes }) => {
@@ -69,8 +80,74 @@ const syncChanges = (name: SyncEventSource, publish: Publish) => {
   };
 };
 
+const syncStoresState = (name: SyncEventSource, publish: Publish) => {
+  const latestData = new Map<string, unknown>();
+
+  const unsubscribeRemoteChanges = subscribe(
+    "sendStoreData",
+    ({ source, data }) => {
+      /// prevent reapplying own changes
+      if (source === name) {
+        return;
+      }
+      for (const { namespace, value } of data) {
+        // apply immerhin stores data
+        const container = store.containers.get(namespace);
+        if (container) {
+          container.set(value);
+        }
+        // apply state stores data
+        const stateStore = stateStores.get(namespace);
+        if (stateStore) {
+          // should be called before store set
+          // to be accessible in listen callback
+          latestData.set(namespace, value);
+          stateStore.set(value);
+        }
+      }
+    }
+  );
+
+  const unsubscribes: Array<() => void> = [];
+  for (const [namespace, store] of stateStores) {
+    unsubscribes.push(
+      // use listen to not invoke initially
+      store.listen((value) => {
+        // nanostores cannot identify the source of change
+        // so we check the latest value applied to the store
+        // and do nothing if was set by synchronization logic
+        if (latestData.has(namespace) && latestData.get(namespace) === value) {
+          return;
+        }
+        latestData.set(namespace, value);
+        publish({
+          type: "sendStoreData",
+          payload: {
+            source: name,
+            data: [
+              {
+                namespace,
+                value,
+              },
+            ],
+          },
+        });
+        //
+      })
+    );
+  }
+
+  return () => {
+    unsubscribeRemoteChanges();
+    for (const unsubscribe of unsubscribes) {
+      unsubscribe();
+    }
+  };
+};
+
 export const useCanvasStore = (publish: Publish) => {
   useEffect(() => {
+    // immerhin data is sent only initially so not part of syncStoresState
     // expect data to be populated by the time effect is called
     const data = [];
     for (const [namespace, container] of store.containers) {
@@ -81,31 +158,30 @@ export const useCanvasStore = (publish: Publish) => {
     }
     publish({
       type: "sendStoreData",
-      payload: data,
+      payload: {
+        source: "canvas",
+        data,
+      },
     });
 
-    const unsubscribeChanges = syncChanges("canvas", publish);
+    const unsubscribeStoresState = syncStoresState("canvas", publish);
+    const unsubscribeStoresChanges = syncStoresChanges("canvas", publish);
 
-    return unsubscribeChanges;
+    return () => {
+      unsubscribeStoresState();
+      unsubscribeStoresChanges();
+    };
   }, [publish]);
 };
 
 export const useDesignerStore = (publish: Publish) => {
   useEffect(() => {
-    const unsubscribeSendStoreData = subscribe("sendStoreData", (data) => {
-      for (const { namespace, value } of data) {
-        const container = store.containers.get(namespace);
-        if (container) {
-          container.set(value);
-        }
-      }
-    });
-
-    const unsubscribeChanges = syncChanges("designer", publish);
+    const unsubscribeStoresState = syncStoresState("designer", publish);
+    const unsubscribeStoresChanges = syncStoresChanges("designer", publish);
 
     return () => {
-      unsubscribeSendStoreData();
-      unsubscribeChanges();
+      unsubscribeStoresState();
+      unsubscribeStoresChanges();
     };
   }, [publish]);
 };


### PR DESCRIPTION
We often need to sync states between canvas and designer without sending to server. Here added logic to synchronize whole states between frames. Almost same as immerhin logic.

Here synchronized selectedInstanceId store.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
