### PR TITLE
Fix props with assets loading

### DIFF
--- a/packages/project/src/db/props.ts
+++ b/packages/project/src/db/props.ts
@@ -1,31 +1,29 @@
 import warnOnce from "warn-once";
-import { type Tree, StoredProps } from "@webstudio-is/project-build";
+import { type Tree, StoredProps, Props } from "@webstudio-is/project-build";
 import { type AllUserProps, type InstanceProps } from "@webstudio-is/react-sdk";
 import { applyPatches, type Patch } from "immer";
 import { prisma } from "@webstudio-is/prisma-client";
 import { formatAsset } from "@webstudio-is/asset-uploader/server";
 
-export const loadByTreeId = async (treeId: Tree["id"]) => {
-  const tree = await prisma.tree.findUnique({
-    where: { id: treeId },
-  });
-
-  if (tree === null) {
-    return [];
+export const parseProps = async (propsString: string) => {
+  let storedProps;
+  try {
+    storedProps = StoredProps.parse(JSON.parse(propsString));
+  } catch (e) {
+    console.log("hello", propsString);
+    throw e;
   }
 
-  const props = StoredProps.parse(JSON.parse(tree.props));
-
-  // Fin all assetId in all props
+  // find all asset ids in all props
   const assetIds: string[] = [];
 
-  for (const propsItem of props) {
-    if (propsItem.type === "asset") {
-      assetIds.push(propsItem.value);
+  for (const prop of storedProps) {
+    if (prop.type === "asset") {
+      assetIds.push(prop.value);
     }
   }
 
-  // Load all assets
+  // load all assets
   const assets = await prisma.asset.findMany({
     where: {
       id: {
@@ -38,8 +36,47 @@ export const loadByTreeId = async (treeId: Tree["id"]) => {
     assets.map((asset) => [asset.id, formatAsset(asset)])
   );
 
-  const instancePropsMap = new Map<string, InstanceProps>();
+  const props: Props = [];
+  for (const prop of storedProps) {
+    if (prop.type === "asset") {
+      const assetId = prop.value;
+      const asset = assetsMap.get(assetId);
 
+      if (asset) {
+        props.push({
+          id: prop.id,
+          instanceId: prop.instanceId,
+          name: prop.name,
+          required: prop.required,
+          type: prop.type,
+          value: asset,
+        });
+
+        continue;
+      }
+
+      warnOnce(true, `Asset with assetId "${assetId}" not found`);
+      continue;
+    }
+
+    props.push(prop);
+  }
+
+  return props;
+};
+
+export const loadByTreeId = async (treeId: Tree["id"]) => {
+  const tree = await prisma.tree.findUnique({
+    where: { id: treeId },
+  });
+
+  if (tree === null) {
+    return [];
+  }
+
+  const props = await parseProps(tree.props);
+
+  const instancePropsMap = new Map<string, InstanceProps>();
   for (const propsItem of props) {
     let instanceProps = instancePropsMap.get(propsItem.instanceId);
     if (instanceProps === undefined) {
@@ -51,32 +88,29 @@ export const loadByTreeId = async (treeId: Tree["id"]) => {
       };
       instancePropsMap.set(propsItem.instanceId, instanceProps);
     }
-
-    if (propsItem.type === "asset") {
-      const assetId = propsItem.value;
-      const asset = assetsMap.get(assetId);
-
-      if (asset) {
-        instanceProps.props.push({
-          id: propsItem.id,
-          instanceId: propsItem.instanceId,
-          name: propsItem.name,
-          required: propsItem.required,
-          type: propsItem.type,
-          value: asset,
-        });
-
-        continue;
-      }
-
-      warnOnce(true, `Asset with assetId "${assetId}" not found`);
-      continue;
-    }
-
     instanceProps.props.push(propsItem);
   }
 
   return Array.from(instancePropsMap.values());
+};
+
+export const serializeProps = (props: Props) => {
+  const storedProps: StoredProps = [];
+  for (const prop of props) {
+    if (prop.type === "asset") {
+      storedProps.push({
+        id: prop.id,
+        instanceId: prop.instanceId,
+        name: prop.name,
+        required: prop.required,
+        type: prop.type,
+        value: prop.value.id,
+      });
+      continue;
+    }
+    storedProps.push(prop);
+  }
+  return JSON.stringify(storedProps);
 };
 
 export const patch = async (
@@ -97,27 +131,11 @@ export const patch = async (
     patches
   );
 
-  const props: StoredProps = [];
-  for (const [instanceId, instanceProps] of Object.entries(nextProps)) {
-    for (const propsItem of instanceProps) {
-      if (propsItem.type === "asset") {
-        props.push({
-          id: propsItem.id,
-          instanceId,
-          name: propsItem.name,
-          required: propsItem.required,
-          type: propsItem.type,
-          value: propsItem.value.id,
-        });
-        continue;
-      }
-      props.push(propsItem);
-    }
-  }
+  const props: Props = Object.values(nextProps).flat();
 
   await prisma.tree.update({
     data: {
-      props: JSON.stringify(props),
+      props: serializeProps(props),
     },
     where: { id: treeId },
   });

--- a/packages/project/src/db/props.ts
+++ b/packages/project/src/db/props.ts
@@ -6,13 +6,7 @@ import { prisma } from "@webstudio-is/prisma-client";
 import { formatAsset } from "@webstudio-is/asset-uploader/server";
 
 export const parseProps = async (propsString: string) => {
-  let storedProps;
-  try {
-    storedProps = StoredProps.parse(JSON.parse(propsString));
-  } catch (e) {
-    console.log("hello", propsString);
-    throw e;
-  }
+  const storedProps = StoredProps.parse(JSON.parse(propsString));
 
   // find all asset ids in all props
   const assetIds: string[] = [];

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -4,9 +4,9 @@ import {
   type Tree,
   type InstancesItem,
   Instance,
-  Styles,
   Instances,
-  Props,
+  type Styles,
+  type Props,
 } from "@webstudio-is/project-build";
 import {
   prisma,
@@ -15,6 +15,7 @@ import {
 } from "@webstudio-is/prisma-client";
 import { utils } from "../index";
 import { parseStyles, serializeStyles } from "./styles";
+import { parseProps, serializeProps } from "./props";
 
 type TreeData = Omit<Tree, "id">;
 
@@ -62,7 +63,7 @@ export const create = async (
     data: {
       root: "",
       instances: JSON.stringify(instances),
-      props: JSON.stringify(treeData.props),
+      props: serializeProps(treeData.props),
       styles: serializeStyles(treeData.styles),
     },
   });
@@ -111,7 +112,7 @@ export const loadById = async (
   const instances = Instances.parse(JSON.parse(tree.instances));
   const root = Instance.parse(denormalizeTree(instances));
 
-  const props = Props.parse(JSON.parse(tree.props));
+  const props = await parseProps(tree.props);
   const styles = await parseStyles(tree.styles);
 
   return {


### PR DESCRIPTION
Db data with asset ids was parsed as client data with resolved assets. Fixed by reusing props parsing/serializing logic in tree.

Asset inlining complicates code so we need to have two versions of types and transformations.

## Code Review

- [ ] hi @kof, I need you to do
  - test it on preview
- [ ] hi @kof, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
