### PR TITLE
Delete instance styles and props

### DIFF
--- a/apps/designer/app/shared/tree-utils.test.ts
+++ b/apps/designer/app/shared/tree-utils.test.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "@jest/globals";
+import type { Instance, Props, Styles } from "@webstudio-is/project-build";
+import { deleteInstanceMutable } from "./tree-utils";
+
+const createInstance = (id: string, children: Instance[]): Instance => {
+  return {
+    type: "instance",
+    id,
+    component: "Box",
+    children: children,
+  };
+};
+
+const createProp = (id: string, instanceId: string): Props[number] => {
+  return {
+    type: "string",
+    id,
+    instanceId,
+    name: "prop",
+    value: "value",
+  };
+};
+
+const createStyleDecl = (instanceId: string): Styles[number] => {
+  return {
+    breakpointId: "breakpoint",
+    instanceId,
+    property: "width",
+    value: {
+      type: "keyword",
+      value: "keyword",
+    },
+  };
+};
+
+test("delete instance with own and descendants styles and props", () => {
+  const rootInstance: Instance = createInstance("root", [
+    createInstance("box1", []),
+    createInstance("box2", [
+      createInstance("box3", [
+        createInstance("child1", []),
+        createInstance("child2", [createInstance("descendant", [])]),
+        createInstance("child3", []),
+      ]),
+    ]),
+    createInstance("box4", []),
+  ]);
+  const props: Props = [
+    createProp("1", "root"),
+    createProp("2", "box1"),
+    createProp("3", "box2"),
+    createProp("4", "box3"),
+    createProp("7", "child3"),
+    createProp("6", "child2"),
+    createProp("5", "child1"),
+    createProp("8", "descendant"),
+    createProp("9", "box4"),
+  ];
+  const styles: Styles = [
+    createStyleDecl("root"),
+    createStyleDecl("box1"),
+    createStyleDecl("box2"),
+    createStyleDecl("box3"),
+    createStyleDecl("child3"),
+    createStyleDecl("child2"),
+    createStyleDecl("child1"),
+    createStyleDecl("descendant"),
+    createStyleDecl("box4"),
+  ];
+
+  deleteInstanceMutable({
+    rootInstance,
+    props,
+    styles,
+    deletedInstanceId: "box3",
+  });
+
+  expect(rootInstance).toEqual(
+    createInstance("root", [
+      createInstance("box1", []),
+      createInstance("box2", []),
+      createInstance("box4", []),
+    ])
+  );
+  expect(props).toEqual([
+    createProp("1", "root"),
+    createProp("2", "box1"),
+    createProp("3", "box2"),
+    createProp("9", "box4"),
+  ]);
+  expect(styles).toEqual([
+    createStyleDecl("root"),
+    createStyleDecl("box1"),
+    createStyleDecl("box2"),
+    createStyleDecl("box4"),
+  ]);
+});

--- a/apps/designer/app/shared/tree-utils.ts
+++ b/apps/designer/app/shared/tree-utils.ts
@@ -1,0 +1,61 @@
+import type { Instance, Props, Styles } from "@webstudio-is/project-build";
+import { removeByMutable } from "./array-utils";
+
+const traverseInstances = (
+  instance: Instance,
+  cb: (child: Instance, parent: Instance) => void
+) => {
+  for (const child of instance.children) {
+    if (child.type === "text") {
+      continue;
+    }
+    if (child.type === "instance") {
+      cb(child, instance);
+      traverseInstances(child, cb);
+    }
+  }
+};
+
+export const deleteInstanceMutable = ({
+  rootInstance,
+  props,
+  styles,
+  deletedInstanceId,
+}: {
+  rootInstance: Instance;
+  props: Props;
+  styles: Styles;
+  deletedInstanceId: string;
+}) => {
+  const parentInstances = new Map<Instance["id"], Instance>();
+  const deletedInstances = new Set<Instance["id"]>();
+
+  traverseInstances(rootInstance, (child, instance) => {
+    parentInstances.set(child.id, instance);
+    // mark as deleted the instance
+    if (child.id === deletedInstanceId) {
+      deletedInstances.add(child.id);
+    }
+    // and all descendants of deleted instance
+    if (deletedInstances.has(instance.id)) {
+      deletedInstances.add(child.id);
+    }
+  });
+
+  const parentInstance = parentInstances.get(deletedInstanceId);
+  if (parentInstance === undefined) {
+    return;
+  }
+
+  removeByMutable(
+    parentInstance.children,
+    (child) => child.type === "instance" && child.id === deletedInstanceId
+  );
+  // delete props and styles of deleted instance and its descendants
+  removeByMutable(props, (prop) => deletedInstances.has(prop.instanceId));
+  removeByMutable(styles, (styleDecl) =>
+    deletedInstances.has(styleDecl.instanceId)
+  );
+
+  return parentInstance;
+};


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/828

Delete instance along with own and descendants styles and props.
This will let us to avoid bloating db with unused data.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
