### PR TITLE
Migrate designer to selected instance store

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -17,10 +17,8 @@ import { useShortcuts } from "./shared/use-shortcuts";
 import {
   useDeleteInstance,
   useInsertInstance,
-  usePublishSelectedInstanceData,
   usePublishTextEditingInstanceId,
   useReparentInstance,
-  useUnselectInstance,
 } from "./shared/instance";
 import { useManageDesignModeStyles, GlobalStyles } from "./shared/styles";
 import { useTrackSelectedElement } from "./shared/use-track-selected-element";
@@ -125,12 +123,10 @@ const useCopyPaste = () => {
 
 const DesignMode = () => {
   useManageDesignModeStyles();
-  usePublishSelectedInstanceData();
   useInsertInstance();
   useReparentInstance();
   useDeleteInstance();
   useTrackSelectedElement();
-  useUnselectInstance();
   usePublishScrollState();
   useSubscribeScrollState();
   usePublishTextEditingInstanceId();

--- a/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
+++ b/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
@@ -6,6 +6,7 @@ import {
   subscribeScrollState,
   subscribeWindowResize,
 } from "~/shared/dom-hooks";
+import { selectedInstanceBrowserStyleStore } from "~/shared/nano-states";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -125,14 +126,7 @@ export const SelectedInstanceConnector = ({
     });
 
     // trigger style recomputing every time instance styles are changed
-    publish({
-      type: "selectInstance",
-      payload: {
-        id: instance.id,
-        component: instance.component,
-        browserStyle: getBrowserStyle(element),
-      },
-    });
+    selectedInstanceBrowserStyleStore.set(getBrowserStyle(element));
 
     return () => {
       resizeObserver.disconnect();

--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import { useStore } from "@nanostores/react";
 import {
   type Instance,
   type PropsItem,
@@ -12,7 +11,6 @@ import {
   utils,
   type HoveredInstanceData,
   type InstanceInsertionSpec,
-  type SelectedInstanceData,
 } from "@webstudio-is/project";
 import store from "immerhin";
 import {
@@ -27,14 +25,12 @@ declare module "~/shared/pubsub" {
   export interface PubsubMap {
     hoveredInstanceRect: DOMRect;
     hoverInstance?: HoveredInstanceData;
-    selectInstance?: SelectedInstanceData;
     textEditingInstanceId?: Instance["id"];
     insertInstance: {
       instance: Instance;
       dropTarget?: { parentId: Instance["id"]; position: number };
       props?: Array<PropsItem>;
     };
-    unselectInstance: undefined;
   }
 }
 
@@ -149,26 +145,6 @@ export const useDeleteInstance = () => {
         utils.tree.deleteInstanceMutable(rootInstance, id);
       }
     });
-  });
-};
-
-export const usePublishSelectedInstanceData = () => {
-  const selectedInstanceId = useStore(selectedInstanceIdStore);
-
-  useEffect(() => {
-    // Unselects the instance by `undefined`
-    if (selectedInstanceId === undefined) {
-      publish({
-        type: "selectInstance",
-        payload: undefined,
-      });
-    }
-  }, [selectedInstanceId]);
-};
-
-export const useUnselectInstance = () => {
-  useSubscribe("unselectInstance", () => {
-    selectedInstanceIdStore.set(undefined);
   });
 };
 

--- a/apps/designer/app/canvas/shared/use-shortcuts.ts
+++ b/apps/designer/app/canvas/shared/use-shortcuts.ts
@@ -8,7 +8,6 @@ import {
   selectedInstanceStore,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
-import { type SelectedInstanceData } from "@webstudio-is/project";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -18,7 +17,6 @@ declare module "~/shared/pubsub" {
     };
     openBreakpointsMenu: undefined;
     selectBreakpointFromShortcut: number;
-    selectInstance?: SelectedInstanceData;
     togglePreviewMode: undefined;
     zoom: "zoomOut" | "zoomIn";
   }
@@ -115,7 +113,6 @@ export const useShortcuts = () => {
         return;
       }
       selectedInstanceIdStore.set(undefined);
