### PR TITLE
Use projectId as composite id in tables

### DIFF
--- a/apps/designer/app/routes/rest/pages.$projectId.ts
+++ b/apps/designer/app/routes/rest/pages.$projectId.ts
@@ -101,7 +101,12 @@ const handlePost = async (
     }
   }
 
-  await db.build.editPage(devBuild.id, id, data);
+  await db.build.editPage({
+    projectId,
+    buildId: devBuild.id,
+    pageId: id,
+    data,
+  });
 
   return { status: "ok" };
 };
@@ -124,7 +129,11 @@ const handleDelete = async (
     return makeFieldError("id", `Can't delete the home page`);
   }
 
-  await db.build.deletePage(devBuild.id, id);
+  await db.build.deletePage({
+    projectId,
+    buildId: devBuild.id,
+    pageId: id,
+  });
 
   return { status: "ok" };
 };

--- a/apps/designer/app/shared/db/canvas.server.ts
+++ b/apps/designer/app/shared/db/canvas.server.ts
@@ -24,7 +24,7 @@ export const loadCanvasData = async (
   }
 
   const [tree, assets] = await Promise.all([
-    projectDb.tree.loadById(page.treeId),
+    projectDb.tree.loadById({ projectId: project.id, treeId: page.treeId }),
     loadByProject(project.id),
   ]);
 

