### PR TITLE
Fix copy paste of props and styles

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -30,6 +30,7 @@ import {
   selectedInstanceStore,
   useBreakpoints,
   useInstanceProps,
+  useInstanceStyles,
   useRootInstance,
   useSetBreakpoints,
   useSetDesignTokens,
@@ -101,15 +102,17 @@ const useAssets = (initialAssets: Array<Asset>) => {
 const useCopyPaste = () => {
   const selectedInstance = useStore(selectedInstanceStore);
   const instanceProps = useInstanceProps(selectedInstance?.id);
+  const instanceStyles = useInstanceStyles(selectedInstance?.id);
 
   const selectedInstanceData = useMemo(() => {
     if (selectedInstance) {
       return {
         instance: selectedInstance,
         props: instanceProps,
+        styles: instanceStyles,
       };
     }
-  }, [selectedInstance, instanceProps]);
+  }, [selectedInstance, instanceProps, instanceStyles]);
 
   // We need to initialize this in both canvas and designer,
   // because the events will fire in either one, depending on where the focus is
@@ -119,10 +122,10 @@ const useCopyPaste = () => {
     onCut: (instance) => {
       publish({ type: "deleteInstance", payload: { id: instance.id } });
     },
-    onPaste: (instance, props) => {
+    onPaste: ({ instance, props, styles }) => {
       publish({
         type: "insertInstance",
-        payload: { instance, props },
+        payload: { instance, props, styles },
       });
     },
   });

--- a/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
@@ -9,11 +9,10 @@ import {
   getComponent,
   idAttribute,
 } from "@webstudio-is/react-sdk";
-import { shallowComputed } from "~/shared/store-utils";
 import {
   selectedInstanceIdStore,
-  stylesIndexStore,
   useInstanceProps,
+  useInstanceStyles,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
 import { useCssRules } from "~/canvas/shared/styles";
@@ -57,13 +56,7 @@ export const WrapperComponentDev = ({
 }: WrapperComponentDevProps) => {
   const instanceId = instance.id;
 
-  const instanceStylesStore = useMemo(() => {
-    return shallowComputed(
-      [stylesIndexStore],
-      (stylesIndex) => stylesIndex.stylesByInstanceId.get(instanceId) ?? []
-    );
-  }, [instanceId]);
-  const instanceStyles = useStore(instanceStylesStore);
+  const instanceStyles = useInstanceStyles(instanceId);
   useCssRules({ instanceId: instance.id, instanceStyles });
 
   const [editingInstanceId, setTextEditingInstanceId] =

--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import store from "immerhin";
-import type { Instance, PropsItem } from "@webstudio-is/project-build";
+import type { Instance, Props, Styles } from "@webstudio-is/project-build";
 import { getComponentMeta } from "@webstudio-is/react-sdk";
 import { utils, type InstanceInsertionSpec } from "@webstudio-is/project";
 import { useSubscribe } from "~/shared/pubsub";
@@ -8,6 +8,7 @@ import {
   propsStore,
   rootInstanceContainer,
   selectedInstanceIdStore,
+  stylesContainer,
   useRootInstance,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
@@ -19,7 +20,8 @@ declare module "~/shared/pubsub" {
     insertInstance: {
       instance: Instance;
       dropTarget?: { parentId: Instance["id"]; position: number };
-      props?: Array<PropsItem>;
+      props?: Props;
+      styles?: Styles;
     };
   }
 }
@@ -57,11 +59,16 @@ export const findInsertLocation = (
 export const useInsertInstance = () => {
   useSubscribe(
     "insertInstance",
-    ({ instance, dropTarget, props: insertedProps }) => {
+    ({
+      instance,
+      dropTarget,
+      props: insertedProps,
+      styles: insertedStyles,
+    }) => {
       const selectedInstanceId = selectedInstanceIdStore.get();
       store.createTransaction(
-        [rootInstanceContainer, propsStore],
-        (rootInstance, props) => {
+        [rootInstanceContainer, propsStore, stylesContainer],
+        (rootInstance, props, styles) => {
           if (rootInstance === undefined) {
             return;
           }
@@ -75,6 +82,9 @@ export const useInsertInstance = () => {
           }
           if (insertedProps !== undefined) {
             props.push(...insertedProps);
+          }
+          if (insertedStyles !== undefined) {
+            styles.push(...insertedStyles);
           }
         }
       );

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -32,6 +32,7 @@ import {
   selectedInstanceStore,
   useDragAndDropState,
   useInstanceProps,
+  useInstanceStyles,
   useIsPreviewMode,
 } from "~/shared/nano-states";
 import { useClientSettings } from "./shared/client-settings";
@@ -85,15 +86,17 @@ const useSubscribeCanvasReady = (publish: Publish) => {
 const useCopyPaste = (publish: Publish) => {
   const selectedInstance = useStore(selectedInstanceStore);
   const instanceProps = useInstanceProps(selectedInstance?.id);
+  const instanceStyles = useInstanceStyles(selectedInstance?.id);
 
   const selectedInstanceData = useMemo(() => {
     if (selectedInstance) {
       return {
         instance: selectedInstance,
         props: instanceProps,
+        styles: instanceStyles,
       };
     }
-  }, [selectedInstance, instanceProps]);
+  }, [selectedInstance, instanceProps, instanceStyles]);
 
   // We need to initialize this in both canvas and designer,
   // because the events will fire in either one, depending on where the focus is
@@ -102,10 +105,10 @@ const useCopyPaste = (publish: Publish) => {
     onCut: (instance) => {
       publish({ type: "deleteInstance", payload: { id: instance.id } });
     },
-    onPaste: (instance, props) => {
+    onPaste: ({ instance, props, styles }) => {
       publish({
         type: "insertInstance",
-        payload: { instance, props },
+        payload: { instance, props, styles },
       });
     },
   });

--- a/apps/designer/app/shared/copy-paste/serialize.ts
+++ b/apps/designer/app/shared/copy-paste/serialize.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
-import { Instance, Props } from "@webstudio-is/project-build";
+import { Instance, Props, Styles } from "@webstudio-is/project-build";
 
 const TYPE = "@webstudio/instance/v0.1" as const;
 
 const InstanceCopyData = z.object({
   instance: Instance,
-  props: Props.optional(),
+  props: Props,
+  styles: Styles,
 });
 
 export type InstanceCopyData = z.infer<typeof InstanceCopyData>;

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -110,6 +110,18 @@ export const useSetStyles = (styles: Styles) => {
     stylesContainer.set(styles);
   });
 };
+export const useInstanceStyles = (instanceId: undefined | Instance["id"]) => {
+  const instanceStylesStore = useMemo(() => {
+    return shallowComputed([stylesIndexStore], (stylesIndex) => {
+      if (instanceId === undefined) {
+        return [];
+      }
+      return stylesIndex.stylesByInstanceId.get(instanceId) ?? [];
+    });
+  }, [instanceId]);
+  const instanceStyles = useStore(instanceStylesStore);
+  return instanceStyles;
+};
 
 export const breakpointsContainer = atom<Breakpoint[]>([]);
 export const useBreakpoints = () => useValue(breakpointsContainer);

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -1,13 +1,11 @@
 import * as breakpointsUtils from "./shared/breakpoints";
 import * as treeUtils from "./shared/tree-utils";
 import * as pagesUtils from "./shared/pages";
-import * as propsUtils from "./shared/props";
 
 export const utils = {
   breakpoints: breakpointsUtils,
   tree: treeUtils,
   pages: pagesUtils,
-  props: propsUtils,
 } as const;
 
 export * from "./shared/styles";

--- a/packages/project/src/shared/props/clone-user-props.ts
+++ b/packages/project/src/shared/props/clone-user-props.ts
@@ -1,5 +1,0 @@
-import ObjectId from "bson-objectid";
-import type { PropsItem } from "@webstudio-is/project-build";
-
-export const cloneUserProps = (props: Array<PropsItem>): Array<PropsItem> =>
-  props.map((prop) => ({ ...prop, id: ObjectId().toString() }));

--- a/packages/project/src/shared/props/index.ts
+++ b/packages/project/src/shared/props/index.ts
@@ -1,1 +1,0 @@
-export * from "./clone-user-props";


### PR DESCRIPTION
Copy/paste of props and styles was broken while converting to normalized data. Here fixed both by providing new instanceId.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
