### PR TITLE
Add style sources schema and table

### DIFF
--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -13,6 +13,9 @@ type Properties = typeof properties & {
 
 export type StyleProperty = keyof Properties;
 
+// @todo can't figure out how to make property to be enum
+export const StyleProperty = z.string() as z.ZodType<StyleProperty>;
+
 type CustomProperty = `--${string}`;
 
 export type AppliesTo = Properties[StyleProperty]["appliesTo"];
@@ -59,6 +62,11 @@ const RgbValue = z.object({
   alpha: z.number(),
 });
 export type RgbValue = z.infer<typeof RgbValue>;
+
+export const StoredImageValue = z.object({
+  type: z.literal("image"),
+  value: z.array(z.object({ type: z.literal("asset"), value: z.string() })),
+});
 
 export const ImageValue = z.object({
   type: z.literal("image"),

--- a/packages/prisma-client/prisma/migrations/20230125124138_style_sources/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230125124138_style_sources/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "Tree" ADD COLUMN     "styleRefs" TEXT NOT NULL DEFAULT '[]';
+
+-- CreateTable
+CREATE TABLE "StyleSources" (
+    "buildIda" TEXT NOT NULL,
+    "styleSources" TEXT NOT NULL DEFAULT '[]',
+    "styles" TEXT NOT NULL DEFAULT '[]',
+
+    CONSTRAINT "StyleSources_pkey" PRIMARY KEY ("buildIda")
+);

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -83,6 +83,7 @@ model Tree {
   props        String @default("[]")
   presetStyles String @default("[]")
   styles       String @default("[]")
+  styleRefs    String @default("[]")
 }
 
 model InstanceProps {
@@ -98,6 +99,12 @@ model Breakpoints {
   build   Build  @relation(fields: [buildId], references: [id])
   buildId String @id
   values  String @default("[]")
+}
+
+model StyleSources {
+  buildIda     String @id
+  styleSources String @default("[]")
+  styles       String @default("[]")
 }
 
 model DesignTokens {

--- a/packages/react-sdk/src/db/index.ts
+++ b/packages/react-sdk/src/db/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 export * from "./instance";
 export * from "./props";
 export * from "./style";
+export * from "./style-sources";

--- a/packages/react-sdk/src/db/style-sources.ts
+++ b/packages/react-sdk/src/db/style-sources.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import {
+  StoredImageValue,
+  ImageValue,
+  SharedStyleValue,
+  StyleProperty,
+} from "@webstudio-is/css-data";
+
+const StyleSourcesToken = z.object({
+  type: z.literal("token"),
+  id: z.string(),
+  name: z.string(),
+});
+
+export const StyleSourcesItem = StyleSourcesToken;
+
+export const StyleSources = z.array(StyleSourcesItem);
+
+export const StoredStyleSourceStylesItem = z.object({
+  styleSourceId: z.string(),
+  breakpointId: z.string(),
+  property: StyleProperty,
+  value: z.union([StoredImageValue, SharedStyleValue]),
+});
+
+export const StoredStyleSourceStyles = z.array(StoredStyleSourceStylesItem);
+
+export const StyleSourceStylesItem = z.object({
+  styleSourceId: z.string(),
+  breakpointId: z.string(),
+  property: StyleProperty,
+  value: z.union([ImageValue, SharedStyleValue]),
+});
+
+export const StyleSourceStyles = z.array(StyleSourceStylesItem);
+
+const StyleRefsLocal = z.object({
+  type: z.literal("local"),
+});
+
+const StyleRefsRemote = z.object({
+  type: z.literal("remote"),
+  styleSourceId: z.string(),
+});
+
+export const StyleRefsItem = z.union([StyleRefsLocal, StyleRefsRemote]);
+
+export const StyleRefs = z.array(StyleRefsItem);

--- a/packages/react-sdk/src/db/style-sources.ts
+++ b/packages/react-sdk/src/db/style-sources.ts
@@ -36,11 +36,13 @@ export const StyleSourceStyles = z.array(StyleSourceStylesItem);
 
 const StyleRefsLocal = z.object({
   type: z.literal("local"),
+  instanceId: z.string(),
 });
 
 const StyleRefsRemote = z.object({
   type: z.literal("remote"),
   styleSourceId: z.string(),
+  instanceId: z.string(),
 });
 
 export const StyleRefsItem = z.union([StyleRefsLocal, StyleRefsRemote]);

--- a/packages/react-sdk/src/db/style.ts
+++ b/packages/react-sdk/src/db/style.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import {
-  type StyleProperty,
+  StyleProperty,
   StyleValue,
   SharedStyleValue,
+  StoredImageValue,
   ImageValue,
 } from "@webstudio-is/css-data";
 import {
@@ -13,8 +14,7 @@ import {
 
 export const PresetStylesItem = z.object({
   component: z.enum(getComponentNames() as [ComponentName]),
-  // @todo can't figure out how to make property to be enum
-  property: z.string() as z.ZodType<StyleProperty>,
+  property: StyleProperty,
   value: SharedStyleValue as z.ZodType<StyleValue>,
 });
 
@@ -52,16 +52,10 @@ export const findMissingPresetStyles = (
   return missingPresetStyles;
 };
 
-const StoredImageValue = z.object({
-  type: z.literal("image"),
-  value: z.array(z.object({ type: z.literal("asset"), value: z.string() })),
-});
-
 export const StoredStylesItem = z.object({
   breakpointId: z.string(),
   instanceId: z.string(),
-  // @todo can't figure out how to make property to be enum
-  property: z.string() as z.ZodType<StyleProperty>,
+  property: StyleProperty,
   value: z.union([StoredImageValue, SharedStyleValue]),
 });
 
@@ -74,8 +68,7 @@ export type StoredStyles = z.infer<typeof StoredStyles>;
 export const StylesItem = z.object({
   breakpointId: z.string(),
   instanceId: z.string(),
-  // @todo can't figure out how to make property to be enum
-  property: z.string() as z.ZodType<StyleProperty>,
+  property: StyleProperty,
   value: z.union([ImageValue, SharedStyleValue]),
 });
 


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/807

We are gonna implement tokens as a subset of possible style sources defined per project in opposite to per instance styles.

Each style is gonna be tied to breakpoint same way as instance styles.

Here resulting types

```ts
// Used for StyleSources.styleSources
type StyleSourcesItem = {
  type: "token",
  id: string,
  name: string,
};

// Used for StyleSources.styles
type StyleSourceStylesItem = {
  styleSourceId: string,
  breakpointId: string,
  property: StyleProperty,
  value: ImageValue | SharedStyleValue,
}

// Used for Tree.styleRefs
type StyleRefsItem =
  | { type: "local", instanceId: string }
  | { type: "remote", instanceId: string, styleSourceId: string };
```

## Description

1. What is this PR about (link the issue and add a short description)

## Steps for reproduction

1. click button
2. expect xyz

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
