### PR TITLE
Delete instance without pubsub

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -15,7 +15,6 @@ import { publish } from "~/shared/pubsub";
 import { registerContainers, useCanvasStore } from "~/shared/sync";
 import { useShortcuts } from "./shared/use-shortcuts";
 import {
-  useDeleteInstance,
   useInsertInstance,
   usePublishTextEditingInstanceId,
   useReparentInstance,
@@ -89,7 +88,6 @@ const DesignMode = () => {
   useManageDesignModeStyles();
   useInsertInstance();
   useReparentInstance();
-  useDeleteInstance();
   useTrackSelectedElement();
   usePublishScrollState();
   useSubscribeScrollState();

--- a/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
+++ b/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
@@ -90,11 +90,7 @@ export const SelectedInstanceConnector = ({
     if (canObserve === false) {
       // recompute inline elements on tree changes
       unsubscribeTreeChange = subscribeAll((type) => {
-        if (
-          type === "insertInstance" ||
-          type === "deleteInstance" ||
-          type === "reparentInstance"
-        ) {
+        if (type === "insertInstance" || type === "reparentInstance") {
           updateOutlineRect(element);
         }
       });

--- a/apps/designer/app/canvas/shared/instance.ts
+++ b/apps/designer/app/canvas/shared/instance.ts
@@ -10,7 +10,6 @@ import {
   useTextEditingInstanceId,
 } from "~/shared/nano-states";
 import { publish } from "~/shared/pubsub";
-import { deleteInstance } from "~/shared/instance-utils";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -91,12 +90,6 @@ export const useReparentInstance = () => {
     if (selectedInstanceId !== instanceId && rootInstance !== undefined) {
       selectedInstanceIdStore.set(instanceId);
     }
-  });
-};
-
-export const useDeleteInstance = () => {
-  useSubscribe("deleteInstance", ({ id: deletedInstanceId }) => {
-    deleteInstance(deletedInstanceId);
   });
 };
 

--- a/apps/designer/app/canvas/shared/use-shortcuts.ts
+++ b/apps/designer/app/canvas/shared/use-shortcuts.ts
@@ -1,6 +1,5 @@
 import { useHotkeys } from "react-hotkeys-hook";
 import store from "immerhin";
-import type { Instance } from "@webstudio-is/project-build";
 import { getComponentMeta } from "@webstudio-is/react-sdk";
 import { shortcuts, options } from "~/shared/shortcuts";
 import { publish, useSubscribe } from "~/shared/pubsub";
@@ -10,13 +9,11 @@ import {
   useTextEditingInstanceId,
   isPreviewModeStore,
 } from "~/shared/nano-states";
+import { deleteInstance } from "~/shared/instance-utils";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
     cancelCurrentDrag: undefined;
-    deleteInstance: {
-      id: Instance["id"];
-    };
     openBreakpointsMenu: undefined;
     selectBreakpointFromShortcut: number;
     zoom: "zoomOut" | "zoomIn";
@@ -70,21 +67,18 @@ const publishCancelCurrentDrag = () => {
 export const useShortcuts = () => {
   const [editingInstanceId, setEditingInstanceId] = useTextEditingInstanceId();
 
-  const publishDeleteInstance = () => {
+  const deleteSelectedInstance = () => {
     const selectedInstanceId = selectedInstanceIdStore.get();
     if (selectedInstanceId === undefined) {
       return;
     }
-    publish({
-      type: "deleteInstance",
-      payload: { id: selectedInstanceId },
-    });
+    deleteInstance(selectedInstanceId);
   };
 
   const shortcutHandlerMap = {
     undo: store.undo.bind(store),
     redo: store.redo.bind(store),
-    delete: publishDeleteInstance,
+    delete: deleteSelectedInstance,
     preview: togglePreviewMode,
     breakpointsMenu: publishOpenBreakpointsMenu,
     breakpoint: publishSelectBreakpoint,

--- a/apps/designer/app/designer/features/sidebar-left/navigator/navigator.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/navigator/navigator.tsx
@@ -8,8 +8,9 @@ import {
   hoveredInstanceIdStore,
   useRootInstance,
 } from "~/shared/nano-states";
-import { Header, CloseButton } from "../header";
 import { InstanceTree } from "~/designer/shared/tree";
+import { deleteInstance } from "~/shared/instance-utils";
+import { Header, CloseButton } from "../header";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -17,7 +18,6 @@ declare module "~/shared/pubsub" {
       instanceId: Instance["id"];
       dropTarget: { instanceId: Instance["id"]; position: number | "end" };
     };
-    deleteInstance: { id: Instance["id"] };
   }
 }
 
@@ -54,16 +54,6 @@ export const Navigator = ({ publish, isClosable, onClose }: NavigatorProps) => {
     [publish]
   );
 
-  const handleDelete = useCallback(
-    (instanceId: Instance["id"]) => {
-      publish({
-        type: "deleteInstance",
-        payload: { id: instanceId },
-      });
-    },
-    [publish]
-  );
-
   const handleHover = useCallback((instance: Instance | undefined) => {
     hoveredInstanceIdStore.set(instance?.id);
   }, []);
@@ -84,7 +74,7 @@ export const Navigator = ({ publish, isClosable, onClose }: NavigatorProps) => {
           onSelect={handleSelect}
           onHover={handleHover}
           onDragEnd={handleDragEnd}
-          onDelete={handleDelete}
+          onDelete={deleteInstance}
         />
       </Flex>
     </Flex>


### PR DESCRIPTION
Synchronized stores allow us to change data anywhere we want so we can get rid of pubsub in almost all cases.

Here removed delete instance subscription and used delete instance command.

## Code Review

- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
