### PR TITLE
Drop unused schema

### DIFF
--- a/packages/prisma-client/prisma/migrations/20230129141714_unused_schema/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230129141714_unused_schema/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "DesignTokens" DROP CONSTRAINT "DesignTokens_buildId_fkey";
+
+-- AlterTable
+ALTER TABLE "Tree" DROP COLUMN "presetStyles";
+
+-- DropTable
+DROP TABLE "DesignTokens";
+
+-- DropTable
+DROP TABLE "InstanceProps";

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -84,18 +84,8 @@ model Tree {
   root            String
   instances       String @default("[]")
   props           String @default("[]")
-  presetStyles    String @default("[]")
   styles          String @default("[]")
   styleSelections String @default("[]")
-}
-
-model InstanceProps {
-  id         String @id @default(uuid())
-  instanceId String
-  treeId     String
-  props      String @default("[]")
-
-  @@unique([instanceId, treeId])
 }
 
 model Breakpoints {

--- a/packages/prisma-client/src/types.ts
+++ b/packages/prisma-client/src/types.ts
@@ -1,6 +1,5 @@
 export { Location } from "@prisma/client";
 export type {
-  InstanceProps,
   User,
   Breakpoints,
   Build,


### PR DESCRIPTION
DesignTokens was removed from schema but without migration. Removed everything else unused too.

- Tree.presetStyles
- InstanceProps
- DesignTokens

## Code Review

- [ ] hi @kof, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
