### PR TITLE
Migrate hovered outline to synchronized stores

### DIFF
--- a/apps/designer/app/canvas/hovered-instance-connector.ts
+++ b/apps/designer/app/canvas/hovered-instance-connector.ts
@@ -1,38 +1,26 @@
 import { useEffect } from "react";
 import debounce from "lodash.debounce";
-import { type Instance, idAttribute } from "@webstudio-is/react-sdk";
-import { utils } from "@webstudio-is/project";
-import { publish, subscribe } from "~/shared/pubsub";
-import { useRootInstance } from "~/shared/nano-states";
+import { type ComponentName, idAttribute } from "@webstudio-is/react-sdk";
+import {
+  hoveredInstanceIdStore,
+  hoveredInstanceOutlineStore,
+} from "~/shared/nano-states";
 import { subscribeScrollState } from "~/shared/dom-hooks";
 
-const startHoveredInstanceConnection = (rootInstance: Instance) => {
+type TimeoutId = undefined | ReturnType<typeof setTimeout>;
+
+const startHoveredInstanceConnection = () => {
   let hoveredElement: undefined | Element = undefined;
 
-  // debounce is used to avoid laggy hover because of iframe message delay
-  const publishHover = debounce((element: Element) => {
+  const updateHoveredInstance = (element: Element) => {
     const id = element.getAttribute(idAttribute) ?? undefined;
     if (id === undefined) {
       return;
     }
-    const instance = utils.tree.findInstanceById(rootInstance, id);
-    if (instance === undefined) {
-      return;
-    }
-    publish({
-      type: "hoveredInstanceRect",
-      payload: element.getBoundingClientRect(),
-    });
-    publish({
-      type: "hoverInstance",
-      payload: {
-        id: instance.id,
-        component: instance.component,
-      },
-    });
-  }, 50);
+    hoveredInstanceIdStore.set(id);
+  };
 
-  let mouseOutTimeoutId: undefined | ReturnType<typeof setTimeout> = undefined;
+  let mouseOutTimeoutId: TimeoutId = undefined;
 
   const handleMouseOver = (event: MouseEvent) => {
     if (event.target instanceof Element) {
@@ -41,7 +29,7 @@ const startHoveredInstanceConnection = (rootInstance: Instance) => {
         clearTimeout(mouseOutTimeoutId);
         // store hovered element locally to update outline when scroll ends
         hoveredElement = element;
-        publishHover(element);
+        updateHoveredInstance(element);
       }
     }
   };
@@ -49,10 +37,7 @@ const startHoveredInstanceConnection = (rootInstance: Instance) => {
   const handleMouseOut = () => {
     mouseOutTimeoutId = setTimeout(() => {
       hoveredElement = undefined;
-      publish({
-        type: "hoverInstance",
-        payload: undefined,
-      });
+      hoveredInstanceIdStore.set(undefined);
     }, 100);
   };
 
@@ -60,56 +45,56 @@ const startHoveredInstanceConnection = (rootInstance: Instance) => {
   window.addEventListener("mouseover", handleMouseOver, eventOptions);
   window.addEventListener("mouseout", handleMouseOut, eventOptions);
 
-  const unsubscribeNavigatorHoveredInstance = subscribe(
-    "navigatorHoveredInstance",
-    (navigatorHoveredInstance) => {
-      if (navigatorHoveredInstance === undefined) {
-        return;
-      }
-      const id = navigatorHoveredInstance.id;
-      const element =
-        document.querySelector(`[${idAttribute}="${id}"]`) ?? undefined;
-      if (element !== undefined) {
-        publishHover(element);
-      }
+  // debounce is used to avoid laggy hover because of iframe message delay
+  const updateHoveredRect = debounce((element: Element) => {
+    const component = element.getAttribute("data-ws-component") ?? undefined;
+    if (component === undefined) {
+      return;
     }
-  );
+    hoveredInstanceOutlineStore.set({
+      // store component in outline to show correct label when hover over elements fast
+      component: component as ComponentName,
+      rect: element.getBoundingClientRect(),
+    });
+  }, 50);
 
-  // remove hover outline when scroll starts
+  // remove hover rect when scroll starts
   // and show it with new rect when scroll ends
   const unsubscribeScrollState = subscribeScrollState({
     onScrollStart() {
-      publish({
-        type: "hoverInstance",
-        payload: undefined,
-      });
+      hoveredInstanceOutlineStore.set(undefined);
     },
     onScrollEnd() {
       if (hoveredElement !== undefined) {
-        publishHover(hoveredElement);
+        updateHoveredRect(hoveredElement);
       }
     },
   });
 
+  // update rect whenever hovered instance is changed
+  const unsubscribeHoveredInstanceId = hoveredInstanceIdStore.subscribe(
+    (id) => {
+      const element =
+        document.querySelector(`[${idAttribute}="${id}"]`) ?? undefined;
+      if (element !== undefined) {
+        updateHoveredRect(element);
+      }
+    }
+  );
+
   return () => {
-    publishHover.cancel();
+    updateHoveredRect.cancel();
     window.removeEventListener("mouseover", handleMouseOver);
     window.removeEventListener("mouseout", handleMouseOut);
-    unsubscribeNavigatorHoveredInstance();
     unsubscribeScrollState();
     clearTimeout(mouseOutTimeoutId);
+    unsubscribeHoveredInstanceId();
   };
 };
 
 export const useHoveredInstanceConnector = () => {
-  const [rootInstance] = useRootInstance();
-
   useEffect(() => {
-    if (rootInstance === undefined) {
-      return;
-    }
-
-    const disconnect = startHoveredInstanceConnection(rootInstance);
+    const disconnect = startHoveredInstanceConnection();
     return disconnect;
-  }, [rootInstance]);
+  }, []);
 };

--- a/apps/designer/app/canvas/hovered-instance-connector.ts
+++ b/apps/designer/app/canvas/hovered-instance-connector.ts
@@ -58,7 +58,7 @@ const startHoveredInstanceConnection = () => {
     });
   }, 50);
 
