### PR TITLE
Drop preset styles from db

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -30,7 +30,6 @@ import {
   useRootInstance,
   useSetBreakpoints,
   useSetDesignTokens,
-  useSetPresetStyles,
   useSetRootInstance,
   useSetStyles,
   useSubscribeScrollState,
@@ -151,7 +150,6 @@ export const Canvas = ({ data }: CanvasProps): JSX.Element | null => {
   useSetBreakpoints(data.breakpoints);
   useSetDesignTokens(data.designTokens);
   useAllUserProps(data.props);
-  useSetPresetStyles(data.tree.presetStyles);
   useSetStyles(data.tree.styles);
   useSetRootInstance(data.tree.root);
   setParams(data.params ?? null);

--- a/apps/designer/app/canvas/shared/styles.ts
+++ b/apps/designer/app/canvas/shared/styles.ts
@@ -1,11 +1,10 @@
 import { useEffect } from "react";
 import { useSubscribe } from "~/shared/pubsub";
-import { addGlobalRules, getPresetStyleRules } from "@webstudio-is/project";
+import { addGlobalRules } from "@webstudio-is/project";
 import {
   selectedInstanceIdStore,
   useBreakpoints,
   useDesignTokens,
-  usePresetStyles,
 } from "~/shared/nano-states";
 import {
   type Styles,
@@ -103,18 +102,11 @@ export const GlobalStyles = ({ assets }: { assets: Array<Asset> }) => {
     tokensCssEngine.render();
   }, [tokens]);
 
-  const [presetStyles] = usePresetStyles();
-
   useIsomorphicLayoutEffect(() => {
     presetStylesEngine.clear();
-    const presetStyleRules = getPresetStyleRules(presetStyles);
     for (const component of getComponentNames()) {
       const meta = getComponentMeta(component);
-      // render preset style and fallback to hardcoded one
-      // because could not be added yet to db
-      const presetStyle =
-        presetStyleRules.find((item) => item.component === component)?.style ??
-        meta.presetStyle;
+      const presetStyle = meta.presetStyle;
       if (presetStyle !== undefined) {
         presetStylesEngine.addStyleRule(`[data-ws-component=${component}]`, {
           style: presetStyle,
@@ -122,7 +114,7 @@ export const GlobalStyles = ({ assets }: { assets: Array<Asset> }) => {
       }
     }
     presetStylesEngine.render();
-  }, [presetStyles]);
+  }, []);
 
   return null;
 };

--- a/apps/designer/app/shared/css-utils/generate-css-text.ts
+++ b/apps/designer/app/shared/css-utils/generate-css-text.ts
@@ -1,13 +1,13 @@
 import { json } from "@remix-run/node";
 import { db } from "@webstudio-is/project/server";
-import {
-  addGlobalRules,
-  getPresetStyleRules,
-  getStyleRules,
-} from "@webstudio-is/project";
+import { addGlobalRules, getStyleRules } from "@webstudio-is/project";
 import { loadCanvasData } from "~/shared/db";
 import { createCssEngine } from "@webstudio-is/css-engine";
-import { idAttribute } from "@webstudio-is/react-sdk";
+import {
+  getComponentMeta,
+  getComponentNames,
+  idAttribute,
+} from "@webstudio-is/react-sdk";
 import type { BuildParams } from "../router-utils";
 
 export const generateCssText = async (buildParams: BuildParams) => {
@@ -35,9 +35,14 @@ export const generateCssText = async (buildParams: BuildParams) => {
     engine.addMediaRule(breakpoint.id, breakpoint);
   }
 
-  const presetStyleRules = getPresetStyleRules(canvasData.tree?.presetStyles);
-  for (const { component, style } of presetStyleRules) {
-    engine.addStyleRule(`[data-ws-component="${component}"]`, { style });
+  for (const component of getComponentNames()) {
+    const meta = getComponentMeta(component);
+    const presetStyle = meta.presetStyle;
+    if (presetStyle !== undefined) {
+      engine.addStyleRule(`[data-ws-component=${component}]`, {
+        style: presetStyle,
+      });
+    }
   }
 
   const styleRules = getStyleRules(canvasData.tree?.styles);

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -1,11 +1,6 @@
 import { atom, computed, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
-import type {
-  ComponentName,
-  Instance,
-  PresetStyles,
-  Styles,
-} from "@webstudio-is/react-sdk";
+import type { ComponentName, Instance, Styles } from "@webstudio-is/react-sdk";
 import type {
   DropTargetChangePayload,
   DragStartPayload,
@@ -46,14 +41,6 @@ export const instancesIndexStore = computed(
     };
   }
 );
-
-export const presetStylesContainer = atom<PresetStyles>([]);
-export const usePresetStyles = () => useValue(presetStylesContainer);
-export const useSetPresetStyles = (presetStyles: PresetStyles) => {
-  useSyncInitializeOnce(() => {
-    presetStylesContainer.set(presetStyles);
-  });
-};
 
 export const stylesContainer = atom<Styles>([]);
 /**

--- a/packages/project/src/shared/styles/style-rules.test.ts
+++ b/packages/project/src/shared/styles/style-rules.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@jest/globals";
 import type { Styles } from "@webstudio-is/react-sdk";
-import { getStyleRules, getPresetStyleRules } from "./style-rules";
+import { getStyleRules } from "./style-rules";
 
 test("get a list of style rules grouped by instance and breakpoint", () => {
   const styles: Styles = [
@@ -54,53 +54,6 @@ test("get a list of style rules grouped by instance and breakpoint", () => {
           "color": {
             "type": "keyword",
             "value": "red",
-          },
-        },
-      },
-    ]
-  `);
-});
-
-test("get a list of preset styles grouped by component", () => {
-  expect(
-    getPresetStyleRules([
-      {
-        component: "Box",
-        property: "width",
-        value: { type: "keyword", value: "auto" },
-      },
-      {
-        component: "Box",
-        property: "height",
-        value: { type: "keyword", value: "auto" },
-      },
-      {
-        component: "Paragraph",
-        property: "width",
-        value: { type: "keyword", value: "auto" },
-      },
-    ])
-  ).toMatchInlineSnapshot(`
-    [
-      {
-        "component": "Box",
-        "style": {
-          "height": {
-            "type": "keyword",
-            "value": "auto",
-          },
-          "width": {
-            "type": "keyword",
-            "value": "auto",
-          },
-        },
-      },
-      {
-        "component": "Paragraph",
-        "style": {
-          "width": {
-            "type": "keyword",
-            "value": "auto",
           },
         },
       },

--- a/packages/project/src/shared/styles/style-rules.ts
+++ b/packages/project/src/shared/styles/style-rules.ts
@@ -1,5 +1,5 @@
 import type { Style } from "@webstudio-is/css-data";
-import type { PresetStyles, Styles } from "@webstudio-is/react-sdk";
+import type { Styles } from "@webstudio-is/react-sdk";
 
 type StyleRule = {
   instanceId: string;
@@ -22,25 +22,4 @@ export const getStyleRules = (styles?: Styles) => {
     styleRule.style[property] = value;
   }
   return Array.from(stylesMap.values());
-};
-
-type PresetStyleRule = {
-  component: string;
-  style: Style;
-};
-
-export const getPresetStyleRules = (presetStyles?: PresetStyles) => {
-  const presetStylesMap = new Map<string, PresetStyleRule>();
-  if (presetStyles === undefined) {
-    return [];
-  }
-  for (const { component, property, value } of presetStyles) {
-    let presetStyleRule = presetStylesMap.get(component);
-    if (presetStyleRule === undefined) {
-      presetStyleRule = { component, style: {} };
-      presetStylesMap.set(component, presetStyleRule);
-    }
-    presetStyleRule.style[property] = value;
-  }
-  return Array.from(presetStylesMap.values());
 };

--- a/packages/react-sdk/src/db/style.ts
+++ b/packages/react-sdk/src/db/style.ts
@@ -1,56 +1,9 @@
 import { z } from "zod";
 import {
   type StyleProperty,
-  StyleValue,
   SharedStyleValue,
   ImageValue,
 } from "@webstudio-is/css-data";
-import {
-  type ComponentName,
-  getComponentMeta,
-  getComponentNames,
-} from "../components";
-
-export const PresetStylesItem = z.object({
-  component: z.enum(getComponentNames() as [ComponentName]),
-  // @todo can't figure out how to make property to be enum
-  property: z.string() as z.ZodType<StyleProperty>,
-  value: SharedStyleValue as z.ZodType<StyleValue>,
-});
-
-export type PresetStylesItem = z.infer<typeof PresetStylesItem>;
-
-export const PresetStyles = z.array(PresetStylesItem);
-
-export type PresetStyles = z.infer<typeof PresetStyles>;
-
-export const findMissingPresetStyles = (
-  presetStyles: PresetStyles,
-  components: ComponentName[]
-) => {
-  const populatedComponents = new Set();
-  for (const style of presetStyles) {
-    populatedComponents.add(style.component);
-  }
-  const missingPresetStyles: PresetStyles = [];
-  for (const component of components) {
-    if (populatedComponents.has(component)) {
-      continue;
-    }
-    const meta = getComponentMeta(component);
-    if (meta.presetStyle === undefined) {
-      continue;
-    }
-    for (const [property, value] of Object.entries(meta.presetStyle)) {
-      missingPresetStyles.push({
-        component,
-        property: property as StyleProperty,
-        value,
-      });
-    }
-  }
-  return missingPresetStyles;
-};
 
 const StoredImageValue = z.object({
   type: z.literal("image"),

--- a/packages/react-sdk/src/db/types.ts
+++ b/packages/react-sdk/src/db/types.ts
@@ -1,13 +1,12 @@
 import type { InstanceProps as DbInstanceProps } from "@webstudio-is/prisma-client";
 import type { Instance } from "./instance";
 import type { Props, PropsItem } from "./props";
-import type { PresetStyles, Styles } from "./style";
+import type { Styles } from "./style";
 
 export type Tree = {
   id: string;
   root: Instance;
   props: Props;
-  presetStyles: PresetStyles;
   styles: Styles;
 };
 


### PR DESCRIPTION
After discussing with @kof figured we do not need to store preset styles in db as after sdk upgrade components may still break.

Sdk versioning along with its hardcoded values will solve the problem better.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
