### PR TITLE
Treat component name as generic string

### DIFF
--- a/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
@@ -27,7 +27,7 @@ const ContentEditable = ({
   elementRef,
   ...props
 }: {
-  Component: ReturnType<typeof getComponent>;
+  Component: NonNullable<ReturnType<typeof getComponent>>;
   elementRef: { current: undefined | HTMLElement };
 }) => {
   const [editor] = useLexicalComposerContext();
@@ -92,6 +92,10 @@ export const WrapperComponentDev = ({
     instance.component === "Input" ? { readOnly: true } : undefined;
 
   const Component = getComponent(instance.component);
+
+  if (Component === undefined) {
+    return <></>;
+  }
 
   const props = {
     ...userProps,

--- a/apps/designer/app/canvas/hovered-instance-connector.ts
+++ b/apps/designer/app/canvas/hovered-instance-connector.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import debounce from "lodash.debounce";
-import { type ComponentName, idAttribute } from "@webstudio-is/react-sdk";
+import { idAttribute } from "@webstudio-is/react-sdk";
 import {
   hoveredInstanceIdStore,
   hoveredInstanceOutlineStore,
@@ -53,7 +53,7 @@ const startHoveredInstanceConnection = () => {
     }
     hoveredInstanceOutlineStore.set({
       // store component in outline to show correct label when hover over elements fast
-      component: component as ComponentName,
+      component: component,
       rect: element.getBoundingClientRect(),
     });
   }, 50);

--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -43,8 +43,8 @@ export const findInsertLocation = (
   path.reverse();
 
   const parentIndex = path.findIndex(({ item }) => {
-    const { type } = getComponentMeta(item.component);
-    return type === "body" || type === "container";
+    const meta = getComponentMeta(item.component);
+    return meta?.type === "body" || meta?.type === "container";
   });
 
   // Just in case selected Instance is not in the tree for some reason.

--- a/apps/designer/app/canvas/shared/styles.ts
+++ b/apps/designer/app/canvas/shared/styles.ts
@@ -106,7 +106,7 @@ export const GlobalStyles = ({ assets }: { assets: Array<Asset> }) => {
     presetStylesEngine.clear();
     for (const component of getComponentNames()) {
       const meta = getComponentMeta(component);
-      const presetStyle = meta.presetStyle;
+      const presetStyle = meta?.presetStyle;
       if (presetStyle !== undefined) {
         presetStylesEngine.addStyleRule(`[data-ws-component=${component}]`, {
           style: presetStyle,

--- a/apps/designer/app/canvas/shared/use-drag-drop.ts
+++ b/apps/designer/app/canvas/shared/use-drag-drop.ts
@@ -116,8 +116,8 @@ export const useDragAndDrop = () => {
       }
 
       const data = path.find((instance) => {
-        const { type } = getComponentMeta(instance.component);
-        return type === "body" || type === "container";
+        const meta = getComponentMeta(instance.component);
+        return meta?.type === "body" || meta?.type === "container";
       });
 
       if (data === undefined) {
@@ -180,7 +180,7 @@ export const useDragAndDrop = () => {
       }
 
       // When trying to drag an inline instance, drag its parent instead
-      if (getComponentMeta(instance.component).type === "rich-text-child") {
+      if (getComponentMeta(instance.component)?.type === "rich-text-child") {
         const nonInlineParent = utils.tree.findClosestNonInlineParent(
           rootInstance,
           instance.id

--- a/apps/designer/app/canvas/shared/use-shortcuts.ts
+++ b/apps/designer/app/canvas/shared/use-shortcuts.ts
@@ -125,8 +125,8 @@ export const useShortcuts = () => {
       if (selectedInstance === undefined) {
         return;
       }
-      const { type } = getComponentMeta(selectedInstance.component);
-      if (type === "rich-text") {
+      const meta = getComponentMeta(selectedInstance.component);
+      if (meta?.type === "rich-text") {
         // Prevents inserting a newline when entering text-editing mode
         event.preventDefault();
         setEditingInstanceId(selectedInstance.id);

--- a/apps/designer/app/canvas/shared/use-track-selected-element.ts
+++ b/apps/designer/app/canvas/shared/use-track-selected-element.ts
@@ -1,10 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useStore } from "@nanostores/react";
-import {
-  type Instance,
-  getComponentMeta,
-  getComponentNames,
-} from "@webstudio-is/react-sdk";
+import { type Instance, getComponentMeta } from "@webstudio-is/react-sdk";
 import {
   selectedInstanceIdStore,
   useRootInstance,
@@ -63,25 +59,24 @@ export const useTrackSelectedElement = () => {
       if (editingInstanceIdRef.current === id) {
         return;
       }
-      const components = getComponentNames();
 
       // It's the second click in a double click.
       if (event.detail === 2) {
         const component = dataset.wsComponent as Instance["component"];
-        if (component === undefined || !components.includes(component)) {
+        if (component === undefined) {
           return;
         }
-        const { type } = getComponentMeta(component);
+        const meta = getComponentMeta(component);
 
         // When user double clicks on an inline instance, we need to select the parent instance and put it indo text editing mode.
         // Inline instances are not editable directly, only through parent instance.
-        if (type === "rich-text-child") {
+        if (meta?.type === "rich-text-child") {
           const parent =
             rootInstance &&
             utils.tree.findClosestNonInlineParent(rootInstance, id);
           if (
             parent &&
-            getComponentMeta(parent.component).type === "rich-text"
+            getComponentMeta(parent.component)?.type === "rich-text"
           ) {
             selectedInstanceIdStore.set(parent.id);
             setEditingInstanceId(parent.id);
@@ -89,7 +84,7 @@ export const useTrackSelectedElement = () => {
           return;
         }
 
-        if (type === "rich-text") {
+        if (meta?.type === "rich-text") {
           setEditingInstanceId(id);
         }
       }

--- a/apps/designer/app/designer/features/props-panel/control.tsx
+++ b/apps/designer/app/designer/features/props-panel/control.tsx
@@ -193,7 +193,7 @@ export function Control({
 }: ControlProps) {
   const meta = getComponentMetaProps(component);
 
-  const argType = meta[userProp.name];
+  const argType = meta?.[userProp.name];
 
   // argType can be undefined in case of new property created
   const defaultValue = argType?.defaultValue ?? "";

--- a/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
@@ -73,7 +73,7 @@ export const DefaultProps: ComponentStory<typeof PropsPanel> = () => {
   );
 };
 
-const meta = getComponentMetaProps("Button");
+const meta = getComponentMetaProps("Button") ?? {};
 
 export const AllProps: ComponentStory<typeof PropsPanel> = () => {
   allUserPropsContainer.set({

--- a/apps/designer/app/designer/features/props-panel/props-panel.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.tsx
@@ -143,7 +143,7 @@ const Property = ({
   required,
   existingProps,
 }: PropertyProps) => {
-  const metaProps = getComponentMetaProps(component);
+  const metaProps = getComponentMetaProps(component) ?? {};
 
   const argType = metaProps[userProp.name as keyof typeof metaProps];
   const isInvalid =

--- a/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.test.ts
@@ -1,14 +1,10 @@
 import { jest, describe, test, expect } from "@jest/globals";
 import { renderHook, act } from "@testing-library/react-hooks";
-import {
-  getComponentMeta,
-  type ComponentName,
-  type Instance,
-} from "@webstudio-is/react-sdk";
+import { getComponentMeta, type Instance } from "@webstudio-is/react-sdk";
 import { nanoid } from "nanoid";
 import { usePropsLogic } from "./use-props-logic";
 
-const getSelectedInstance = (componentName: ComponentName): Instance => {
+const getSelectedInstance = (componentName: string): Instance => {
   return {
     type: "instance",
     id: nanoid(8),
@@ -176,14 +172,14 @@ describe("usePropsLogic", () => {
 
     const propNames = result.current.userProps.map((userProp) => userProp.name);
 
-    expect(imgMeta.initialProps).toEqual(
-      propNames.slice(0, imgMeta.initialProps?.length ?? 0)
+    expect(imgMeta?.initialProps).toEqual(
+      propNames.slice(0, imgMeta?.initialProps?.length ?? 0)
     );
 
-    expect(propNames.slice(imgMeta.initialProps?.length ?? 0)).toEqual(
+    expect(propNames.slice(imgMeta?.initialProps?.length ?? 0)).toEqual(
       result.current.userProps
         .filter(
-          (userProp) => imgMeta.initialProps?.includes(userProp.name) === false
+          (userProp) => imgMeta?.initialProps?.includes(userProp.name) === false
         )
         .map((userProp) => userProp.name)
     );

--- a/apps/designer/app/designer/features/props-panel/use-props-logic.ts
+++ b/apps/designer/app/designer/features/props-panel/use-props-logic.ts
@@ -1,12 +1,7 @@
 import { useMemo, useState } from "react";
 import ObjectId from "bson-objectid";
 import warnOnce from "warn-once";
-import type {
-  Instance,
-  PropsItem,
-  MetaProps,
-  ComponentName,
-} from "@webstudio-is/react-sdk";
+import type { Instance, PropsItem, MetaProps } from "@webstudio-is/react-sdk";
 import {
   getComponentMeta,
   getComponentMetaProps,
@@ -41,11 +36,11 @@ export const getValueFromPropMeta = (propValue?: MetaProps[string]) => {
   return typedValue;
 };
 
-const getRequiredPropsList = (component: ComponentName) => {
+const getRequiredPropsList = (component: string) => {
   const meta = getComponentMeta(component);
-  const metaProps = getComponentMetaProps(component);
+  const metaProps = getComponentMetaProps(component) ?? {};
 
-  const initialProps = meta.initialProps ?? [];
+  const initialProps = meta?.initialProps ?? [];
   const requiredProps = [];
   const propsWithDefaultValue = [];
 
@@ -108,7 +103,7 @@ export const usePropsLogic = ({
   const { id: instanceId, component } = selectedInstance;
 
   const metaProps = useMemo(
-    () => getComponentMetaProps(component),
+    () => getComponentMetaProps(component) ?? {},
     [component]
   );
   const requiredPropsList = useMemo(

--- a/apps/designer/app/designer/features/sidebar-left/panels/components/component-thumb.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/panels/components/component-thumb.tsx
@@ -31,7 +31,10 @@ export const ComponentThumb = forwardRef<
   ElementRef<typeof Thumb>,
   ComponentThumbProps
 >(({ component, ...rest }, ref) => {
-  const { Icon, label } = getComponentMeta(component);
+  const meta = getComponentMeta(component);
+  if (meta === undefined) {
+    return null;
+  }
   return (
     <Thumb
       direction="column"
@@ -41,8 +44,8 @@ export const ComponentThumb = forwardRef<
       ref={ref}
       {...rest}
     >
-      <Icon width={30} height={30} />
-      <Text>{label}</Text>
+      <meta.Icon width={30} height={30} />
+      <Text>{meta.label}</Text>
     </Thumb>
   );
 });

--- a/apps/designer/app/designer/features/sidebar-left/panels/components/components.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/panels/components/components.tsx
@@ -98,12 +98,12 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
   };
 
   const listedComponentNames = getComponentNames().filter((name) => {
-    const { type } = getComponentMeta(name);
+    const meta = getComponentMeta(name);
     return (
-      type === "container" ||
-      type === "control" ||
-      type === "embed" ||
-      type === "rich-text"
+      meta?.type === "container" ||
+      meta?.type === "control" ||
+      meta?.type === "embed" ||
+      meta?.type === "rich-text"
     );
   });
 

--- a/apps/designer/app/designer/features/workspace/canvas-tools/outline/label.tsx
+++ b/apps/designer/app/designer/features/workspace/canvas-tools/outline/label.tsx
@@ -77,11 +77,14 @@ type LabelProps = {
 
 export const Label = ({ component, instanceRect }: LabelProps) => {
   const [labelRef, position] = useLabelPosition(instanceRect);
-  const { Icon, label } = getComponentMeta(component);
+  const meta = getComponentMeta(component);
+  if (meta === undefined) {
+    return <></>;
+  }
   return (
     <LabelContainer position={position} ref={labelRef}>
-      <Icon width="1em" height="1em" />
-      {label}
+      <meta.Icon width="1em" height="1em" />
+      {meta.label}
     </LabelContainer>
   );
 };

--- a/apps/designer/app/designer/shared/inspector/component-info.tsx
+++ b/apps/designer/app/designer/shared/inspector/component-info.tsx
@@ -16,7 +16,7 @@ export const ComponentInfo = ({
           fontWeight: "500",
         }}
       >{`Selected: ${
-        getComponentMeta(selectedInstance.component).label
+        getComponentMeta(selectedInstance.component)?.label
       }`}</Text>
     </Flex>
   );

--- a/apps/designer/app/designer/shared/tree/index.tsx
+++ b/apps/designer/app/designer/shared/tree/index.tsx
@@ -15,23 +15,23 @@ const instanceRelatedProps = {
   getItemPath: utils.tree.getInstancePath,
   getItemPathWithPositions: utils.tree.getInstancePathWithPositions,
   canLeaveParent(item: Instance) {
-    const { type } = getComponentMeta(item.component);
-    return type !== "rich-text-child";
+    const meta = getComponentMeta(item.component);
+    return meta?.type !== "rich-text-child";
   },
   canAcceptChild(item: Instance) {
-    const { type } = getComponentMeta(item.component);
-    return type === "body" || type === "container";
+    const meta = getComponentMeta(item.component);
+    return meta?.type === "body" || meta?.type === "container";
   },
   getItemChildren(item: Instance) {
-    const { type } = getComponentMeta(item.component);
+    const meta = getComponentMeta(item.component);
 
     // We want to avoid calling .filter() unnecessarily, because this is a hot path for performance.
     // We rely on the fact that only rich-text or rich-text-child components may have `string` children.
     if (
-      type === "body" ||
-      type === "container" ||
-      type === "control" ||
-      type === "embed"
+      meta?.type === "body" ||
+      meta?.type === "container" ||
+      meta?.type === "control" ||
+      meta?.type === "embed"
     ) {
       return item.children as Instance[];
     }
@@ -41,10 +41,13 @@ const instanceRelatedProps = {
     );
   },
   renderItem(props: TreeItemRenderProps<Instance>) {
-    const { Icon, label } = getComponentMeta(props.itemData.component);
+    const meta = getComponentMeta(props.itemData.component);
+    if (meta === undefined) {
+      return <></>;
+    }
     return (
       <TreeItemBody {...props} selectionEvent="focus">
-        <TreeItemLabel prefix={<Icon />}>{label}</TreeItemLabel>
+        <TreeItemLabel prefix={<meta.Icon />}>{meta.label}</TreeItemLabel>
       </TreeItemBody>
     );
   },

--- a/apps/designer/app/shared/css-utils/generate-css-text.ts
+++ b/apps/designer/app/shared/css-utils/generate-css-text.ts
@@ -37,7 +37,7 @@ export const generateCssText = async (buildParams: BuildParams) => {
 
   for (const component of getComponentNames()) {
     const meta = getComponentMeta(component);
-    const presetStyle = meta.presetStyle;
+    const presetStyle = meta?.presetStyle;
     if (presetStyle !== undefined) {
       engine.addStyleRule(`[data-ws-component=${component}]`, {
         style: presetStyle,

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -1,6 +1,6 @@
 import { atom, computed, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
-import type { ComponentName, Instance, Styles } from "@webstudio-is/react-sdk";
+import type { Instance, Styles } from "@webstudio-is/react-sdk";
 import type {
   DropTargetChangePayload,
   DragStartPayload,
@@ -109,7 +109,7 @@ export const hoveredInstanceIdStore = atom<undefined | Instance["id"]>(
   undefined
 );
 export const hoveredInstanceOutlineStore = atom<
-  undefined | { component: ComponentName; rect: DOMRect }
+  undefined | { component: string; rect: DOMRect }
 >(undefined);
 
 const isPreviewModeContainer = atom<boolean>(false);

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -2,7 +2,6 @@ import { applyPatches, type Patch } from "immer";
 import { z } from "zod";
 import {
   type Tree,
-  type ComponentName,
   type InstancesItem,
   Instance,
   Styles,
@@ -82,7 +81,7 @@ const denormalizeTree = (instances: z.infer<typeof Instances>) => {
     const legacyInstance: Instance = {
       type: "instance",
       id: instance.id,
-      component: instance.component as ComponentName,
+      component: instance.component,
       children: [],
     };
     for (const child of instance.children) {

--- a/packages/project/src/shared/tree-utils/create-instance.ts
+++ b/packages/project/src/shared/tree-utils/create-instance.ts
@@ -21,7 +21,7 @@ export const createInstance = ({
     id: id === undefined ? createInstanceId() : id,
     children:
       children === undefined
-        ? componentMeta.children?.map((value) => ({ type: "text", value })) ??
+        ? componentMeta?.children?.map((value) => ({ type: "text", value })) ??
           []
         : children,
   };

--- a/packages/project/src/shared/tree-utils/find-closest-non-inline-parent.ts
+++ b/packages/project/src/shared/tree-utils/find-closest-non-inline-parent.ts
@@ -8,7 +8,7 @@ export const findClosestNonInlineParent = (
   const path = getInstancePath(rootInstance, instanceId);
   path.reverse();
   return path.find((item) => {
-    const { type } = getComponentMeta(item.component);
-    return type !== "rich-text-child";
+    const meta = getComponentMeta(item.component);
+    return meta?.type !== "rich-text-child";
   });
 };

--- a/packages/react-sdk/src/components/index.ts
+++ b/packages/react-sdk/src/components/index.ts
@@ -96,28 +96,37 @@ export const getComponentNames = (): ComponentName[] => {
   return [...uniqueNames.values()] as ComponentName[];
 };
 
-export const getComponentMeta = (name: ComponentName): WsComponentMeta => {
+export const getComponentMeta = (name: string): undefined | WsComponentMeta => {
+  const componentMeta = meta[name as ComponentName];
   if (registeredComponentsMeta != null && name in registeredComponentsMeta) {
-    return { ...meta[name], ...registeredComponentsMeta[name] };
+    return {
+      ...componentMeta,
+      ...registeredComponentsMeta[name as ComponentName],
+    };
   }
 
-  return meta[name];
+  return componentMeta;
 };
 
 export const getComponent = (
-  name: ComponentName
-): typeof components[ComponentName] => {
+  name: string
+): undefined | typeof components[ComponentName] => {
   return registeredComponents != null && name in registeredComponents
-    ? (registeredComponents[name] as typeof components[ComponentName])
-    : components[name];
+    ? (registeredComponents[
+        name as ComponentName
+      ] as typeof components[ComponentName])
+    : components[name as ComponentName];
 };
 
-export const getComponentMetaProps = (name: ComponentName): MetaProps => {
+export const getComponentMetaProps = (name: string): undefined | MetaProps => {
+  const componentMeta = meta[name as ComponentName];
   if (registeredComponentsMeta != null && name in registeredComponentsMeta) {
+    const registeredComponentMeta =
+      registeredComponentsMeta[name as ComponentName];
     const allMetaPropKeys = new Set([
-      ...Object.keys(meta[name]?.props ?? {}),
+      ...Object.keys(componentMeta?.props ?? {}),
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      ...Object.keys(registeredComponentsMeta[name]!.props!),
+      ...Object.keys(registeredComponentMeta!.props!),
     ]);
 
     const props: MetaProps = {};
@@ -126,21 +135,21 @@ export const getComponentMetaProps = (name: ComponentName): MetaProps => {
      **/
     for (const key of allMetaPropKeys.values()) {
       props[key] = {
-        ...meta[name]?.props[key],
-        ...registeredComponentsMeta[name]?.props?.[key],
+        ...componentMeta?.props[key],
+        ...registeredComponentMeta?.props?.[key],
         defaultValue:
-          registeredComponentsMeta[name]?.props?.[key]?.defaultValue ??
-          meta[name]?.props[key]?.defaultValue ??
+          registeredComponentMeta?.props?.[key]?.defaultValue ??
+          componentMeta?.props[key]?.defaultValue ??
           null,
         required:
-          registeredComponentsMeta[name]?.props?.[key]?.required ||
-          meta[name]?.props[key]?.required,
+          registeredComponentMeta?.props?.[key]?.required ||
+          componentMeta?.props[key]?.required,
       } as MetaProps[string];
     }
     return props;
   }
 
-  return meta[name].props;
+  return componentMeta?.props;
 };
 
 /**

--- a/packages/react-sdk/src/db/instance.ts
+++ b/packages/react-sdk/src/db/instance.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
-import { type ComponentName, getComponentNames } from "../components";
 
 // This should be used when passing a lot of data is potentially costly.
 // For example, when passing data from an iframe.
 export type BaseInstance = {
   id: string;
-  component: ComponentName;
+  component: string;
 };
 
 export type Instance = BaseInstance & {
@@ -36,7 +35,7 @@ export type Id = z.infer<typeof Id>;
 export const InstancesItem = z.object({
   type: z.literal("instance"),
   id: z.string(),
-  component: z.enum(getComponentNames() as [ComponentName]),
+  component: z.string(),
   children: z.array(z.union([Id, Text])),
 });
 
@@ -50,7 +49,7 @@ export const Instance: z.ZodType<Instance> = z.lazy(() =>
   z.object({
     type: z.literal("instance"),
     id: z.string(),
-    component: z.enum(getComponentNames() as [ComponentName]),
+    component: z.string(),
     children: z.array(z.union([Instance, Text])),
   })
 );

--- a/packages/react-sdk/src/index.ts
+++ b/packages/react-sdk/src/index.ts
@@ -9,4 +9,4 @@ export {
   customComponents,
   customComponentsMeta,
 } from "./app/custom-components";
-export type { MetaProps } from "./components/component-type";
+export type { MetaProps, WsComponentMeta } from "./components/component-type";

--- a/packages/react-sdk/src/tree/wrapper-component.tsx
+++ b/packages/react-sdk/src/tree/wrapper-component.tsx
@@ -40,6 +40,9 @@ export const WrapperComponent = ({
   ...rest
 }: WrapperComponentProps) => {
   const Component = getComponent(instance.component);
+  if (Component === undefined) {
+    return <></>;
+  }
   const userProps = useUserProps(instance.id);
   const props = {
     ...userProps,

--- a/packages/react-sdk/src/tree/wrapper-component.tsx
+++ b/packages/react-sdk/src/tree/wrapper-component.tsx
@@ -39,10 +39,6 @@ export const WrapperComponent = ({
   children,
   ...rest
 }: WrapperComponentProps) => {
-  const Component = getComponent(instance.component);
-  if (Component === undefined) {
-    return <></>;
-  }
   const userProps = useUserProps(instance.id);
   const props = {
     ...userProps,
@@ -50,6 +46,10 @@ export const WrapperComponent = ({
     [idAttribute]: instance.id,
     [componentAttribute]: instance.component,
   };
+  const Component = getComponent(instance.component);
+  if (Component === undefined) {
+    return <></>;
+  }
   return (
     <Component {...props}>{renderWrapperComponentChildren(children)}</Component>
   );


### PR DESCRIPTION
We want to decouple schema stored in db from sdk which generates a list of components. Components will be added dynamically later so better avoid component name enum.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
