### PR TITLE
Fix undo/redo when input is focused

### DIFF
--- a/apps/designer/app/canvas/shared/use-shortcuts.ts
+++ b/apps/designer/app/canvas/shared/use-shortcuts.ts
@@ -23,8 +23,6 @@ declare module "~/shared/pubsub" {
   }
 }
 
-const inputTags = ["INPUT", "SELECT", "TEXTAREA"] as const;
-
 type HandlerEvent = {
   key?: string;
   preventDefault?: () => void;
@@ -94,12 +92,9 @@ export const useShortcuts = () => {
     esc: publishCancelCurrentDrag,
   } as const;
 
-  useHotkeys(
-    "backspace, delete",
+  useHotkeys("backspace, delete", shortcutHandlerMap.delete, options, [
     shortcutHandlerMap.delete,
-    { ...options, enableOnTags: [...inputTags] },
-    [shortcutHandlerMap.delete]
-  );
+  ]);
 
   useHotkeys(
     "esc",
@@ -115,7 +110,7 @@ export const useShortcuts = () => {
       }
       selectedInstanceIdStore.set(undefined);
     },
-    { ...options, enableOnContentEditable: true, enableOnTags: [...inputTags] },
+    { ...options, enableOnContentEditable: true },
     [editingInstanceId]
   );
 

--- a/apps/designer/app/shared/shortcuts/shortcuts.ts
+++ b/apps/designer/app/shared/shortcuts/shortcuts.ts
@@ -1,3 +1,5 @@
+import type { Options } from "react-hotkeys-hook";
+
 export const shortcuts = {
   esc: "esc",
   undo: "cmd+z, ctrl+z",
@@ -11,4 +13,8 @@ export const shortcuts = {
   zoom: "=, -",
 } as const;
 
-export const options = { splitKey: "+", keydown: true };
+export const options: Options = {
+  splitKey: "+",
+  keydown: true,
+  enableOnTags: ["INPUT", "SELECT", "TEXTAREA"],
+};


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/755

react-hotkeys by default prevents reacting when native elements are focused. Here I globally enabled input, select and textarea for both designer and canvas to catch undo/redo while focused.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
