### PR TITLE
Migrate designer to normalized props

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -27,9 +27,11 @@ import {
   rootInstanceContainer,
   selectedInstanceStore,
   useBreakpoints,
+  useInstanceProps,
   useRootInstance,
   useSetBreakpoints,
   useSetDesignTokens,
+  useSetProps,
   useSetRootInstance,
   useSetStyles,
   useSubscribeScrollState,
@@ -95,13 +97,17 @@ const useAssets = (initialAssets: Array<Asset>) => {
 };
 
 const useCopyPaste = () => {
-  const instance = useStore(selectedInstanceStore);
-  const allUserProps = useAllUserProps();
+  const selectedInstance = useStore(selectedInstanceStore);
+  const instanceProps = useInstanceProps(selectedInstance?.id);
 
-  const selectedInstanceData = useMemo(
-    () => instance && { instance, props: allUserProps[instance.id] },
-    [allUserProps, instance]
-  );
+  const selectedInstanceData = useMemo(() => {
+    if (selectedInstance) {
+      return {
+        instance: selectedInstance,
+        props: instanceProps,
+      };
+    }
+  }, [selectedInstance, instanceProps]);
 
   // We need to initialize this in both canvas and designer,
   // because the events will fire in either one, depending on where the focus is
@@ -150,6 +156,7 @@ export const Canvas = ({ data }: CanvasProps): JSX.Element | null => {
   useSetBreakpoints(data.breakpoints);
   useSetDesignTokens(data.designTokens);
   useAllUserProps(data.props);
+  useSetProps(data.tree.props);
   useSetStyles(data.tree.styles);
   useSetRootInstance(data.tree.root);
   setParams(data.params ?? null);

--- a/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
@@ -8,12 +8,12 @@ import {
   renderWrapperComponentChildren,
   getComponent,
   idAttribute,
-  useAllUserProps,
 } from "@webstudio-is/react-sdk";
 import { shallowComputed } from "~/shared/store-utils";
 import {
   selectedInstanceIdStore,
   stylesIndexStore,
+  useInstanceProps,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
 import { useCssRules } from "~/canvas/shared/styles";
@@ -70,8 +70,7 @@ export const WrapperComponentDev = ({
     useTextEditingInstanceId();
   const selectedInstanceId = useStore(selectedInstanceIdStore);
 
-  const allUserProps = useAllUserProps();
-  const instanceProps = allUserProps[instance.id];
+  const instanceProps = useInstanceProps(instance.id);
   const userProps = useMemo(() => {
     const result: UserProps = {};
     if (instanceProps === undefined) {

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -6,7 +6,7 @@ import {
   type Project,
   utils as projectUtils,
 } from "@webstudio-is/project";
-import { Box, type CSS, Flex, Grid } from "@webstudio-is/design-system";
+import { theme, Box, type CSS, Flex, Grid } from "@webstudio-is/design-system";
 import { registerContainers, useDesignerStore } from "~/shared/sync";
 import { useSyncServer } from "./shared/sync-server";
 // eslint-disable-next-line import/no-internal-modules
@@ -31,6 +31,7 @@ import { usePublishShortcuts } from "./shared/shortcuts";
 import {
   selectedInstanceStore,
   useDragAndDropState,
+  useInstanceProps,
   useIsPreviewMode,
 } from "~/shared/nano-states";
 import { useClientSettings } from "./shared/client-settings";
@@ -38,8 +39,6 @@ import { Navigator } from "./features/sidebar-left";
 import { getBuildUrl } from "~/shared/router-utils";
 import { useInstanceCopyPaste } from "~/shared/copy-paste";
 import { AssetsProvider, usePublishAssets } from "./shared/assets";
-import { useAllUserProps } from "@webstudio-is/react-sdk";
-import { theme } from "@webstudio-is/design-system";
 
 registerContainers();
 export const links = () => {
@@ -85,16 +84,16 @@ const useSubscribeCanvasReady = (publish: Publish) => {
 
 const useCopyPaste = (publish: Publish) => {
   const selectedInstance = useStore(selectedInstanceStore);
-  const allUserProps = useAllUserProps();
+  const instanceProps = useInstanceProps(selectedInstance?.id);
 
   const selectedInstanceData = useMemo(() => {
     if (selectedInstance) {
       return {
         instance: selectedInstance,
-        props: allUserProps[selectedInstance.id] ?? [],
+        props: instanceProps,
       };
     }
-  }, [selectedInstance, allUserProps]);
+  }, [selectedInstance, instanceProps]);
 
   // We need to initialize this in both canvas and designer,
   // because the events will fire in either one, depending on where the focus is

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -5,6 +5,7 @@ import { allUserPropsContainer } from "@webstudio-is/react-sdk";
 import { type Publish, subscribe } from "~/shared/pubsub";
 import {
   rootInstanceContainer,
+  propsStore,
   breakpointsContainer,
   designTokensContainer,
   stylesContainer,
@@ -44,6 +45,7 @@ export const registerContainers = () => {
   store.register("root", rootInstanceContainer);
   store.register("styles", stylesContainer);
   store.register("props", allUserPropsContainer);
+  store.register("props-modern", propsStore);
   store.register("designTokens", designTokensContainer);
   // synchronize whole states
   clientStores.set("selectedInstanceId", selectedInstanceIdStore);


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/696

Here added normalized props logic to transactions and replaced useAllUserProps with computed store.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
