### PR TITLE
Switch to utils for style management

### DIFF
--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -7,8 +7,8 @@ import { useSubscribe } from "~/shared/pubsub";
 import {
   propsStore,
   rootInstanceContainer,
+  stylesStore,
   selectedInstanceIdStore,
-  stylesContainer,
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
 import { publish } from "~/shared/pubsub";
@@ -67,7 +67,7 @@ export const useInsertInstance = () => {
     }) => {
       const selectedInstanceId = selectedInstanceIdStore.get();
       store.createTransaction(
-        [rootInstanceContainer, propsStore, stylesContainer],
+        [rootInstanceContainer, propsStore, stylesStore],
         (rootInstance, props, styles) => {
           if (rootInstance === undefined) {
             return;
@@ -123,7 +123,7 @@ export const useDeleteInstance = () => {
       return;
     }
     store.createTransaction(
-      [rootInstanceContainer, propsStore, stylesContainer],
+      [rootInstanceContainer, propsStore, stylesStore],
       (rootInstance, props, styles) => {
         if (rootInstance === undefined) {
           return;

--- a/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
+++ b/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
@@ -25,7 +25,7 @@ import {
 import { ConfirmationDialog } from "./confirmation-dialog";
 import {
   breakpointsContainer,
-  stylesContainer,
+  stylesStore,
   useBreakpoints,
 } from "~/shared/nano-states";
 import { utils } from "@webstudio-is/project";
@@ -67,7 +67,7 @@ export const Breakpoints = () => {
       return;
     }
     const [updatedBreakpoints] = store.createTransaction(
-      [breakpointsContainer, stylesContainer],
+      [breakpointsContainer, stylesStore],
       (breakpoints, styles) => {
         removeByMutable(breakpoints, ({ id }) => id === breakpointToDelete.id);
         removeByMutable(

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.test.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.test.ts
@@ -36,7 +36,8 @@ const cascadedBreakpointIds = getCascadedBreakpointIds(
   selectedBreakpointId
 );
 
-const cascadingStyles: Styles = [
+const cascadingStylesByInstanceId = new Map<Instance["id"], Styles>();
+cascadingStylesByInstanceId.set(selectedInstanceId, [
   {
     breakpointId: "1",
     instanceId: selectedInstanceId,
@@ -68,7 +69,7 @@ const cascadingStyles: Styles = [
     property: "width",
     value: { type: "unit", value: 400, unit: "px" },
   },
-];
+]);
 
 const rootInstance: Instance = {
   type: "instance",
@@ -91,7 +92,8 @@ const rootInstance: Instance = {
   ],
 };
 
-const inheritingStyles: Styles = [
+const inheritingStylesByInstanceId = new Map<Instance["id"], Styles>();
+inheritingStylesByInstanceId.set("1", [
   // should be inherited even from another breakpoint
   {
     breakpointId: "1",
@@ -99,7 +101,8 @@ const inheritingStyles: Styles = [
     property: "fontSize",
     value: { type: "unit", value: 20, unit: "px" },
   },
-
+]);
+inheritingStylesByInstanceId.set("2", [
   // should not be inherited because width is not inheritable
   {
     breakpointId: "3",
@@ -114,7 +117,8 @@ const inheritingStyles: Styles = [
     property: "fontWeight",
     value: { type: "keyword", value: "600" },
   },
-
+]);
+inheritingStylesByInstanceId.set("3", [
   // should not show selected style as inherited
   {
     breakpointId: "3",
@@ -122,11 +126,15 @@ const inheritingStyles: Styles = [
     property: "fontWeight",
     value: { type: "keyword", value: "500" },
   },
-];
+]);
 
 test("compute cascaded styles", () => {
   expect(
-    getCascadedInfo(cascadingStyles, selectedInstanceId, cascadedBreakpointIds)
+    getCascadedInfo(
+      cascadingStylesByInstanceId,
+      selectedInstanceId,
+      cascadedBreakpointIds
+    )
   ).toMatchInlineSnapshot(`
     {
       "height": {
@@ -153,7 +161,7 @@ test("compute inherited styles", () => {
   expect(
     getInheritedInfo(
       rootInstance,
-      inheritingStyles,
+      inheritingStylesByInstanceId,
       selectedInstanceId,
       cascadedBreakpointIds,
       selectedBreakpointId

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -77,7 +77,7 @@ export const useInstanceProps = (instanceId: undefined | Instance["id"]) => {
   return instanceProps;
 };
 
-export const stylesContainer = atom<Styles>([]);
+export const stylesStore = atom<Styles>([]);
 /**
  * Indexed styles data is recomputed on every styles update
  * Compumer should use shallow-equal to check all items in the list
@@ -87,7 +87,7 @@ export const stylesContainer = atom<Styles>([]);
  * though will require to move away from running immer patches on array
  * of styles
  */
-export const stylesIndexStore = computed(stylesContainer, (styles) => {
+export const stylesIndexStore = computed(stylesStore, (styles) => {
   const stylesByInstanceId = new Map<Instance["id"], Styles>();
   for (const stylesItem of styles) {
     const { instanceId } = stylesItem;
@@ -103,10 +103,9 @@ export const stylesIndexStore = computed(stylesContainer, (styles) => {
   };
 });
 
-export const useStyles = () => useValue(stylesContainer);
 export const useSetStyles = (styles: Styles) => {
   useSyncInitializeOnce(() => {
-    stylesContainer.set(styles);
+    stylesStore.set(styles);
   });
 };
 export const useInstanceStyles = (instanceId: undefined | Instance["id"]) => {

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -6,7 +6,7 @@ import {
   rootInstanceContainer,
   propsStore,
   breakpointsContainer,
-  stylesContainer,
+  stylesStore,
   selectedInstanceIdStore,
   selectedInstanceBrowserStyleStore,
   hoveredInstanceIdStore,
@@ -41,7 +41,7 @@ export const registerContainers = () => {
   // synchronize patches
   store.register("breakpoints", breakpointsContainer);
   store.register("root", rootInstanceContainer);
-  store.register("styles", stylesContainer);
+  store.register("styles", stylesStore);
   store.register("props", propsStore);
   // synchronize whole states
   clientStores.set("selectedInstanceId", selectedInstanceIdStore);


### PR DESCRIPTION
Replaced manual array manipulations with array utils and reused styles index to compute style info.

This will let to do less work when switch to build styles.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
