### PR TITLE
Add style sources stores

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -32,6 +32,8 @@ import {
   useSetProps,
   useSetRootInstance,
   useSetStyles,
+  useSetStyleSources,
+  useSetStyleSourceSelections,
   useSubscribeScrollState,
 } from "~/shared/nano-states";
 import { usePublishScrollState } from "./shared/use-publish-scroll-state";
@@ -122,6 +124,9 @@ const propsByInstanceIdStore = computed(
 );
 
 export const Canvas = ({ data }: CanvasProps): JSX.Element | null => {
+  if (data.build === null) {
+    throw new Error("Build is null");
+  }
   if (data.tree === null) {
     throw new Error("Tree is null");
   }
@@ -132,6 +137,8 @@ export const Canvas = ({ data }: CanvasProps): JSX.Element | null => {
   // inject props store to sdk
   setPropsByInstanceIdStore(propsByInstanceIdStore);
   useSetStyles(data.tree.styles);
+  useSetStyleSources(data.build.styleSources);
+  useSetStyleSourceSelections(data.tree.styleSourceSelections);
   useSetRootInstance(data.tree.root);
   setParams(data.params ?? null);
   useCanvasStore(publish);

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -344,7 +344,7 @@ export const Designer = ({
           {dragAndDropState.isDragging ? (
             <TreePrevew />
           ) : (
-            <Inspector publish={publish} />
+            <Inspector treeId={treeId} publish={publish} />
           )}
         </SidePanel>
         <Footer />

--- a/apps/designer/app/designer/features/inspector/inspector.tsx
+++ b/apps/designer/app/designer/features/inspector/inspector.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { useStore } from "@nanostores/react";
+import { Tree } from "@webstudio-is/project-build";
 import type { Publish } from "~/shared/pubsub";
 import {
   DeprecatedText2,
@@ -20,6 +21,7 @@ import { theme } from "@webstudio-is/design-system";
 import { selectedInstanceStore } from "~/shared/nano-states";
 
 type InspectorProps = {
+  treeId: Tree["id"];
   publish: Publish;
 };
 
@@ -29,7 +31,7 @@ const contentStyle = {
   overflow: "auto",
 };
 
-export const Inspector = ({ publish }: InspectorProps) => {
+export const Inspector = ({ treeId, publish }: InspectorProps) => {
   const selectedInstance = useStore(selectedInstanceStore);
   const tabsRef = useRef<HTMLDivElement>(null);
 
@@ -69,10 +71,15 @@ export const Inspector = ({ publish }: InspectorProps) => {
             </TabsTrigger>
           </TabsList>
           <TabsContent value="style" css={contentStyle}>
-            <StylePanel publish={publish} selectedInstance={selectedInstance} />
+            <StylePanel
+              treeId={treeId}
+              publish={publish}
+              selectedInstance={selectedInstance}
+            />
           </TabsContent>
           <TabsContent value="props" css={contentStyle}>
             <PropsPanel
+              treeId={treeId}
               publish={publish}
               key={selectedInstance.id /* Re-render when instance changes */}
               selectedInstance={selectedInstance}

--- a/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
@@ -21,6 +21,7 @@ export const NoProps: ComponentStory<typeof PropsPanel> = () => {
   ]);
   return (
     <PropsPanel
+      treeId="treeId"
       selectedInstance={{
         type: "instance",
         id: "1",
@@ -37,6 +38,7 @@ export const RequiredProps: ComponentStory<typeof PropsPanel> = () => {
   propsStore.set([]);
   return (
     <PropsPanel
+      treeId="treeId"
       selectedInstance={{
         type: "instance",
         id: "1",
@@ -53,6 +55,7 @@ export const DefaultProps: ComponentStory<typeof PropsPanel> = () => {
   propsStore.set([]);
   return (
     <PropsPanel
+      treeId="treeId"
       selectedInstance={{
         type: "instance",
         id: "1",
@@ -80,6 +83,7 @@ export const AllProps: ComponentStory<typeof PropsPanel> = () => {
   );
   return (
     <PropsPanel
+      treeId="treeId"
       selectedInstance={{
         type: "instance",
         id: "3",

--- a/apps/designer/app/designer/features/props-panel/props-panel.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import store from "immerhin";
-import type { Instance, PropsItem } from "@webstudio-is/project-build";
+import type { Instance, PropsItem, Tree } from "@webstudio-is/project-build";
 import { getComponentMetaProps } from "@webstudio-is/react-sdk";
 import {
   theme,
@@ -213,11 +213,16 @@ const Property = ({
 };
 
 type PropsPanelProps = {
+  treeId: Tree["id"];
   publish: Publish;
   selectedInstance: Instance;
 };
 
-export const PropsPanel = ({ selectedInstance, publish }: PropsPanelProps) => {
+export const PropsPanel = ({
+  treeId,
+  selectedInstance,
+  publish,
+}: PropsPanelProps) => {
   const instanceId = selectedInstance.id;
   const instanceProps = useInstanceProps(instanceId);
 
@@ -250,6 +255,7 @@ export const PropsPanel = ({ selectedInstance, publish }: PropsPanelProps) => {
   });
 
   const { setProperty: setCssProperty } = useStyleData({
+    treeId,
     selectedInstance,
     publish,
   });

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -1,19 +1,24 @@
 import { useCallback } from "react";
+import ObjectID from "bson-objectid";
 import store from "immerhin";
 import warnOnce from "warn-once";
-import type { Instance } from "@webstudio-is/project-build";
+import type { Instance, Tree } from "@webstudio-is/project-build";
 import type { StyleUpdates } from "@webstudio-is/project";
 import type { StyleProperty, StyleValue } from "@webstudio-is/css-data";
 import { type Publish } from "~/shared/pubsub";
-import { stylesStore } from "~/shared/nano-states";
+import {
+  styleSourceSelectionsStore,
+  styleSourcesStore,
+  stylesStore,
+} from "~/shared/nano-states";
 import { useSelectedBreakpoint } from "~/designer/shared/nano-states";
-// @todo: must be removed, now it's only for compatibility with existing code
-import { parseCssValue } from "./parse-css-value";
-import { useStyleInfo } from "./style-info";
 import {
   removeByMutable,
   replaceByOrAppendMutable,
 } from "~/shared/array-utils";
+// @todo: must be removed, now it's only for compatibility with existing code
+import { parseCssValue } from "./parse-css-value";
+import { useStyleInfo } from "./style-info";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -23,6 +28,7 @@ declare module "~/shared/pubsub" {
 }
 
 type UseStyleData = {
+  treeId: Tree["id"];
   publish: Publish;
   selectedInstance: Instance;
 };
@@ -47,7 +53,11 @@ export type CreateBatchUpdate = () => {
   publish: (options?: StyleUpdateOptions) => void;
 };
 
-export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
+export const useStyleData = ({
+  treeId,
+  selectedInstance,
+  publish,
+}: UseStyleData) => {
   const [selectedBreakpoint] = useSelectedBreakpoint();
 
   const currentStyle = useStyleInfo();
@@ -70,38 +80,59 @@ export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
         return;
       }
 
-      store.createTransaction([stylesStore], (styles) => {
-        const instanceId = selectedInstance.id;
-        const breakpointId = selectedBreakpoint.id;
+      store.createTransaction(
+        [styleSourceSelectionsStore, styleSourcesStore, stylesStore],
+        (styleSourceSelections, styleSources, styles) => {
+          const instanceId = selectedInstance.id;
+          const breakpointId = selectedBreakpoint.id;
 
-        for (const update of updates) {
-          if (update.operation === "set") {
-            replaceByOrAppendMutable(
-              styles,
-              {
-                breakpointId,
-                instanceId,
-                property: update.property,
-                value: update.value,
-              },
-              (item) =>
-                item.instanceId === instanceId &&
-                item.breakpointId === breakpointId &&
-                item.property === update.property
-            );
+          // crate style source and its selection on currently selected instance
+          let matchedStyleSourceSelection = styleSourceSelections.find(
+            (styleSourceSelection) =>
+              styleSourceSelection.instanceId === instanceId
+          );
+          if (matchedStyleSourceSelection === undefined) {
+            const styleSourceId = ObjectID.toString();
+            styleSources.push({
+              type: "local",
+              id: styleSourceId,
+              treeId,
+            });
+            styleSourceSelections.push({
+              instanceId,
+              values: [styleSourceId],
+            });
           }
 
-          if (update.operation === "delete") {
-            removeByMutable(
-              styles,
-              (item) =>
-                item.instanceId === instanceId &&
-                item.breakpointId === breakpointId &&
-                item.property === update.property
-            );
+          for (const update of updates) {
+            if (update.operation === "set") {
+              replaceByOrAppendMutable(
+                styles,
+                {
+                  breakpointId,
+                  instanceId,
+                  property: update.property,
+                  value: update.value,
+                },
+                (item) =>
+                  item.instanceId === instanceId &&
+                  item.breakpointId === breakpointId &&
+                  item.property === update.property
+              );
+            }
+
+            if (update.operation === "delete") {
+              removeByMutable(
+                styles,
+                (item) =>
+                  item.instanceId === instanceId &&
+                  item.breakpointId === breakpointId &&
+                  item.property === update.property
+              );
+            }
           }
         }
-      });
+      );
     },
     [publish, selectedBreakpoint, selectedInstance]
   );

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -87,7 +87,7 @@ export const useStyleData = ({
           const breakpointId = selectedBreakpoint.id;
 
           // crate style source and its selection on currently selected instance
-          let matchedStyleSourceSelection = styleSourceSelections.find(
+          const matchedStyleSourceSelection = styleSourceSelections.find(
             (styleSourceSelection) =>
               styleSourceSelection.instanceId === instanceId
           );

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -134,7 +134,7 @@ export const useStyleData = ({
         }
       );
     },
-    [publish, selectedBreakpoint, selectedInstance]
+    [publish, selectedBreakpoint, selectedInstance, treeId]
   );
 
   // @deprecated should not be called

--- a/apps/designer/app/designer/features/style-panel/style-panel.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-panel.tsx
@@ -6,7 +6,7 @@ import {
   DeprecatedParagraph,
   SearchField,
 } from "@webstudio-is/design-system";
-import type { Instance } from "@webstudio-is/project-build";
+import type { Instance, Tree } from "@webstudio-is/project-build";
 import { useStyleData } from "./shared/use-style-data";
 import { StyleSettings } from "./style-settings";
 import { useState } from "react";
@@ -17,13 +17,19 @@ import {
 import { theme } from "@webstudio-is/design-system";
 
 type StylePanelProps = {
+  treeId: Tree["id"];
   publish: Publish;
   selectedInstance: Instance;
 };
 
-export const StylePanel = ({ selectedInstance, publish }: StylePanelProps) => {
+export const StylePanel = ({
+  treeId,
+  selectedInstance,
+  publish,
+}: StylePanelProps) => {
   const { currentStyle, setProperty, deleteProperty, createBatchUpdate } =
     useStyleData({
+      treeId,
       selectedInstance,
       publish,
     });

--- a/apps/designer/app/routes/rest/patch.ts
+++ b/apps/designer/app/routes/rest/patch.ts
@@ -36,6 +36,12 @@ export const action = async ({ request }: ActionArgs) => {
 
       if (namespace === "root") {
         await projectDb.tree.patch({ treeId, projectId }, patches, context);
+      } else if (namespace === "styleSourceSelections") {
+        // @todo enable when styles migrated to style sources
+        continue;
+      } else if (namespace === "styleSources") {
+        // @todo enable when styles migrated to style sources
+        continue;
       } else if (namespace === "styles") {
         await projectDb.styles.patch({ treeId, projectId }, patches, context);
       } else if (namespace === "props") {

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -1,12 +1,18 @@
 import { useMemo } from "react";
 import { atom, computed, type WritableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
-import type { Instance, Props, Styles } from "@webstudio-is/project-build";
+import type {
+  Instance,
+  Props,
+  Styles,
+  StyleSources,
+  StyleSourceSelections,
+} from "@webstudio-is/project-build";
+import type { Breakpoint, Style } from "@webstudio-is/css-data";
 import type {
   DropTargetChangePayload,
   DragStartPayload,
 } from "~/canvas/shared/use-drag-drop";
-import type { Breakpoint, Style } from "@webstudio-is/css-data";
 import { useSyncInitializeOnce } from "../hook-utils";
 import { shallowComputed } from "../store-utils";
 
@@ -119,6 +125,22 @@ export const useInstanceStyles = (instanceId: undefined | Instance["id"]) => {
   }, [instanceId]);
   const instanceStyles = useStore(instanceStylesStore);
   return instanceStyles;
+};
+
+export const styleSourcesStore = atom<StyleSources>([]);
+export const useSetStyleSources = (styleSources: StyleSources) => {
+  useSyncInitializeOnce(() => {
+    styleSourcesStore.set(styleSources);
+  });
+};
+
+export const styleSourceSelectionsStore = atom<StyleSourceSelections>([]);
+export const useSetStyleSourceSelections = (
+  styleSourceSelections: StyleSourceSelections
+) => {
+  useSyncInitializeOnce(() => {
+    styleSourceSelectionsStore.set(styleSourceSelections);
+  });
 };
 
 export const breakpointsContainer = atom<Breakpoint[]>([]);

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -7,6 +7,8 @@ import {
   propsStore,
   breakpointsContainer,
   stylesStore,
+  styleSourcesStore,
+  styleSourceSelectionsStore,
   selectedInstanceIdStore,
   selectedInstanceBrowserStyleStore,
   hoveredInstanceIdStore,
@@ -42,6 +44,8 @@ export const registerContainers = () => {
   store.register("breakpoints", breakpointsContainer);
   store.register("root", rootInstanceContainer);
   store.register("styles", stylesStore);
+  store.register("styleSources", styleSourcesStore);
+  store.register("styleSourceSelections", styleSourceSelectionsStore);
   store.register("props", propsStore);
   // synchronize whole states
   clientStores.set("selectedInstanceId", selectedInstanceIdStore);

--- a/apps/designer/app/shared/tree-utils.test.ts
+++ b/apps/designer/app/shared/tree-utils.test.ts
@@ -1,13 +1,79 @@
 import { test, expect } from "@jest/globals";
-import type { Instance } from "@webstudio-is/project-build";
-import { cloneInstance, findSubtree } from "./tree-utils";
+import type {
+  Instance,
+  PropsItem,
+  StylesItem,
+  StyleSource,
+  StyleSourceSelection,
+} from "@webstudio-is/project-build";
+import {
+  cloneInstance,
+  cloneProps,
+  cloneStyles,
+  cloneStyleSources,
+  cloneStyleSourceSelections,
+  findSubtree,
+  findSubtreeLocalStyleSources,
+} from "./tree-utils";
 
-const createInstance = (id: string, children: Instance[]): Instance => {
+const expectString = expect.any(String) as unknown as string;
+
+const createInstance = (id: Instance["id"], children: Instance[]): Instance => {
   return {
     type: "instance",
     id,
     component: "Box",
     children: children,
+  };
+};
+
+const createProp = (id: string, instanceId: string): PropsItem => {
+  return {
+    id,
+    instanceId,
+    type: "string",
+    name: "prop",
+    value: "value",
+  };
+};
+
+const createStyleSource = (
+  type: StyleSource["type"],
+  id: StyleSource["id"]
+): StyleSource => {
+  if (type === "token") {
+    return {
+      type,
+      id,
+      name: id,
+    };
+  }
+  return {
+    type,
+    id,
+    treeId: "",
+  };
+};
+
+const createStyleSourceSelection = (
+  instanceId: Instance["id"],
+  values: StyleSource["id"][]
+): StyleSourceSelection => {
+  return {
+    instanceId,
+    values,
+  };
+};
+
+const createStyleDecl = (instanceId: string): StylesItem => {
+  return {
+    instanceId,
+    breakpointId: "breakpointId",
+    property: "width",
+    value: {
+      type: "keyword",
+      value: "value",
+    },
   };
 };
 
@@ -55,17 +121,131 @@ test("clone instance tree and provide cloned ids map", () => {
     createInstance("child2", [createInstance("descendant", [])]),
     createInstance("child3", []),
   ]);
-  const { clonedInstance, clonedIds } = cloneInstance(instance);
-  const string = expect.any(String) as unknown as string;
+  const { clonedInstance, clonedInstanceIds } = cloneInstance(instance);
   expect(clonedInstance).toEqual(
-    createInstance(string, [
-      createInstance(string, []),
-      createInstance(string, [createInstance(string, [])]),
-      createInstance(string, []),
+    createInstance(expectString, [
+      createInstance(expectString, []),
+      createInstance(expectString, [createInstance(expectString, [])]),
+      createInstance(expectString, []),
     ])
   );
-  expect(clonedIds.get(instance.id)).toEqual(clonedInstance.id);
-  expect(clonedIds.get((instance.children[0] as Instance).id)).toEqual(
+  expect(clonedInstanceIds.get(instance.id)).toEqual(clonedInstance.id);
+  expect(clonedInstanceIds.get((instance.children[0] as Instance).id)).toEqual(
     (clonedInstance.children[0] as Instance).id
   );
+});
+
+test("clone props with new ids and apply new instance ids", () => {
+  const props = [
+    createProp("prop1", "instance1"),
+    createProp("prop2", "instance2"),
+    createProp("prop3", "instance1"),
+    createProp("prop4", "instance3"),
+    createProp("prop5", "instance1"),
+    createProp("prop6", "instance3"),
+  ];
+  const clonedInstanceIds = new Map<Instance["id"], Instance["id"]>();
+  clonedInstanceIds.set("instance2", "newInstance2");
+  clonedInstanceIds.set("instance3", "newInstance3");
+  expect(cloneProps(props, clonedInstanceIds)).toEqual([
+    createProp(expectString, "newInstance2"),
+    createProp(expectString, "newInstance3"),
+    createProp(expectString, "newInstance3"),
+  ]);
+});
+
+test("clone style sources with new ids within provided subset", () => {
+  const styleSources = [
+    createStyleSource("local", "local1"),
+    createStyleSource("local", "local2"),
+    createStyleSource("token", "token3"),
+    createStyleSource("local", "local4"),
+  ];
+  const subsetIds = new Set<StyleSource["id"]>(["local2", "token3"]);
+  expect(cloneStyleSources(styleSources, subsetIds)).toEqual({
+    clonedStyleSources: [
+      createStyleSource("local", expectString),
+      createStyleSource("token", expectString),
+    ],
+    clonedStyleSourceIds: new Map([
+      ["local2", expectString],
+      ["token3", expectString],
+    ]),
+  });
+});
+
+test("clone style source selections with applied instance ids and style source ids", () => {
+  const styleSourceSelections = [
+    createStyleSourceSelection("instance1", ["local1", "token2"]),
+    createStyleSourceSelection("instance2", ["token3", "local4", "token5"]),
+    createStyleSourceSelection("instance3", ["local6"]),
+  ];
+  const clonedStyleSourceIds = new Map<StyleSource["id"], StyleSource["id"]>([
+    ["local1", "newLocal1"],
+    ["local4", "newLocal4"],
+  ]);
+  const clonedInstanceIds = new Map<Instance["id"], Instance["id"]>([
+    ["instance1", "newInstance1"],
+    ["instance2", "newInstance2"],
+  ]);
+  expect(
+    cloneStyleSourceSelections(
+      styleSourceSelections,
+      clonedInstanceIds,
+      clonedStyleSourceIds
+    )
+  ).toEqual([
+    createStyleSourceSelection("newInstance1", ["newLocal1", "token2"]),
+    createStyleSourceSelection("newInstance2", [
+      "token3",
+      "newLocal4",
+      "token5",
+    ]),
+  ]);
+});
+
+test("clone styles with appled new instance ids", () => {
+  const styles = [
+    createStyleDecl("instance1"),
+    createStyleDecl("instance2"),
+    createStyleDecl("instance1"),
+    createStyleDecl("instance3"),
+    createStyleDecl("instance1"),
+    createStyleDecl("instance3"),
+  ];
+  const clonedInstanceIds = new Map<Instance["id"], Instance["id"]>();
+  clonedInstanceIds.set("instance2", "newInstance2");
+  clonedInstanceIds.set("instance3", "newInstance3");
+  expect(cloneStyles(styles, clonedInstanceIds)).toEqual([
+    createStyleDecl("newInstance2"),
+    createStyleDecl("newInstance3"),
+    createStyleDecl("newInstance3"),
+  ]);
+});
+
+test("find subtree local style sources", () => {
+  const subtreeIds = new Set(["instance2", "instance4"]);
+  const styleSources = [
+    createStyleSource("local", "local1"),
+    createStyleSource("local", "local2"),
+    createStyleSource("token", "token3"),
+    createStyleSource("local", "local4"),
+    createStyleSource("token", "token5"),
+    createStyleSource("local", "local6"),
+  ];
+  const styleSourceSelections = [
+    createStyleSourceSelection("instance1", ["local1"]),
+    createStyleSourceSelection("instance2", ["local2"]),
+    createStyleSourceSelection("instance3", ["token3"]),
+    createStyleSourceSelection("instance4", ["local4", "token5"]),
+    createStyleSourceSelection("instance5", ["local6"]),
+  ];
+
+  expect(
+    findSubtreeLocalStyleSources(
+      subtreeIds,
+      styleSources,
+      styleSourceSelections
+    )
+  ).toEqual(new Set(["local2", "local4"]));
 });

--- a/packages/project/src/db/index.ts
+++ b/packages/project/src/db/index.ts
@@ -1,7 +1,18 @@
 import * as project from "./project";
 import * as tree from "./tree";
 import * as styles from "./styles";
+import * as styleSources from "./style-sources";
+import * as styleSourceSelections from "./style-source-selections";
 import * as props from "./props";
 import * as breakpoints from "./breakpoints";
 import * as build from "./build";
-export { project, tree, breakpoints, styles, props, build };
+export {
+  project,
+  tree,
+  breakpoints,
+  styles,
+  styleSources,
+  styleSourceSelections,
+  props,
+  build,
+};

--- a/packages/project/src/db/style-source-selections.ts
+++ b/packages/project/src/db/style-source-selections.ts
@@ -25,7 +25,7 @@ export const patch = async (
     where: { id: treeId },
   });
   if (tree === null) {
-    return null;
+    return;
   }
 
   const styleSourceSelections = StyleSources.parse(

--- a/packages/project/src/db/style-source-selections.ts
+++ b/packages/project/src/db/style-source-selections.ts
@@ -1,0 +1,45 @@
+import { type Patch, applyPatches } from "immer";
+import { prisma } from "@webstudio-is/prisma-client";
+import {
+  authorizeProject,
+  type AppContext,
+} from "@webstudio-is/trpc-interface/server";
+import { StyleSources, type Tree } from "@webstudio-is/project-build";
+import type { Project } from "./schema";
+
+export const patch = async (
+  { treeId, projectId }: { treeId: Tree["id"]; projectId: Project["id"] },
+  patches: Array<Patch>,
+  context: AppContext
+) => {
+  const canEdit = await authorizeProject.hasProjectPermit(
+    { projectId, permit: "edit" },
+    context
+  );
+
+  if (canEdit === false) {
+    throw new Error("You don't have edit access to this project");
+  }
+
+  const tree = await prisma.tree.findUnique({
+    where: { id: treeId },
+  });
+  if (tree === null) {
+    return null;
+  }
+
+  const styleSourceSelections = StyleSources.parse(
+    JSON.parse(tree.styleSelections)
+  );
+
+  const patchedStyleSourceSelections = StyleSources.parse(
+    applyPatches(styleSourceSelections, patches)
+  );
+
+  await prisma.tree.update({
+    data: {
+      styleSelections: JSON.stringify(patchedStyleSourceSelections),
+    },
+    where: { id: treeId },
+  });
+};

--- a/packages/project/src/db/style-sources.ts
+++ b/packages/project/src/db/style-sources.ts
@@ -25,7 +25,7 @@ export const patch = async (
     where: { id: buildId },
   });
   if (build === null) {
-    return null;
+    return;
   }
 
   const styleSources = StyleSources.parse(JSON.parse(build.styleSources));

--- a/packages/project/src/db/style-sources.ts
+++ b/packages/project/src/db/style-sources.ts
@@ -1,0 +1,43 @@
+import { type Patch, applyPatches } from "immer";
+import { prisma } from "@webstudio-is/prisma-client";
+import {
+  authorizeProject,
+  type AppContext,
+} from "@webstudio-is/trpc-interface/server";
+import { StyleSources } from "@webstudio-is/project-build";
+import type { Build, Project } from "./schema";
+
+export const patch = async (
+  { buildId, projectId }: { buildId: Build["id"]; projectId: Project["id"] },
+  patches: Array<Patch>,
+  context: AppContext
+) => {
+  const canEdit = await authorizeProject.hasProjectPermit(
+    { projectId, permit: "edit" },
+    context
+  );
+
+  if (canEdit === false) {
+    throw new Error("You don't have edit access to this project");
+  }
+
+  const build = await prisma.build.findUnique({
+    where: { id: buildId },
+  });
+  if (build === null) {
+    return null;
+  }
+
+  const styleSources = StyleSources.parse(JSON.parse(build.styleSources));
+
+  const patchedStyleSources = StyleSources.parse(
+    applyPatches(styleSources, patches)
+  );
+
+  await prisma.build.update({
+    data: {
+      styleSources: JSON.stringify(patchedStyleSources),
+    },
+    where: { id: buildId },
+  });
+};


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/807

Here added style sources and style source selections stores, added updates along styles and covered with tests. Patch utilities for rest endpoint are not used to avoid collision with temporary logic in styles.

Next step will be integration styles with style sources on client.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
