### PR TITLE
Support multiple style sources in preview

### DIFF
--- a/apps/designer/app/shared/css-utils/generate-css-text.ts
+++ b/apps/designer/app/shared/css-utils/generate-css-text.ts
@@ -49,7 +49,10 @@ export const generateCssText = async (
     }
   }
 
-  const styleRules = getStyleRules(canvasData.tree?.styles);
+  const styleRules = getStyleRules(
+    canvasData.build?.styles,
+    canvasData.tree?.styleSourceSelections
+  );
   for (const { breakpointId, instanceId, style } of styleRules) {
     engine.addStyleRule(`[${idAttribute}="${instanceId}"]`, {
       breakpoint: breakpointId,

--- a/apps/designer/app/shared/db/canvas.server.ts
+++ b/apps/designer/app/shared/db/canvas.server.ts
@@ -38,6 +38,7 @@ export const loadCanvasData = async (
   }
 
   return {
+    build,
     tree,
     breakpoints: breakpoints.values,
     buildId: build.id,

--- a/packages/project-build/src/schema/styles.ts
+++ b/packages/project-build/src/schema/styles.ts
@@ -25,8 +25,8 @@ export const StoredStyles = z.array(StoredStylesItem);
 export type StoredStyles = z.infer<typeof StoredStyles>;
 
 export const StylesItem = z.object({
-  breakpointId: z.string(),
   instanceId: z.string(),
+  breakpointId: z.string(),
   // @todo can't figure out how to make property to be enum
   property: z.string() as z.ZodType<StyleProperty>,
   value: z.union([ImageValue, SharedStyleValue]),
@@ -37,3 +37,17 @@ export type StylesItem = z.infer<typeof StylesItem>;
 export const Styles = z.array(StylesItem);
 
 export type Styles = z.infer<typeof Styles>;
+
+export const NewStylesItem = z.object({
+  styleSourceId: z.string(),
+  breakpointId: z.string(),
+  // @todo can't figure out how to make property to be enum
+  property: z.string() as z.ZodType<StyleProperty>,
+  value: z.union([ImageValue, SharedStyleValue]),
+});
+
+export type NewStylesItem = z.infer<typeof NewStylesItem>;
+
+export const NewStyles = z.array(NewStylesItem);
+
+export type NewStyles = z.infer<typeof NewStyles>;

--- a/packages/project-build/src/types.ts
+++ b/packages/project-build/src/types.ts
@@ -1,5 +1,6 @@
 import type { Instance } from "./schema/instances";
 import type { Props } from "./schema/props";
+import type { StyleSourceSelections } from "./schema/style-sources";
 import type { Styles } from "./schema/styles";
 
 export type Tree = {
@@ -9,4 +10,5 @@ export type Tree = {
   root: Instance;
   props: Props;
   styles: Styles;
+  styleSourceSelections: StyleSourceSelections;
 };

--- a/packages/project/src/db/build.ts
+++ b/packages/project/src/db/build.ts
@@ -15,6 +15,7 @@ export const parseBuild = async (build: DbBuild): Promise<Build> => {
   const pages = Pages.parse(JSON.parse(build.pages));
   return {
     ...build,
+    createdAt: build.createdAt.toISOString(),
     pages,
     styles: await parseNewStyles(build.styles),
     styleSources: StyleSources.parse(JSON.parse(build.styleSources)),

--- a/packages/project/src/db/build.ts
+++ b/packages/project/src/db/build.ts
@@ -5,13 +5,20 @@ import {
   Prisma,
   Project,
 } from "@webstudio-is/prisma-client";
+import { StyleSources } from "@webstudio-is/project-build";
 import * as db from ".";
 import { Build, Page, Pages } from "./schema";
 import * as pagesUtils from "../shared/pages";
+import { parseNewStyles } from "./styles";
 
-export const parseBuild = (build: DbBuild): Build => {
+export const parseBuild = async (build: DbBuild): Promise<Build> => {
   const pages = Pages.parse(JSON.parse(build.pages));
-  return { ...build, pages };
+  return {
+    ...build,
+    pages,
+    styles: await parseNewStyles(build.styles),
+    styleSources: StyleSources.parse(JSON.parse(build.styleSources)),
+  };
 };
 
 export const loadById = async (id: Build["id"]): Promise<Build> => {

--- a/packages/project/src/db/schema.ts
+++ b/packages/project/src/db/schema.ts
@@ -74,7 +74,7 @@ export type Pages = z.infer<typeof Pages>;
 export type Build = {
   id: string;
   projectId: string;
-  createdAt: Date;
+  createdAt: string;
   isDev: boolean;
   isProd: boolean;
   pages: Pages;

--- a/packages/project/src/db/schema.ts
+++ b/packages/project/src/db/schema.ts
@@ -1,5 +1,6 @@
 import { z, type ZodType } from "zod";
-import { Project, Build as DbBuild } from "@webstudio-is/prisma-client";
+import { Project } from "@webstudio-is/prisma-client";
+import type { NewStyles, StyleSources } from "@webstudio-is/project-build";
 import type { Data } from "@webstudio-is/react-sdk";
 
 export type { Project };
@@ -70,6 +71,19 @@ export const Pages: z.ZodType<{ homePage: Page; pages: Array<Page> }> =
   });
 export type Pages = z.infer<typeof Pages>;
 
-export type Build = Omit<DbBuild, "pages"> & { pages: Pages };
+export type Build = {
+  id: string;
+  projectId: string;
+  createdAt: Date;
+  isDev: boolean;
+  isProd: boolean;
+  pages: Pages;
+  styles: NewStyles;
+  styleSources: StyleSources;
+};
 
-export type CanvasData = Data & { buildId: Build["id"]; page: Page };
+export type CanvasData = Data & {
+  build: null | Build;
+  buildId: Build["id"];
+  page: Page;
+};

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -6,8 +6,6 @@ import {
   type InstancesItem,
   Instance,
   Instances,
-  type Styles,
-  type Props,
   StyleSourceSelections,
   StyleSources,
   StoredStyles,
@@ -50,17 +48,16 @@ export const createTree = ({
   buildId: string;
 }): TreeData => {
   const root = utils.tree.createInstance({ component: "Body" });
-  const styles: Styles = [];
   const instances: Instances = [];
   normalizeTree(root, instances);
-  const props: Props = [];
 
   return {
     projectId,
     buildId,
     root,
-    props,
-    styles,
+    props: [],
+    styles: [],
+    styleSourceSelections: [],
   };
 };
 
@@ -177,11 +174,16 @@ export const loadById = async (
     tree.styleSelections
   );
 
+  const styleSourceSelections = StyleSourceSelections.parse(
+    JSON.parse(tree.styleSelections)
+  );
+
   return {
     ...tree,
     root,
     props,
     styles,
+    styleSourceSelections,
   };
 };
 

--- a/packages/project/src/shared/styles/style-rules.test.ts
+++ b/packages/project/src/shared/styles/style-rules.test.ts
@@ -1,34 +1,75 @@
 import { test, expect } from "@jest/globals";
-import type { Styles } from "@webstudio-is/project-build";
+import type {
+  NewStyles,
+  StyleSourceSelections,
+} from "@webstudio-is/project-build";
 import { getStyleRules } from "./style-rules";
 
-test("get a list of style rules grouped by instance and breakpoint", () => {
-  const styles: Styles = [
+test("compute styles from different style sources", () => {
+  const styles: NewStyles = [
     {
       breakpointId: "a",
-      instanceId: "1",
+      styleSourceId: "styleSource1",
       property: "width",
       value: { type: "unit", value: 10, unit: "px" },
     },
     {
       breakpointId: "a",
-      instanceId: "2",
+      styleSourceId: "styleSource2",
       property: "display",
       value: { type: "keyword", value: "block" },
     },
     {
       breakpointId: "a",
-      instanceId: "3",
+      styleSourceId: "styleSource4",
+      property: "color",
+      value: { type: "keyword", value: "green" },
+    },
+    {
+      breakpointId: "a",
+      styleSourceId: "styleSource4",
+      property: "width",
+      value: { type: "keyword", value: "min-content" },
+    },
+    {
+      breakpointId: "a",
+      styleSourceId: "styleSource3",
       property: "color",
       value: { type: "keyword", value: "red" },
     },
+    {
+      breakpointId: "b",
+      styleSourceId: "styleSource5",
+      property: "color",
+      value: { type: "keyword", value: "orange" },
+    },
+    {
+      breakpointId: "a",
+      styleSourceId: "styleSource6",
+      property: "color",
+      value: { type: "keyword", value: "blue" },
+    },
+  ];
+  const styleSourceSelections: StyleSourceSelections = [
+    {
+      instanceId: "instance1",
+      values: ["styleSource1"],
+    },
+    {
+      instanceId: "instance2",
+      values: ["styleSource4", "styleSource5", "styleSource3"],
+    },
+    {
+      instanceId: "instance3",
+      values: ["styleSource6"],
+    },
   ];
 
-  expect(getStyleRules(styles)).toMatchInlineSnapshot(`
+  expect(getStyleRules(styles, styleSourceSelections)).toMatchInlineSnapshot(`
     [
       {
         "breakpointId": "a",
-        "instanceId": "1",
+        "instanceId": "instance1",
         "style": {
           "width": {
             "type": "unit",
@@ -39,21 +80,35 @@ test("get a list of style rules grouped by instance and breakpoint", () => {
       },
       {
         "breakpointId": "a",
-        "instanceId": "2",
+        "instanceId": "instance2",
         "style": {
-          "display": {
+          "color": {
             "type": "keyword",
-            "value": "block",
+            "value": "red",
+          },
+          "width": {
+            "type": "keyword",
+            "value": "min-content",
+          },
+        },
+      },
+      {
+        "breakpointId": "b",
+        "instanceId": "instance2",
+        "style": {
+          "color": {
+            "type": "keyword",
+            "value": "orange",
           },
         },
       },
       {
         "breakpointId": "a",
-        "instanceId": "3",
+        "instanceId": "instance3",
         "style": {
           "color": {
             "type": "keyword",
-            "value": "red",
+            "value": "blue",
           },
         },
       },


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/807

Designer data still rely on legacy style format though here I migrated preview styles to combination of style source selections and styles from build.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