-      publish({ type: "selectInstance" });
     },
     { ...options, enableOnContentEditable: true, enableOnTags: [...inputTags] },
     [editingInstanceId]

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo } from "react";
+import { useStore } from "@nanostores/react";
 import { type Publish, usePublish, useSubscribe } from "~/shared/pubsub";
 import {
   type Pages,
@@ -17,7 +18,6 @@ import {
   usePages,
   useProject,
   useCurrentPageId,
-  useSelectedInstanceData,
 } from "./shared/nano-states";
 import { Topbar } from "./features/topbar";
 import designerStyles from "./designer.css";
@@ -34,9 +34,9 @@ import {
 } from "./features/workspace";
 import { usePublishShortcuts } from "./shared/shortcuts";
 import {
+  selectedInstanceStore,
   useDragAndDropState,
   useIsPreviewMode,
-  useRootInstance,
 } from "~/shared/nano-states";
 import { useClientSettings } from "./shared/client-settings";
 import { Navigator } from "./features/sidebar-left";
@@ -52,11 +52,6 @@ export const links = () => {
     { rel: "stylesheet", href: interFont },
     { rel: "stylesheet", href: designerStyles },
   ];
-};
-
-const useSubscribeSelectedInstanceData = () => {
-  const [, setValue] = useSelectedInstanceData();
-  useSubscribe("selectInstance", setValue);
 };
 
 const useSubscribeHoveredInstanceData = () => {
@@ -99,21 +94,17 @@ const useSubscribeCanvasReady = (publish: Publish) => {
 };
 
 const useCopyPaste = (publish: Publish) => {
-  const [selectedInstance] = useSelectedInstanceData();
-  const [rootInstance] = useRootInstance();
+  const selectedInstance = useStore(selectedInstanceStore);
   const allUserProps = useAllUserProps();
 
   const selectedInstanceData = useMemo(() => {
-    if (selectedInstance && rootInstance) {
-      const instance = projectUtils.tree.findInstanceById(
-        rootInstance,
-        selectedInstance.id
-      );
-      return (
-        instance && { instance, props: allUserProps[selectedInstance.id] ?? [] }
-      );
+    if (selectedInstance) {
+      return {
+        instance: selectedInstance,
+        props: allUserProps[selectedInstance.id] ?? [],
+      };
     }
-  }, [rootInstance, selectedInstance, allUserProps]);
+  }, [selectedInstance, allUserProps]);
 
   // We need to initialize this in both canvas and designer,
   // because the events will fire in either one, depending on where the focus is
@@ -294,7 +285,6 @@ export const Designer = ({
   buildId,
   buildOrigin,
 }: DesignerProps) => {
-  useSubscribeSelectedInstanceData();
   useSubscribeHoveredInstanceData();
   useSubscribeBreakpoints();
   useSetProject(project);

--- a/apps/designer/app/designer/features/footer/breadcrumbs.tsx
+++ b/apps/designer/app/designer/features/footer/breadcrumbs.tsx
@@ -1,9 +1,9 @@
+import { useStore } from "@nanostores/react";
 import { ChevronRightIcon } from "@webstudio-is/icons";
 import { DeprecatedButton, Flex, Text } from "@webstudio-is/design-system";
-import { useSelectedInstancePath } from "~/designer/shared/instance/use-selected-instance-path";
-import { useSelectedInstanceData } from "~/designer/shared/nano-states";
 import { theme } from "@webstudio-is/design-system";
 import { selectedInstanceIdStore } from "~/shared/nano-states";
+import { useSelectedInstancePath } from "~/designer/shared/instance/use-selected-instance-path";
 
 type BreadcrumbProps = {
   children: JSX.Element | string;
@@ -31,10 +31,8 @@ const Breadcrumb = ({ children, onClick }: BreadcrumbProps) => {
 };
 
 export const Breadcrumbs = () => {
-  const [selectedInstanceData] = useSelectedInstanceData();
-  const selectedInstancePath = useSelectedInstancePath(
-    selectedInstanceData?.id
-  );
+  const selectedInstanceId = useStore(selectedInstanceIdStore);
+  const selectedInstancePath = useSelectedInstancePath(selectedInstanceId);
   return (
     <Flex align="center" css={{ height: "100%" }}>
       {selectedInstancePath.length === 0 ? (

--- a/apps/designer/app/designer/features/inspector/inspector.tsx
+++ b/apps/designer/app/designer/features/inspector/inspector.tsx
@@ -1,3 +1,5 @@
+import { useRef } from "react";
+import { useStore } from "@nanostores/react";
 import type { Publish } from "~/shared/pubsub";
 import {
   Text,
@@ -13,10 +15,9 @@ import {
 } from "@webstudio-is/design-system";
 import { StylePanel } from "~/designer/features/style-panel";
 import { PropsPanel } from "~/designer/features/props-panel";
-import { useSelectedInstanceData } from "~/designer/shared/nano-states";
 import { FloatingPanelProvider } from "~/designer/shared/floating-panel";
-import { useRef } from "react";
 import { theme } from "@webstudio-is/design-system";
+import { selectedInstanceStore } from "~/shared/nano-states";
 
 type InspectorProps = {
   publish: Publish;
@@ -29,10 +30,10 @@ const contentStyle = {
 };
 
 export const Inspector = ({ publish }: InspectorProps) => {
-  const [selectedInstanceData] = useSelectedInstanceData();
+  const selectedInstance = useStore(selectedInstanceStore);
   const tabsRef = useRef<HTMLDivElement>(null);
 
-  if (selectedInstanceData === undefined) {
+  if (selectedInstance === undefined) {
     return (
       <Box css={{ p: theme.spacing[5], flexBasis: "100%" }}>
         {/* @todo: use this space for something more usefull: a-la figma's no instance selected sate, maybe create an issue with a more specific proposal? */}
@@ -66,18 +67,13 @@ export const Inspector = ({ publish }: InspectorProps) => {
             </TabsTrigger>
           </TabsList>
           <TabsContent value="style" css={contentStyle}>
-            <StylePanel
-              publish={publish}
-              selectedInstanceData={selectedInstanceData}
-            />
+            <StylePanel publish={publish} selectedInstance={selectedInstance} />
           </TabsContent>
           <TabsContent value="props" css={contentStyle}>
             <PropsPanel
               publish={publish}
-              key={
-                selectedInstanceData.id /* Re-render when instance changes */
-              }
-              selectedInstanceData={selectedInstanceData}
+              key={selectedInstance.id /* Re-render when instance changes */}
+              selectedInstance={selectedInstance}
             />
           </TabsContent>
         </Flex>

--- a/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
@@ -25,10 +25,11 @@ export const NoProps: ComponentStory<typeof PropsPanel> = () => {
   });
   return (
     <PropsPanel
-      selectedInstanceData={{
+      selectedInstance={{
+        type: "instance",
         id: "1",
         component: "Button",
-        browserStyle: {},
+        children: [],
       }}
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       publish={() => {}}
@@ -42,10 +43,11 @@ export const RequiredProps: ComponentStory<typeof PropsPanel> = () => {
   });
   return (
     <PropsPanel
-      selectedInstanceData={{
+      selectedInstance={{
+        type: "instance",
         id: "1",
         component: "Link",
-        browserStyle: {},
+        children: [],
       }}
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       publish={() => {}}
@@ -59,10 +61,11 @@ export const DefaultProps: ComponentStory<typeof PropsPanel> = () => {
   });
   return (
     <PropsPanel
-      selectedInstanceData={{
+      selectedInstance={{
+        type: "instance",
         id: "1",
         component: "Button",
-        browserStyle: {},
+        children: [],
       }}
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       publish={() => {}}
@@ -84,10 +87,11 @@ export const AllProps: ComponentStory<typeof PropsPanel> = () => {
   });
   return (
     <PropsPanel
-      selectedInstanceData={{
+      selectedInstance={{
+        type: "instance",
         id: "3",
         component: "Heading",
-        browserStyle: {},
+        children: [],
       }}
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       publish={() => {}}

--- a/apps/designer/app/designer/features/props-panel/props-panel.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.tsx
@@ -10,7 +10,6 @@ import {
 import { type Publish } from "~/shared/pubsub";
 import { Control } from "./control";
 import { CollapsibleSection, ComponentInfo } from "~/designer/shared/inspector";
-import type { SelectedInstanceData } from "@webstudio-is/project";
 import {
   Box,
   Button,
@@ -219,14 +218,11 @@ const Property = ({
 
 type PropsPanelProps = {
   publish: Publish;
-  selectedInstanceData: SelectedInstanceData;
+  selectedInstance: Instance;
 };
 
-export const PropsPanel = ({
-  selectedInstanceData,
-  publish,
-}: PropsPanelProps) => {
-  const instanceId = selectedInstanceData.id;
+export const PropsPanel = ({ selectedInstance, publish }: PropsPanelProps) => {
+  const instanceId = selectedInstance.id;
   const allUserProps = useAllUserProps();
   const props = allUserProps[instanceId] ?? [];
 
@@ -239,7 +235,7 @@ export const PropsPanel = ({
     isRequired,
   } = usePropsLogic({
     props,
-    selectedInstanceData,
+    selectedInstance,
 
     updateProps: (update) => {
       store.createTransaction([allUserPropsContainer], (allUserProps) => {
@@ -267,7 +263,7 @@ export const PropsPanel = ({
   });
 
   const { setProperty: setCssProperty } = useStyleData({
-    selectedInstanceData,
+    selectedInstance,
     publish,
   });
 
@@ -287,7 +283,7 @@ export const PropsPanel = ({
   return (
     <Box>
       <Box css={{ p: theme.spacing[9] }}>
-        <ComponentInfo selectedInstanceData={selectedInstanceData} />
+        <ComponentInfo selectedInstance={selectedInstance} />
       </Box>
       <CollapsibleSection
         label="Properties"
@@ -305,7 +301,7 @@ export const PropsPanel = ({
             <Property
               key={userProp.id}
               userProp={userProp}
-              component={selectedInstanceData.component}
+              component={selectedInstance.component}
               onChangePropName={(name) => handleChangePropName(userProp, name)}
               onChangePropValue={(value) =>
                 handleChangePropValue(userProp, value)

--- a/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
@@ -1,17 +1,19 @@
 import { jest, describe, test, expect } from "@jest/globals";
 import { renderHook, act } from "@testing-library/react-hooks";
-import { ComponentName, getComponentMeta } from "@webstudio-is/react-sdk";
+import {
+  getComponentMeta,
+  type ComponentName,
+  type Instance,
+} from "@webstudio-is/react-sdk";
 import { nanoid } from "nanoid";
-import type { SelectedInstanceData } from "@webstudio-is/project";
 import { usePropsLogic } from "./use-props-logic";
 
-const getSelectedInstanceData = (
-  componentName: ComponentName
-): SelectedInstanceData => {
+const getSelectedInstance = (componentName: ComponentName): Instance => {
   return {
+    type: "instance",
     id: nanoid(8),
     component: componentName,
-    browserStyle: {},
+    children: [],
   };
 };
 
@@ -20,7 +22,7 @@ describe("usePropsLogic", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
         props: [],
-        selectedInstanceData: getSelectedInstanceData("Link"),
+        selectedInstance: getSelectedInstance("Link"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -36,7 +38,7 @@ describe("usePropsLogic", () => {
     const { result: res1 } = renderHook(() =>
       usePropsLogic({
         props: [],
-        selectedInstanceData: getSelectedInstanceData("Heading"),
+        selectedInstance: getSelectedInstance("Heading"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -44,7 +46,7 @@ describe("usePropsLogic", () => {
     const { result: res2 } = renderHook(() =>
       usePropsLogic({
         props: [],
-        selectedInstanceData: getSelectedInstanceData("Button"),
+        selectedInstance: getSelectedInstance("Button"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -63,7 +65,7 @@ describe("usePropsLogic", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
         props: [],
-        selectedInstanceData: getSelectedInstanceData("Button"),
+        selectedInstance: getSelectedInstance("Button"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -87,7 +89,7 @@ describe("usePropsLogic", () => {
             value: "submit",
           },
         ],
-        selectedInstanceData: getSelectedInstanceData("Button"),
+        selectedInstance: getSelectedInstance("Button"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -103,7 +105,7 @@ describe("usePropsLogic", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
         props: [],
-        selectedInstanceData: getSelectedInstanceData("Box"),
+        selectedInstance: getSelectedInstance("Box"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -164,7 +166,7 @@ describe("usePropsLogic", () => {
             required: true,
           },
         ],
-        selectedInstanceData: getSelectedInstanceData("Image"),
+        selectedInstance: getSelectedInstance("Image"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -191,7 +193,7 @@ describe("usePropsLogic", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
         props: [],
-        selectedInstanceData: getSelectedInstanceData("Image"),
+        selectedInstance: getSelectedInstance("Image"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })
@@ -213,7 +215,7 @@ describe("usePropsLogic", () => {
     const { result } = renderHook(() =>
       usePropsLogic({
         props: [],
-        selectedInstanceData: getSelectedInstanceData("Image"),
+        selectedInstance: getSelectedInstance("Image"),
         updateProps: jest.fn(),
         deleteProp: jest.fn(),
       })

--- a/apps/designer/app/designer/features/props-panel/use-props-logic.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.ts
@@ -11,7 +11,6 @@ import {
   getComponentMeta,
   getComponentMetaProps,
 } from "@webstudio-is/react-sdk";
-import type { SelectedInstanceData } from "@webstudio-is/project";
 
 export type UserPropValue = PropsItem extends infer T
   ? T extends { value: unknown; type: unknown }
@@ -75,7 +74,7 @@ const getRequiredPropsList = (component: ComponentName) => {
 
 type UsePropsLogic = {
   props: PropsItem[];
-  selectedInstanceData: SelectedInstanceData;
+  selectedInstance: Instance;
   updateProps: (update: PropsItem) => void;
   deleteProp: (id: PropsItem["id"]) => void;
 };
@@ -102,11 +101,11 @@ const getPropsItemFromMetaProps = (
  */
 export const usePropsLogic = ({
   props,
-  selectedInstanceData,
+  selectedInstance,
   updateProps,
   deleteProp,
 }: UsePropsLogic) => {
-  const { id: instanceId, component } = selectedInstanceData;
+  const { id: instanceId, component } = selectedInstance;
 
   const metaProps = useMemo(
     () => getComponentMetaProps(component),

--- a/apps/designer/app/designer/features/sidebar-left/lib/navigator/navigator.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/lib/navigator/navigator.tsx
@@ -1,8 +1,8 @@
+import { useCallback } from "react";
+import { useStore } from "@nanostores/react";
 import { Flex } from "@webstudio-is/design-system";
 import { type Instance } from "@webstudio-is/react-sdk";
 import { type Publish } from "~/shared/pubsub";
-import { useCallback } from "react";
-import { useSelectedInstanceData } from "~/designer/shared/nano-states";
 import { selectedInstanceIdStore, useRootInstance } from "~/shared/nano-states";
 import { Header, CloseButton } from "../header";
 import { InstanceTree } from "~/designer/shared/tree";
@@ -25,7 +25,7 @@ type NavigatorProps = {
 };
 
 export const Navigator = ({ publish, isClosable, onClose }: NavigatorProps) => {
-  const [selectedInstanceData] = useSelectedInstanceData();
+  const selectedInstanceId = useStore(selectedInstanceIdStore);
   const [rootInstance] = useRootInstance();
 
   const handleSelect = useCallback((instanceId: Instance["id"]) => {
@@ -83,7 +83,7 @@ export const Navigator = ({ publish, isClosable, onClose }: NavigatorProps) => {
       <Flex css={{ flexGrow: 1, flexDirection: "column" }}>
         <InstanceTree
           root={rootInstance}
-          selectedItemId={selectedInstanceData?.id}
+          selectedItemId={selectedInstanceId}
           onSelect={handleSelect}
           onHover={handleHover}
           onDragEnd={handleDragEnd}

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useStore } from "@nanostores/react";
 import type {
   Breakpoint,
   Style,
@@ -9,14 +10,13 @@ import { properties } from "@webstudio-is/css-data";
 import { utils } from "@webstudio-is/project";
 import type { Instance, Styles } from "@webstudio-is/react-sdk";
 import {
+  selectedInstanceBrowserStyleStore,
+  selectedInstanceIdStore,
   useBreakpoints,
   useRootInstance,
   useStyles,
 } from "~/shared/nano-states";
-import {
-  useSelectedBreakpoint,
-  useSelectedInstanceData,
-} from "~/designer/shared/nano-states";
+import { useSelectedBreakpoint } from "~/designer/shared/nano-states";
 
 type CascadedValueInfo = {
   breakpointId: string;
@@ -185,9 +185,8 @@ export const useStyleInfo = () => {
   const [breakpoints] = useBreakpoints();
   const [selectedBreakpoint] = useSelectedBreakpoint();
   const selectedBreakpointId = selectedBreakpoint?.id;
-  const [selectedInstanceData] = useSelectedInstanceData();
-  const selectedInstanceId = selectedInstanceData?.id;
-  const browserStyle = selectedInstanceData?.browserStyle;
+  const selectedInstanceId = useStore(selectedInstanceIdStore);
+  const browserStyle = useStore(selectedInstanceBrowserStyleStore);
   const [rootInstance] = useRootInstance();
   const [styles] = useStyles();
 

--- a/apps/designer/app/designer/features/style-panel/style-panel.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-panel.tsx
@@ -1,7 +1,7 @@
 import type { Publish } from "~/shared/pubsub";
 import { willRender } from "~/designer/shared/breakpoints";
 import { Box, Card, Paragraph, SearchField } from "@webstudio-is/design-system";
-import type { SelectedInstanceData } from "@webstudio-is/project";
+import type { Instance } from "@webstudio-is/react-sdk";
 import { useStyleData } from "./shared/use-style-data";
 import { StyleSettings } from "./style-settings";
 import { useState } from "react";
@@ -13,16 +13,13 @@ import { theme } from "@webstudio-is/design-system";
 
 type StylePanelProps = {
   publish: Publish;
-  selectedInstanceData?: SelectedInstanceData;
+  selectedInstance: Instance;
 };
 
-export const StylePanel = ({
-  selectedInstanceData,
-  publish,
-}: StylePanelProps) => {
+export const StylePanel = ({ selectedInstance, publish }: StylePanelProps) => {
   const { currentStyle, setProperty, deleteProperty, createBatchUpdate } =
     useStyleData({
-      selectedInstanceData,
+      selectedInstance,
       publish,
     });
 
@@ -32,7 +29,7 @@ export const StylePanel = ({
 
   if (
     currentStyle === undefined ||
-    selectedInstanceData === undefined ||
+    selectedInstance === undefined ||
     breakpoint === undefined
   ) {
     return null;

--- a/apps/designer/app/designer/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
@@ -1,23 +1,22 @@
+import { useStore } from "@nanostores/react";
 import {
+  selectedInstanceIdStore,
   useHoveredInstanceRect,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
-import {
-  useHoveredInstanceData,
-  useSelectedInstanceData,
-} from "~/designer/shared/nano-states";
+import { useHoveredInstanceData } from "~/designer/shared/nano-states";
 import { Outline } from "./outline";
 import { Label } from "./label";
 
 export const HoveredInstanceOutline = () => {
-  const [selectedInstanceData] = useSelectedInstanceData();
+  const selectedInstanceId = useStore(selectedInstanceIdStore);
   const [instanceRect] = useHoveredInstanceRect();
   const [hoveredInstanceData] = useHoveredInstanceData();
   const [textEditingInstanceId] = useTextEditingInstanceId();
 
   const isEditingText = textEditingInstanceId !== undefined;
   const isHoveringSelectedInstance =
-    selectedInstanceData?.id === hoveredInstanceData?.id;
+    selectedInstanceId === hoveredInstanceData?.id;
 
   if (
     hoveredInstanceData === undefined ||

--- a/apps/designer/app/designer/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/outline/selected-instance-outline.tsx
@@ -1,22 +1,23 @@
+import { useStore } from "@nanostores/react";
 import {
+  selectedInstanceStore,
   useSelectedInstanceOutline,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
-import { useSelectedInstanceData } from "~/designer/shared/nano-states";
 import { Outline } from "./outline";
 import { Label } from "./label";
 
 export const SelectedInstanceOutline = () => {
   const [{ rect, visible }] = useSelectedInstanceOutline();
-  const [instanceData] = useSelectedInstanceData();
+  const selectedInstance = useStore(selectedInstanceStore);
   const [textEditingInstanceId] = useTextEditingInstanceId();
 
   const isEditingCurrentInstance =
     textEditingInstanceId !== undefined &&
-    textEditingInstanceId === instanceData?.id;
+    textEditingInstanceId === selectedInstance?.id;
 
   if (
-    instanceData === undefined ||
+    selectedInstance === undefined ||
     isEditingCurrentInstance ||
     visible === false ||
     rect === undefined
@@ -26,7 +27,7 @@ export const SelectedInstanceOutline = () => {
 
   return (
     <Outline rect={rect}>
-      <Label component={instanceData.component} instanceRect={rect} />
+      <Label component={selectedInstance.component} instanceRect={rect} />
     </Outline>
   );
 };

--- a/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/text-toolbar/text-toolbar.tsx
@@ -1,8 +1,8 @@
 import { useRef, useEffect } from "react";
+import { useStore } from "@nanostores/react";
 import { computePosition, flip, offset, shift } from "@floating-ui/dom";
 import { type Publish } from "~/shared/pubsub";
 import {
-  useSelectedInstanceData,
   type TextToolbarState,
   useTextToolbarState,
 } from "~/designer/shared/nano-states";
@@ -18,6 +18,7 @@ import {
 } from "@webstudio-is/icons";
 import { useSubscribe } from "~/shared/pubsub";
 import { theme } from "@webstudio-is/design-system";
+import { selectedInstanceIdStore } from "~/shared/nano-states";
 
 type Format =
   | "bold"
@@ -190,9 +191,9 @@ type TextToolbarProps = {
 
 export const TextToolbar = ({ publish }: TextToolbarProps) => {
   const [textToolbar] = useTextToolbarState();
-  const [selectedIntsanceData] = useSelectedInstanceData();
+  const selectedInstanceId = useStore(selectedInstanceIdStore);
 
-  if (textToolbar == null || selectedIntsanceData === undefined) {
+  if (textToolbar == null || selectedInstanceId === undefined) {
     return null;
   }
 

--- a/apps/designer/app/designer/features/workspace/workspace.tsx
+++ b/apps/designer/app/designer/features/workspace/workspace.tsx
@@ -3,6 +3,7 @@ import { useCanvasWidth, useZoom } from "~/designer/shared/nano-states";
 import { CanvasTools } from "./canvas-tools";
 import { type Publish } from "~/shared/pubsub";
 import { theme } from "@webstudio-is/design-system";
+import { selectedInstanceIdStore } from "~/shared/nano-states";
 
 const workspaceStyle = {
   flexGrow: 1,
@@ -40,7 +41,7 @@ export const Workspace = ({
   const [canvasWidth] = useCanvasWidth();
 
   const handleWorkspaceClick = () => {
-    publish({ type: "unselectInstance" });
+    selectedInstanceIdStore.set(undefined);
   };
 
   return (

--- a/apps/designer/app/designer/shared/inspector/component-info.tsx
+++ b/apps/designer/app/designer/shared/inspector/component-info.tsx
@@ -1,12 +1,11 @@
-import { getComponentMeta } from "@webstudio-is/react-sdk";
+import { getComponentMeta, type Instance } from "@webstudio-is/react-sdk";
 import { Flex, Text } from "@webstudio-is/design-system";
-import type { SelectedInstanceData } from "@webstudio-is/project";
 import { theme } from "@webstudio-is/design-system";
 
 export const ComponentInfo = ({
-  selectedInstanceData,
+  selectedInstance,
 }: {
-  selectedInstanceData: SelectedInstanceData;
+  selectedInstance: Instance;
 }) => {
   return (
     <Flex justify="between" align="center">
@@ -17,7 +16,7 @@ export const ComponentInfo = ({
           fontWeight: "500",
         }}
       >{`Selected: ${
-        getComponentMeta(selectedInstanceData.component).label
+        getComponentMeta(selectedInstance.component).label
       }`}</Text>
     </Flex>
   );

--- a/apps/designer/app/designer/shared/nano-states/index.ts
+++ b/apps/designer/app/designer/shared/nano-states/index.ts
@@ -1,10 +1,7 @@
 import { atom, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
 import { type Breakpoint } from "@webstudio-is/css-data";
-import {
-  type SelectedInstanceData,
-  type HoveredInstanceData,
-} from "@webstudio-is/project";
+import { type HoveredInstanceData } from "@webstudio-is/project";
 import { type Pages, type Project } from "@webstudio-is/project";
 import type { AssetContainer, DeletingAssetContainer } from "../assets";
 
@@ -12,10 +9,6 @@ const useValue = <T>(atom: WritableAtom<T>) => {
   const value = useStore(atom);
   return [value, atom.set] as const;
 };
-
-const selectedInstanceDataContainer = atom<SelectedInstanceData | undefined>();
-export const useSelectedInstanceData = () =>
-  useValue(selectedInstanceDataContainer);
 
 const hoveredInstanceDataContainer = atom<HoveredInstanceData | undefined>();
 export const useHoveredInstanceData = () =>

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -5,7 +5,7 @@ import type {
   DropTargetChangePayload,
   DragStartPayload,
 } from "~/canvas/shared/use-drag-drop";
-import type { Breakpoint } from "@webstudio-is/css-data";
+import type { Breakpoint, Style } from "@webstudio-is/css-data";
 import type { DesignToken } from "@webstudio-is/design-tokens";
 import { useSyncInitializeOnce } from "../hook-utils";
 
@@ -111,6 +111,7 @@ export const selectedInstanceStore = computed(
     return instancesIndex.instancesById.get(selectedInstanceId);
   }
 );
+export const selectedInstanceBrowserStyleStore = atom<undefined | Style>();
 
 const isPreviewModeContainer = atom<boolean>(false);
 export const useIsPreviewMode = () => useValue(isPreviewModeContainer);

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -9,6 +9,7 @@ import {
   designTokensContainer,
   stylesContainer,
   selectedInstanceIdStore,
+  selectedInstanceBrowserStyleStore,
 } from "~/shared/nano-states";
 
 type StoreData = {
@@ -44,6 +45,10 @@ export const registerContainers = () => {
   store.register("designTokens", designTokensContainer);
   // synchronize whole states
   clientStores.set("selectedInstanceId", selectedInstanceIdStore);
+  clientStores.set(
+    "selectedInstanceBrowserStyle",
+    selectedInstanceBrowserStyleStore
+  );
 };
 
 const syncStoresChanges = (name: SyncEventSource, publish: Publish) => {

--- a/packages/project/src/shared/canvas-components/instance-data.ts
+++ b/packages/project/src/shared/canvas-components/instance-data.ts
@@ -1,16 +1,9 @@
 import type { Instance } from "@webstudio-is/react-sdk";
 import type {
-  Style,
   StyleProperty,
   StyleValue,
   Breakpoint,
 } from "@webstudio-is/css-data";
-
-export type SelectedInstanceData = {
-  id: Instance["id"];
-  component: Instance["component"];
-  browserStyle: Style;
-};
 
 export type HoveredInstanceData = {
   id: Instance["id"];


### PR DESCRIPTION
selectedInstanceData update is sent from canvas after every render in effect. The latency can be avoided by subscribing to selectedInstanceId directly. For styles added new store selectedInstanceBrowserStyle and synchronized it the same way. Works without flashing in UI even without reset.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