-  // remove hover rect when scroll starts
+  // remove hover outline when scroll starts
   // and show it with new rect when scroll ends
   const unsubscribeScrollState = subscribeScrollState({
     onScrollStart() {

--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -7,11 +7,7 @@ import {
 } from "@webstudio-is/react-sdk";
 
 import { useSubscribe } from "~/shared/pubsub";
-import {
-  utils,
-  type HoveredInstanceData,
-  type InstanceInsertionSpec,
-} from "@webstudio-is/project";
+import { utils, type InstanceInsertionSpec } from "@webstudio-is/project";
 import store from "immerhin";
 import {
   rootInstanceContainer,
@@ -23,8 +19,6 @@ import { publish } from "~/shared/pubsub";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
-    hoveredInstanceRect: DOMRect;
-    hoverInstance?: HoveredInstanceData;
     textEditingInstanceId?: Instance["id"];
     insertInstance: {
       instance: Instance;

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -13,12 +13,7 @@ import { useSyncServer } from "./shared/sync-server";
 import interFont from "@fontsource/inter/variable.css";
 import { SidebarLeft } from "./features/sidebar-left";
 import { Inspector } from "./features/inspector";
-import {
-  useHoveredInstanceData,
-  usePages,
-  useProject,
-  useCurrentPageId,
-} from "./shared/nano-states";
+import { usePages, useProject, useCurrentPageId } from "./shared/nano-states";
 import { Topbar } from "./features/topbar";
 import designerStyles from "./designer.css";
 import { Footer } from "./features/footer";
@@ -52,11 +47,6 @@ export const links = () => {
     { rel: "stylesheet", href: interFont },
     { rel: "stylesheet", href: designerStyles },
   ];
-};
-
-const useSubscribeHoveredInstanceData = () => {
-  const [, setValue] = useHoveredInstanceData();
-  useSubscribe("hoverInstance", setValue);
 };
 
 const useSetProject = (project: Project) => {
@@ -285,7 +275,6 @@ export const Designer = ({
   buildId,
   buildOrigin,
 }: DesignerProps) => {
-  useSubscribeHoveredInstanceData();
   useSubscribeBreakpoints();
   useSetProject(project);
   useSetPages(pages);

--- a/apps/designer/app/designer/features/sidebar-left/lib/navigator/navigator.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/lib/navigator/navigator.tsx
@@ -3,7 +3,11 @@ import { useStore } from "@nanostores/react";
 import { Flex } from "@webstudio-is/design-system";
 import { type Instance } from "@webstudio-is/react-sdk";
 import { type Publish } from "~/shared/pubsub";
-import { selectedInstanceIdStore, useRootInstance } from "~/shared/nano-states";
+import {
+  selectedInstanceIdStore,
+  hoveredInstanceIdStore,
+  useRootInstance,
+} from "~/shared/nano-states";
 import { Header, CloseButton } from "../header";
 import { InstanceTree } from "~/designer/shared/tree";
 
@@ -14,7 +18,6 @@ declare module "~/shared/pubsub" {
       dropTarget: { instanceId: Instance["id"]; position: number | "end" };
     };
     deleteInstance: { id: Instance["id"] };
-    navigatorHoveredInstance: { id: Instance["id"] } | undefined;
   }
 }
 
@@ -61,15 +64,9 @@ export const Navigator = ({ publish, isClosable, onClose }: NavigatorProps) => {
     [publish]
   );
 
-  const handleHover = useCallback(
-    (instance: Instance | undefined) => {
-      publish({
-        type: "navigatorHoveredInstance",
-        payload: instance && { id: instance.id },
-      });
-    },
-    [publish]
-  );
+  const handleHover = useCallback((instance: Instance | undefined) => {
+    hoveredInstanceIdStore.set(instance?.id);
+  }, []);
 
   if (rootInstance === undefined) {
     return null;

--- a/apps/designer/app/designer/features/workspace/canvas-tools/hooks/use-subscribe-instance-rect.ts
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/hooks/use-subscribe-instance-rect.ts
@@ -1,8 +1,5 @@
 import { useSubscribe } from "~/shared/pubsub";
-import {
-  useSelectedInstanceOutline,
-  useHoveredInstanceRect,
-} from "~/shared/nano-states";
+import { useSelectedInstanceOutline } from "~/shared/nano-states";
 
 export const useSubscribeInstanceRect = () => {
   const [selectedInstanceOutline, setSelectedInstanceOutline] =
@@ -10,6 +7,4 @@ export const useSubscribeInstanceRect = () => {
   useSubscribe("updateSelectedInstanceOutline", (value) => {
     setSelectedInstanceOutline({ ...selectedInstanceOutline, ...value });
   });
-  const [, setHoveredRect] = useHoveredInstanceRect();
-  useSubscribe("hoveredInstanceRect", setHoveredRect);
 };

--- a/apps/designer/app/designer/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
@@ -1,6 +1,6 @@
 import { useStore } from "@nanostores/react";
 import {
-  hoveredInstanceStore,
+  hoveredInstanceIdStore,
   hoveredInstanceOutlineStore,
   selectedInstanceIdStore,
   useTextEditingInstanceId,
@@ -10,15 +10,15 @@ import { Label } from "./label";
 
 export const HoveredInstanceOutline = () => {
   const selectedInstanceId = useStore(selectedInstanceIdStore);
-  const hoveredInstance = useStore(hoveredInstanceStore);
+  const hoveredInstanceId = useStore(hoveredInstanceIdStore);
   const instanceOutline = useStore(hoveredInstanceOutlineStore);
   const [textEditingInstanceId] = useTextEditingInstanceId();
 
   const isEditingText = textEditingInstanceId !== undefined;
-  const isHoveringSelectedInstance = selectedInstanceId === hoveredInstance?.id;
+  const isHoveringSelectedInstance = selectedInstanceId === hoveredInstanceId;
 
   if (
-    hoveredInstance === undefined ||
+    hoveredInstanceId === undefined ||
     instanceOutline === undefined ||
     isHoveringSelectedInstance ||
     isEditingText

--- a/apps/designer/app/designer/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/outline/hovered-instance-outline.tsx
@@ -1,26 +1,25 @@
 import { useStore } from "@nanostores/react";
 import {
+  hoveredInstanceStore,
+  hoveredInstanceOutlineStore,
   selectedInstanceIdStore,
-  useHoveredInstanceRect,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
-import { useHoveredInstanceData } from "~/designer/shared/nano-states";
 import { Outline } from "./outline";
 import { Label } from "./label";
 
 export const HoveredInstanceOutline = () => {
   const selectedInstanceId = useStore(selectedInstanceIdStore);
-  const [instanceRect] = useHoveredInstanceRect();
-  const [hoveredInstanceData] = useHoveredInstanceData();
+  const hoveredInstance = useStore(hoveredInstanceStore);
+  const instanceOutline = useStore(hoveredInstanceOutlineStore);
   const [textEditingInstanceId] = useTextEditingInstanceId();
 
   const isEditingText = textEditingInstanceId !== undefined;
-  const isHoveringSelectedInstance =
-    selectedInstanceId === hoveredInstanceData?.id;
+  const isHoveringSelectedInstance = selectedInstanceId === hoveredInstance?.id;
 
   if (
-    hoveredInstanceData === undefined ||
-    instanceRect === undefined ||
+    hoveredInstance === undefined ||
+    instanceOutline === undefined ||
     isHoveringSelectedInstance ||
     isEditingText
   ) {
@@ -28,10 +27,10 @@ export const HoveredInstanceOutline = () => {
   }
 
   return (
-    <Outline rect={instanceRect}>
+    <Outline rect={instanceOutline.rect}>
       <Label
-        component={hoveredInstanceData.component}
-        instanceRect={instanceRect}
+        component={instanceOutline.component}
+        instanceRect={instanceOutline.rect}
       />
     </Outline>
   );

--- a/apps/designer/app/designer/shared/nano-states/index.ts
+++ b/apps/designer/app/designer/shared/nano-states/index.ts
@@ -1,7 +1,6 @@
 import { atom, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
 import { type Breakpoint } from "@webstudio-is/css-data";
-import { type HoveredInstanceData } from "@webstudio-is/project";
 import { type Pages, type Project } from "@webstudio-is/project";
 import type { AssetContainer, DeletingAssetContainer } from "../assets";
 
@@ -9,10 +8,6 @@ const useValue = <T>(atom: WritableAtom<T>) => {
   const value = useStore(atom);
   return [value, atom.set] as const;
 };
-
-const hoveredInstanceDataContainer = atom<HoveredInstanceData | undefined>();
-export const useHoveredInstanceData = () =>
-  useValue(hoveredInstanceDataContainer);
 
 const isShareDialogOpenContainer = atom<boolean>(false);
 export const useIsShareDialogOpen = () => useValue(isShareDialogOpenContainer);

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -1,6 +1,11 @@
 import { atom, computed, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
-import { Instance, PresetStyles, Styles } from "@webstudio-is/react-sdk";
+import type {
+  ComponentName,
+  Instance,
+  PresetStyles,
+  Styles,
+} from "@webstudio-is/react-sdk";
 import type {
   DropTargetChangePayload,
   DragStartPayload,
@@ -113,6 +118,22 @@ export const selectedInstanceStore = computed(
 );
 export const selectedInstanceBrowserStyleStore = atom<undefined | Style>();
 
+export const hoveredInstanceIdStore = atom<undefined | Instance["id"]>(
+  undefined
+);
+export const hoveredInstanceStore = computed(
+  [instancesIndexStore, hoveredInstanceIdStore],
+  (instancesIndex, hoveredInstanceId) => {
+    if (hoveredInstanceId === undefined) {
+      return;
+    }
+    return instancesIndex.instancesById.get(hoveredInstanceId);
+  }
+);
+export const hoveredInstanceOutlineStore = atom<
+  undefined | { component: ComponentName; rect: DOMRect }
+>(undefined);
+
 const isPreviewModeContainer = atom<boolean>(false);
 export const useIsPreviewMode = () => useValue(isPreviewModeContainer);
 
@@ -125,10 +146,6 @@ const selectedInstanceOutlineContainer = atom<{
 });
 export const useSelectedInstanceOutline = () =>
   useValue(selectedInstanceOutlineContainer);
-
-const hoveredInstanceRectContainer = atom<DOMRect | undefined>();
-export const useHoveredInstanceRect = () =>
-  useValue(hoveredInstanceRectContainer);
 
 const isScrollingContainer = atom<boolean>(false);
 export const useIsScrolling = () => useValue(isScrollingContainer);

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -121,15 +121,6 @@ export const selectedInstanceBrowserStyleStore = atom<undefined | Style>();
 export const hoveredInstanceIdStore = atom<undefined | Instance["id"]>(
   undefined
 );
-export const hoveredInstanceStore = computed(
-  [instancesIndexStore, hoveredInstanceIdStore],
-  (instancesIndex, hoveredInstanceId) => {
-    if (hoveredInstanceId === undefined) {
-      return;
-    }
-    return instancesIndex.instancesById.get(hoveredInstanceId);
-  }
-);
 export const hoveredInstanceOutlineStore = atom<
   undefined | { component: ComponentName; rect: DOMRect }
 >(undefined);

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -10,6 +10,8 @@ import {
   stylesContainer,
   selectedInstanceIdStore,
   selectedInstanceBrowserStyleStore,
+  hoveredInstanceIdStore,
+  hoveredInstanceOutlineStore,
 } from "~/shared/nano-states";
 
 type StoreData = {
@@ -49,6 +51,8 @@ export const registerContainers = () => {
     "selectedInstanceBrowserStyle",
     selectedInstanceBrowserStyleStore
   );
+  clientStores.set("hoveredInstanceIdStore", hoveredInstanceIdStore);
+  clientStores.set("hoveredInstanceOutlineStore", hoveredInstanceOutlineStore);
 };
 
 const syncStoresChanges = (name: SyncEventSource, publish: Publish) => {

--- a/packages/project/src/shared/canvas-components/instance-data.ts
+++ b/packages/project/src/shared/canvas-components/instance-data.ts
@@ -5,11 +5,6 @@ import type {
   Breakpoint,
 } from "@webstudio-is/css-data";
 
-export type HoveredInstanceData = {
-  id: Instance["id"];
-  component: Instance["component"];
-};
-
 export type StyleUpdate =
   | {
       operation: "delete";


### PR DESCRIPTION
Recently added support for synchronization of non-immerhin stores. Here refactored instance hovering from pubsub to such stores.

Designer and canvas can both set hovered instance id and instance connector subscribes to these changes and sends to designer outline rect.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
