### PR TITLE
Migrate styles to style sources variant

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -131,7 +131,7 @@ export const Canvas = ({ data }: CanvasProps): JSX.Element | null => {
   useSetProps(data.tree.props);
   // inject props store to sdk
   setPropsByInstanceIdStore(propsByInstanceIdStore);
-  useSetStyles(data.tree.styles);
+  useSetStyles(data.build.styles);
   useSetStyleSources(data.build.styleSources);
   useSetStyleSourceSelections(data.tree.styleSourceSelections);
   useSetRootInstance(data.tree.root);

--- a/apps/designer/app/designer/features/style-panel/shared/style-info.test.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/style-info.test.ts
@@ -40,32 +40,32 @@ const cascadingStylesByInstanceId = new Map<Instance["id"], Styles>();
 cascadingStylesByInstanceId.set(selectedInstanceId, [
   {
     breakpointId: "1",
-    instanceId: selectedInstanceId,
+    styleSourceId: "styleSourceId",
     property: "width",
     value: { type: "unit", value: 100, unit: "px" },
   },
   {
     breakpointId: "1",
-    instanceId: selectedInstanceId,
+    styleSourceId: "styleSourceId",
     property: "height",
     value: { type: "unit", value: 50, unit: "px" },
   },
   {
     breakpointId: "2",
-    instanceId: selectedInstanceId,
+    styleSourceId: "styleSourceId",
     property: "width",
     value: { type: "unit", value: 200, unit: "px" },
   },
   {
     breakpointId: "3",
-    instanceId: selectedInstanceId,
+    styleSourceId: "styleSourceId",
     // should not be computed because current breakpoint
     property: "height",
     value: { type: "unit", value: 150, unit: "px" },
   },
   {
     breakpointId: "4",
-    instanceId: selectedInstanceId,
+    styleSourceId: "styleSourceId",
     property: "width",
     value: { type: "unit", value: 400, unit: "px" },
   },
@@ -97,7 +97,7 @@ inheritingStylesByInstanceId.set("1", [
   // should be inherited even from another breakpoint
   {
     breakpointId: "1",
-    instanceId: "1",
+    styleSourceId: "styleSourceId1",
     property: "fontSize",
     value: { type: "unit", value: 20, unit: "px" },
   },
@@ -106,14 +106,14 @@ inheritingStylesByInstanceId.set("2", [
   // should not be inherited because width is not inheritable
   {
     breakpointId: "3",
-    instanceId: "2",
+    styleSourceId: "styleSourceId2",
     property: "width",
     value: { type: "unit", value: 100, unit: "px" },
   },
   // should be inherited from selected breakpoint
   {
     breakpointId: "3",
-    instanceId: "2",
+    styleSourceId: "styleSourceId2",
     property: "fontWeight",
     value: { type: "keyword", value: "600" },
   },
@@ -122,7 +122,7 @@ inheritingStylesByInstanceId.set("3", [
   // should not show selected style as inherited
   {
     breakpointId: "3",
-    instanceId: "3",
+    styleSourceId: "styleSourceId3",
     property: "fontWeight",
     value: { type: "keyword", value: "500" },
   },

--- a/apps/designer/app/routes/rest/patch.ts
+++ b/apps/designer/app/routes/rest/patch.ts
@@ -37,13 +37,19 @@ export const action = async ({ request }: ActionArgs) => {
       if (namespace === "root") {
         await projectDb.tree.patch({ treeId, projectId }, patches, context);
       } else if (namespace === "styleSourceSelections") {
-        // @todo enable when styles migrated to style sources
-        continue;
+        await projectDb.styleSourceSelections.patch(
+          { treeId, projectId },
+          patches,
+          context
+        );
       } else if (namespace === "styleSources") {
-        // @todo enable when styles migrated to style sources
-        continue;
+        await projectDb.styleSources.patch(
+          { buildId, projectId },
+          patches,
+          context
+        );
       } else if (namespace === "styles") {
-        await projectDb.styles.patch({ treeId, projectId }, patches, context);
+        await projectDb.styles.patch({ buildId, projectId }, patches, context);
       } else if (namespace === "props") {
         await projectDb.props.patch({ treeId, projectId }, patches, context);
       } else if (namespace === "breakpoints") {

--- a/apps/designer/app/shared/copy-paste/copy-paste-instance.ts
+++ b/apps/designer/app/shared/copy-paste/copy-paste-instance.ts
@@ -77,8 +77,7 @@ const copyInstanceData = (targetInstanceId: string) => {
     clonedInstanceIds,
     clonedStyleSourceIds
   );
-  // @todo migrate to style source variant
-  const clonedStyles = cloneStyles(stylesStore.get(), clonedInstanceIds);
+  const clonedStyles = cloneStyles(stylesStore.get(), clonedStyleSourceIds);
 
   return {
     instance: clonedInstance,

--- a/apps/designer/app/shared/instance-utils.ts
+++ b/apps/designer/app/shared/instance-utils.ts
@@ -53,9 +53,8 @@ export const deleteInstance = (targetInstanceId: Instance["id"]) => {
       removeByMutable(styleSources, (styleSource) =>
         subtreeLocalStyleSourceIds.has(styleSource.id)
       );
-      // @todo migrate to style source variant
       removeByMutable(styles, (styleDecl) =>
-        subtreeIds.has(styleDecl.instanceId)
+        subtreeLocalStyleSourceIds.has(styleDecl.styleSourceId)
       );
 
       selectedInstanceIdStore.set(parentInstance.id);

--- a/apps/designer/app/shared/tree-utils.test.ts
+++ b/apps/designer/app/shared/tree-utils.test.ts
@@ -65,9 +65,9 @@ const createStyleSourceSelection = (
   };
 };
 
-const createStyleDecl = (instanceId: string): StylesItem => {
+const createStyleDecl = (styleSourceId: string): StylesItem => {
   return {
-    instanceId,
+    styleSourceId,
     breakpointId: "breakpointId",
     property: "width",
     value: {
@@ -204,22 +204,22 @@ test("clone style source selections with applied instance ids and style source i
   ]);
 });
 
-test("clone styles with appled new instance ids", () => {
+test("clone styles with appled new style source ids", () => {
   const styles = [
-    createStyleDecl("instance1"),
-    createStyleDecl("instance2"),
-    createStyleDecl("instance1"),
-    createStyleDecl("instance3"),
-    createStyleDecl("instance1"),
-    createStyleDecl("instance3"),
+    createStyleDecl("styleSource1"),
+    createStyleDecl("styleSource2"),
+    createStyleDecl("styleSource1"),
+    createStyleDecl("styleSource3"),
+    createStyleDecl("styleSource1"),
+    createStyleDecl("styleSource3"),
   ];
-  const clonedInstanceIds = new Map<Instance["id"], Instance["id"]>();
-  clonedInstanceIds.set("instance2", "newInstance2");
-  clonedInstanceIds.set("instance3", "newInstance3");
-  expect(cloneStyles(styles, clonedInstanceIds)).toEqual([
-    createStyleDecl("newInstance2"),
-    createStyleDecl("newInstance3"),
-    createStyleDecl("newInstance3"),
+  const clonedStyleSourceIds = new Map<StyleSource["id"], StyleSource["id"]>();
+  clonedStyleSourceIds.set("styleSource2", "newStyleSource2");
+  clonedStyleSourceIds.set("styleSource3", "newStyleSource3");
+  expect(cloneStyles(styles, clonedStyleSourceIds)).toEqual([
+    createStyleDecl("newStyleSource2"),
+    createStyleDecl("newStyleSource3"),
+    createStyleDecl("newStyleSource3"),
   ]);
 });
 

--- a/apps/designer/app/shared/tree-utils.ts
+++ b/apps/designer/app/shared/tree-utils.ts
@@ -134,20 +134,19 @@ export const cloneStyleSourceSelections = (
   return clonedStyleSourceSelections;
 };
 
-// @todo migrate to style source variant
 export const cloneStyles = (
   styles: Styles,
-  clonedInstanceIds: Map<Instance["id"], Instance["id"]>
+  clonedStyleSourceIds: Map<Instance["id"], Instance["id"]>
 ) => {
   const clonedStyles: Styles = [];
   for (const styleDecl of styles) {
-    const instanceId = clonedInstanceIds.get(styleDecl.instanceId);
-    if (instanceId === undefined) {
+    const styleSourceId = clonedStyleSourceIds.get(styleDecl.styleSourceId);
+    if (styleSourceId === undefined) {
       continue;
     }
     clonedStyles.push({
       ...styleDecl,
-      instanceId,
+      styleSourceId,
     });
   }
   return clonedStyles;

--- a/packages/project-build/src/schema/styles.ts
+++ b/packages/project-build/src/schema/styles.ts
@@ -25,7 +25,7 @@ export const StoredStyles = z.array(StoredStylesItem);
 export type StoredStyles = z.infer<typeof StoredStyles>;
 
 export const StylesItem = z.object({
-  instanceId: z.string(),
+  styleSourceId: z.string(),
   breakpointId: z.string(),
   // @todo can't figure out how to make property to be enum
   property: z.string() as z.ZodType<StyleProperty>,
@@ -37,17 +37,3 @@ export type StylesItem = z.infer<typeof StylesItem>;
 export const Styles = z.array(StylesItem);
 
 export type Styles = z.infer<typeof Styles>;
-
-export const NewStylesItem = z.object({
-  styleSourceId: z.string(),
-  breakpointId: z.string(),
-  // @todo can't figure out how to make property to be enum
-  property: z.string() as z.ZodType<StyleProperty>,
-  value: z.union([ImageValue, SharedStyleValue]),
-});
-
-export type NewStylesItem = z.infer<typeof NewStylesItem>;
-
-export const NewStyles = z.array(NewStylesItem);
-
-export type NewStyles = z.infer<typeof NewStyles>;

--- a/packages/project-build/src/types.ts
+++ b/packages/project-build/src/types.ts
@@ -1,7 +1,6 @@
 import type { Instance } from "./schema/instances";
 import type { Props } from "./schema/props";
 import type { StyleSourceSelections } from "./schema/style-sources";
-import type { Styles } from "./schema/styles";
 
 export type Tree = {
   id: string;
@@ -9,6 +8,5 @@ export type Tree = {
   buildId: string;
   root: Instance;
   props: Props;
-  styles: Styles;
   styleSourceSelections: StyleSourceSelections;
 };

--- a/packages/project/src/db/build.ts
+++ b/packages/project/src/db/build.ts
@@ -9,7 +9,7 @@ import { StyleSources } from "@webstudio-is/project-build";
 import * as db from ".";
 import { Build, Page, Pages } from "./schema";
 import * as pagesUtils from "../shared/pages";
-import { parseNewStyles } from "./styles";
+import { parseStyles, serializeStyles } from "./styles";
 
 export const parseBuild = async (build: DbBuild): Promise<Build> => {
   const pages = Pages.parse(JSON.parse(build.pages));
@@ -17,7 +17,7 @@ export const parseBuild = async (build: DbBuild): Promise<Build> => {
     ...build,
     createdAt: build.createdAt.toISOString(),
     pages,
-    styles: await parseNewStyles(build.styles),
+    styles: await parseStyles(build.styles),
     styleSources: StyleSources.parse(JSON.parse(build.styleSources)),
   };
 };
@@ -262,6 +262,8 @@ export async function create(
     data: {
       projectId,
       pages: JSON.stringify([]),
+      styles: serializeStyles(sourceBuild?.styles ?? []),
+      styleSources: JSON.stringify(sourceBuild?.styleSources ?? []),
       isDev: env === "dev",
       isProd: env === "prod",
     },

--- a/packages/project/src/db/schema.ts
+++ b/packages/project/src/db/schema.ts
@@ -1,6 +1,6 @@
 import { z, type ZodType } from "zod";
 import { Project } from "@webstudio-is/prisma-client";
-import type { NewStyles, StyleSources } from "@webstudio-is/project-build";
+import type { Styles, StyleSources } from "@webstudio-is/project-build";
 import type { Data } from "@webstudio-is/react-sdk";
 
 export type { Project };
@@ -78,7 +78,7 @@ export type Build = {
   isDev: boolean;
   isProd: boolean;
   pages: Pages;
-  styles: NewStyles;
+  styles: Styles;
   styleSources: StyleSources;
 };
 

--- a/packages/project/src/db/style-source-selections.ts
+++ b/packages/project/src/db/style-source-selections.ts
@@ -4,7 +4,7 @@ import {
   authorizeProject,
   type AppContext,
 } from "@webstudio-is/trpc-interface/server";
-import { StyleSources, type Tree } from "@webstudio-is/project-build";
+import { StyleSourceSelections, type Tree } from "@webstudio-is/project-build";
 import type { Project } from "./schema";
 
 export const patch = async (
@@ -28,11 +28,11 @@ export const patch = async (
     return;
   }
 
-  const styleSourceSelections = StyleSources.parse(
+  const styleSourceSelections = StyleSourceSelections.parse(
     JSON.parse(tree.styleSelections)
   );
 
-  const patchedStyleSourceSelections = StyleSources.parse(
+  const patchedStyleSourceSelections = StyleSourceSelections.parse(
     applyPatches(styleSourceSelections, patches)
   );
 

--- a/packages/project/src/shared/styles/style-rules.test.ts
+++ b/packages/project/src/shared/styles/style-rules.test.ts
@@ -1,12 +1,12 @@
 import { test, expect } from "@jest/globals";
 import type {
-  NewStyles,
+  Styles,
   StyleSourceSelections,
 } from "@webstudio-is/project-build";
 import { getStyleRules } from "./style-rules";
 
 test("compute styles from different style sources", () => {
-  const styles: NewStyles = [
+  const styles: Styles = [
     {
       breakpointId: "a",
       styleSourceId: "styleSource1",

--- a/packages/project/src/shared/styles/style-rules.ts
+++ b/packages/project/src/shared/styles/style-rules.ts
@@ -1,6 +1,6 @@
 import type { Breakpoint, Style } from "@webstudio-is/css-data";
 import type {
-  NewStyles,
+  Styles,
   StyleSource,
   StyleSourceSelections,
 } from "@webstudio-is/project-build";
@@ -16,13 +16,13 @@ type StyleRule = {
  * and group by instance and breakpoint
  */
 export const getStyleRules = (
-  styles?: NewStyles,
+  styles?: Styles,
   styleSourceSelections?: StyleSourceSelections
 ) => {
   if (styles === undefined || styleSourceSelections === undefined) {
     return [];
   }
-  const stylesByStyleSourceId = new Map<StyleSource["id"], NewStyles>();
+  const stylesByStyleSourceId = new Map<StyleSource["id"], Styles>();
   for (const styleDecl of styles) {
     const { styleSourceId } = styleDecl;
     let styleSourceStyles = stylesByStyleSourceId.get(styleSourceId);


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/807

Styles are resolved based on style sources of every instance. Here finally migrated whole logic to new variant.

For now the only local style source is used as default for style updates. In the next PR will add support for tokens.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