--- a/packages/asset-uploader/src/db/create.ts
+++ b/packages/asset-uploader/src/db/create.ts
@@ -92,7 +92,9 @@ export const createAssetWithLimit = async (
     const { id, meta, format, name, location } = asset;
 
     const dbAsset = await prisma.asset.update({
-      where: { id: updated.id },
+      where: {
+        id_projectId: { id: updated.id, projectId },
+      },
       data: {
         id,
         location,
@@ -108,7 +110,11 @@ export const createAssetWithLimit = async (
     return formatAsset(dbAsset);
   } catch (error) {
     if (updated) {
-      await prisma.asset.delete({ where: { id: updated.id } });
+      await prisma.asset.delete({
+        where: {
+          id_projectId: { id: updated.id, projectId },
+        },
+      });
     }
 
     throw error;

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -42,7 +42,7 @@ module.exports = {
     ],
     curly: 2,
     eqeqeq: ["error", "always", { null: "ignore" }],
-    camelcase: 2,
+    camelcase: [2, { properties: "never" }],
     radix: 2,
     "import/no-internal-modules": [
       "error",

--- a/packages/prisma-client/prisma/migrations/20230202192437_composite_ids/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20230202192437_composite_ids/migration.sql
@@ -1,0 +1,17 @@
+-- DropForeignKey
+ALTER TABLE "Tree" DROP CONSTRAINT "Tree_buildId_fkey";
+
+-- AlterTable
+ALTER TABLE "Asset" DROP CONSTRAINT "Asset_pkey",
+ADD CONSTRAINT "Asset_pkey" PRIMARY KEY ("id", "projectId");
+
+-- AlterTable
+ALTER TABLE "Build" DROP CONSTRAINT "Build_pkey",
+ADD CONSTRAINT "Build_pkey" PRIMARY KEY ("id", "projectId");
+
+-- AlterTable
+ALTER TABLE "Tree" DROP CONSTRAINT "Tree_pkey",
+ADD CONSTRAINT "Tree_pkey" PRIMARY KEY ("id", "projectId");
+
+-- AddForeignKey
+ALTER TABLE "Tree" ADD CONSTRAINT "Tree_buildId_projectId_fkey" FOREIGN KEY ("buildId", "projectId") REFERENCES "Build"("id", "projectId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -28,7 +28,7 @@ enum UploadStatus {
 }
 
 model Asset {
-  id          String       @id @default(uuid())
+  id          String       @default(uuid())
   projectId   String
   format      String
   size        Int
@@ -38,6 +38,8 @@ model Asset {
   createdAt   DateTime     @default(now())
   meta        String       @default("{}")
   status      UploadStatus @default(UPLOADED)
+
+  @@id([id, projectId])
 }
 
 model User {
@@ -65,7 +67,7 @@ model Project {
 }
 
 model Build {
-  id        String   @id @default(uuid())
+  id        String   @default(uuid())
   createdAt DateTime @default(now())
   pages     String
 
@@ -79,19 +81,23 @@ model Build {
   breakpoints  String @default("[]")
   styles       String @default("[]")
   styleSources String @default("[]")
+
+  @@id([id, projectId])
 }
 
 model Tree {
-  id              String  @id @default(uuid())
+  id              String  @default(uuid())
   project         Project @relation(fields: [projectId], references: [id])
   projectId       String
-  build           Build   @relation(fields: [buildId], references: [id])
+  build           Build   @relation(fields: [buildId, projectId], references: [id, projectId])
   buildId         String
   root            String
   instances       String  @default("[]")
   props           String  @default("[]")
   styles          String  @default("[]")
   styleSelections String  @default("[]")
+
+  @@id([id, projectId])
 }
 
 model Breakpoints {

--- a/packages/project/src/db/breakpoints.ts
+++ b/packages/project/src/db/breakpoints.ts
@@ -37,7 +37,9 @@ export const patch = async (
   }
 
   const build = await prisma.build.findUnique({
-    where: { id: buildId },
+    where: {
+      id_projectId: { id: buildId, projectId },
+    },
   });
 
   if (build === null) {
@@ -49,7 +51,9 @@ export const patch = async (
   );
 
   await prisma.build.update({
-    where: { id: buildId },
+    where: {
+      id_projectId: { id: buildId, projectId },
+    },
     data: { breakpoints: JSON.stringify(patchedBreakpoints) },
   });
 };

--- a/packages/project/src/db/props.ts
+++ b/packages/project/src/db/props.ts
@@ -97,7 +97,9 @@ export const patch = async (
   }
 
   const tree = await prisma.tree.findUnique({
-    where: { id: treeId },
+    where: {
+      id_projectId: { projectId, id: treeId },
+    },
   });
   if (tree === null) {
     return;
@@ -109,6 +111,8 @@ export const patch = async (
     data: {
       props: serializeProps(patchedProps),
     },
-    where: { id: treeId },
+    where: {
+      id_projectId: { projectId, id: treeId },
+    },
   });
 };

--- a/packages/project/src/db/style-source-selections.ts
+++ b/packages/project/src/db/style-source-selections.ts
@@ -22,7 +22,9 @@ export const patch = async (
   }
 
   const tree = await prisma.tree.findUnique({
-    where: { id: treeId },
+    where: {
+      id_projectId: { projectId, id: treeId },
+    },
   });
   if (tree === null) {
     return;
@@ -40,6 +42,8 @@ export const patch = async (
     data: {
       styleSelections: JSON.stringify(patchedStyleSourceSelections),
     },
-    where: { id: treeId },
+    where: {
+      id_projectId: { projectId, id: treeId },
+    },
   });
 };

--- a/packages/project/src/db/style-sources.ts
+++ b/packages/project/src/db/style-sources.ts
@@ -22,7 +22,9 @@ export const patch = async (
   }
 
   const build = await prisma.build.findUnique({
-    where: { id: buildId },
+    where: {
+      id_projectId: { projectId, id: buildId },
+    },
   });
   if (build === null) {
     return;
@@ -38,6 +40,8 @@ export const patch = async (
     data: {
       styleSources: JSON.stringify(patchedStyleSources),
     },
-    where: { id: buildId },
+    where: {
+      id_projectId: { projectId, id: buildId },
+    },
   });
 };

--- a/packages/project/src/db/styles.ts
+++ b/packages/project/src/db/styles.ts
@@ -121,7 +121,9 @@ export const patch = async (
   }
 
   const build = await prisma.build.findUnique({
-    where: { id: buildId },
+    where: {
+      id_projectId: { projectId, id: buildId },
+    },
   });
   if (build === null) {
     return;
@@ -136,6 +138,8 @@ export const patch = async (
     data: {
       styles: JSON.stringify(patchedStyles),
     },
-    where: { id: build.id },
+    where: {
+      id_projectId: { projectId, id: buildId },
+    },
   });
 };

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -84,8 +84,18 @@ export const create = async (
   });
 };
 
-export const deleteById = async (treeId: Tree["id"]): Promise<void> => {
-  await prisma.tree.delete({ where: { id: treeId } });
+export const deleteById = async ({
+  projectId,
+  treeId,
+}: {
+  projectId: Project["id"];
+  treeId: Tree["id"];
+}): Promise<void> => {
+  await prisma.tree.delete({
+    where: {
+      id_projectId: { projectId, id: treeId },
+    },
+  });
 };
 
 const denormalizeTree = (instances: z.infer<typeof Instances>) => {
@@ -113,11 +123,13 @@ const denormalizeTree = (instances: z.infer<typeof Instances>) => {
 };
 
 export const loadById = async (
-  treeId: Tree["id"],
+  { projectId, treeId }: { projectId: Project["id"]; treeId: Tree["id"] },
   client: Prisma.TransactionClient = prisma
 ): Promise<Tree | null> => {
   const tree = await client.tree.findUnique({
-    where: { id: treeId },
+    where: {
+      id_projectId: { projectId, id: treeId },
+    },
   });
   if (tree === null) {
     return null;
@@ -141,10 +153,10 @@ export const loadById = async (
 };
 
 export const clone = async (
-  treeId: Tree["id"],
+  { projectId, treeId }: { projectId: Project["id"]; treeId: Tree["id"] },
   client: Prisma.TransactionClient = prisma
 ) => {
-  const tree = await loadById(treeId, client);
+  const tree = await loadById({ projectId, treeId }, client);
   if (tree === null) {
     throw new Error(`Tree ${treeId} not found`);
   }
@@ -165,7 +177,7 @@ export const patch = async (
     throw new Error("You don't have edit access to this project");
   }
 
-  const tree = await loadById(treeId);
+  const tree = await loadById({ projectId, treeId });
   if (tree === null) {
     throw new Error(`Tree ${treeId} not found`);
   }
@@ -180,6 +192,8 @@ export const patch = async (
       root: "",
       instances: JSON.stringify(instances),
     },
-    where: { id: treeId },
+    where: {
+      id_projectId: { projectId, id: treeId },
+    },
   });
 };


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/896

Here changed Asset, Build and Tree tables to composite ids with projectId to improve security and simplify project management.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
