### PR TITLE
Disable sync for user/token with "view" permit and show view mode icon

### DIFF
--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -33,6 +33,7 @@ import { usePublishShortcuts } from "./shared/shortcuts";
 import {
   useDragAndDropState,
   useIsPreviewMode,
+  useSetAuthPermit,
   useSetIsPreviewMode,
 } from "~/shared/nano-states";
 import { useClientSettings } from "./shared/client-settings";
@@ -40,6 +41,7 @@ import { Navigator } from "./features/sidebar-left";
 import { getBuildUrl } from "~/shared/router-utils";
 import { useCopyPasteInstance } from "~/shared/copy-paste";
 import { AssetsProvider } from "./shared/assets";
+import type { AuthPermit } from "@webstudio-is/trpc-interface";
 
 registerContainers();
 export const links = () => {
@@ -247,7 +249,7 @@ export type DesignerProps = {
   buildOrigin: string;
   authReadToken: string;
   authToken?: string;
-  authPermit: "view" | "build" | "own";
+  authPermit: AuthPermit;
 };
 
 export const Designer = ({
@@ -261,13 +263,20 @@ export const Designer = ({
   authToken,
   authPermit,
 }: DesignerProps) => {
+  useSetAuthPermit(authPermit);
   useSubscribeBreakpoints();
   useSetProject(project);
   useSetPages(pages);
   useSetCurrentPageId(pageId);
   const [publish, publishRef] = usePublish();
   useDesignerStore(publish);
-  useSyncServer({ buildId, treeId, projectId: project.id, authToken });
+  useSyncServer({
+    buildId,
+    treeId,
+    projectId: project.id,
+    authToken,
+    authPermit,
+  });
   useSharedShortcuts();
   useSetIsPreviewMode(authPermit === "view");
   const [isPreviewMode] = useIsPreviewMode();

--- a/apps/designer/app/designer/features/topbar/topbar.tsx
+++ b/apps/designer/app/designer/features/topbar/topbar.tsx
@@ -9,6 +9,7 @@ import { Breakpoints } from "../breakpoints";
 import type { Page, Project } from "@webstudio-is/project";
 import { theme } from "@webstudio-is/design-system";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
+import { ViewMode } from "./view-mode";
 
 const topbarContainerStyle = css({
   background: theme.colors.backgroundTopbar,
@@ -53,6 +54,7 @@ export const Topbar = ({ gridArea, project, page, publish }: TopbarProps) => {
         gap="2"
         css={{ width: theme.spacing[30] }}
       >
+        <ViewMode />
         <SyncStatus />
         <PreviewButton />
         {isFeatureEnabled("share2") && <ShareButton projectId={project.id} />}

--- a/apps/designer/app/designer/features/topbar/view-mode.tsx
+++ b/apps/designer/app/designer/features/topbar/view-mode.tsx
@@ -1,0 +1,30 @@
+import {
+  Flex,
+  AccessibleIcon,
+  rawTheme,
+  Tooltip,
+} from "@webstudio-is/design-system";
+import { CloudIcon } from "@webstudio-is/icons";
+import { useAuthPermit } from "~/shared/nano-states";
+
+export const ViewMode = () => {
+  const [authPermit] = useAuthPermit();
+
+  if (authPermit !== "view") {
+    return null;
+  }
+
+  return (
+    <Flex align="center" justify="center">
+      <AccessibleIcon label={`View mode`}>
+        <Tooltip
+          variant="wrapped"
+          content={<>View mode. Your changes will not be saved</>}
+        >
+          {/* @todo replace the icon, waiting for figma */}
+          <CloudIcon width={20} height={20} color={rawTheme.colors.yellow10} />
+        </Tooltip>
+      </AccessibleIcon>
+    </Flex>
+  );
+};

--- a/apps/designer/app/designer/shared/sync/sync-server.ts
+++ b/apps/designer/app/designer/shared/sync/sync-server.ts
@@ -5,6 +5,7 @@ import { restPatchPath } from "~/shared/router-utils";
 import { useEffect } from "react";
 import { enqueue, dequeue, queueStatus } from "./queue";
 import { useBeforeUnload } from "react-use";
+import { AuthPermit } from "@webstudio-is/trpc-interface";
 
 // Periodic check for new entries to group them into one job/call in sync queue.
 const NEW_ENTRIES_INTERVAL = 1000;
@@ -44,8 +45,13 @@ const useNewEntriesCheck = ({
   buildId,
   projectId,
   authToken,
+  authPermit,
 }: UserSyncServerProps) => {
   useEffect(() => {
+    if (authPermit === "view") {
+      return;
+    }
+
     // @todo setInterval can be completely avoided.
     // Right now prisma can't do atomic updates yet with sandbox documents
     // and backend fetches and updates big objects, so if we send quickly,
@@ -71,7 +77,7 @@ const useNewEntriesCheck = ({
     }, NEW_ENTRIES_INTERVAL);
 
     return () => clearInterval(intervalId);
-  }, [treeId, buildId, projectId, authToken]);
+  }, [treeId, buildId, projectId, authToken, authPermit]);
 };
 
 type UserSyncServerProps = {
@@ -79,6 +85,7 @@ type UserSyncServerProps = {
   treeId: Tree["id"];
   projectId: Project["id"];
   authToken: string | undefined;
+  authPermit: AuthPermit;
 };
 
 export const useSyncServer = (props: UserSyncServerProps) => {

--- a/apps/designer/app/routes/designer/$projectId.tsx
+++ b/apps/designer/app/routes/designer/$projectId.tsx
@@ -32,7 +32,7 @@ export const loader = async ({
     (await authorizeProject.getProjectPermit(
       {
         projectId: project.id,
-        permits: ["own", "build"],
+        permits: ["own", "build"] as const,
       },
       context
     )) ?? "view";

--- a/apps/designer/app/routes/designer/$projectId.tsx
+++ b/apps/designer/app/routes/designer/$projectId.tsx
@@ -26,12 +26,12 @@ export const loader = async ({
 
   const project = await db.project.loadById(params.projectId, context);
 
-  // At this point we already knew that if project loaded we have at least "view" permit
-  // having that getProjectPermit is heavy operation we can skip check "view" permit
   const authPermit =
     (await authorizeProject.getProjectPermit(
       {
         projectId: project.id,
+        // At this point we already knew that if project loaded we have at least "view" permit
+        // having that getProjectPermit is heavy operation we can skip check "view" permit
         permits: ["own", "build"] as const,
       },
       context

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -21,6 +21,7 @@ import type {
 } from "~/designer/shared/assets";
 import { useSyncInitializeOnce } from "../hook-utils";
 import { shallowComputed } from "../store-utils";
+import type { AuthPermit } from "@webstudio-is/trpc-interface";
 
 const useValue = <T>(atom: WritableAtom<T>) => {
   const value = useStore(atom);
@@ -262,6 +263,14 @@ export const useIsPreviewMode = () => useValue(isPreviewModeStore);
 export const useSetIsPreviewMode = (isPreviewMode: boolean) => {
   useSyncInitializeOnce(() => {
     isPreviewModeStore.set(isPreviewMode);
+  });
+};
+
+const authPermitStore = atom<AuthPermit>("view");
+export const useAuthPermit = () => useValue(authPermitStore);
+export const useSetAuthPermit = (authPermit: AuthPermit) => {
+  useSyncInitializeOnce(() => {
+    authPermitStore.set(authPermit);
   });
 };
 

--- a/packages/trpc-interface/src/authorize/project.server.ts
+++ b/packages/trpc-interface/src/authorize/project.server.ts
@@ -1,5 +1,5 @@
 import type { Project } from "@webstudio-is/prisma-client";
-import { AuthPermit } from "src/index.server";
+import { AuthPermit } from "../shared/authorization-router";
 import type { AppContext } from "../context/context.server";
 
 /**

--- a/packages/trpc-interface/src/authorize/project.server.ts
+++ b/packages/trpc-interface/src/authorize/project.server.ts
@@ -1,4 +1,5 @@
 import type { Project } from "@webstudio-is/prisma-client";
+import { AuthPermit } from "src/index.server";
 import type { AppContext } from "../context/context.server";
 
 /**
@@ -29,12 +30,10 @@ export const registerProjectOwner = async (
   });
 };
 
-type Permit = "view" | "edit" | "build" | "own";
-
 export const hasProjectPermit = async (
   props: {
     projectId: Project["id"];
-    permit: Permit;
+    permit: AuthPermit;
   },
   context: AppContext
 ) => {
@@ -114,10 +113,10 @@ export const hasProjectPermit = async (
  * @todo think about caching to authorizeTrpc.check.query
  * batching check queries would help too https://github.com/ory/keto/issues/812
  */
-export const getProjectPermit = async <T extends Permit>(
+export const getProjectPermit = async <T extends AuthPermit>(
   props: {
     projectId: string;
-    permits: T[];
+    permits: readonly T[];
   },
   context: AppContext
 ): Promise<T | undefined> => {

--- a/packages/trpc-interface/src/index.server.ts
+++ b/packages/trpc-interface/src/index.server.ts
@@ -4,3 +4,4 @@ export { createTrpcProxyServiceClient } from "./shared/client";
 export type { AppContext } from "./context/context.server";
 export * as authorizeProject from "./authorize/project.server";
 export * as authorizeAuthorizationToken from "./authorize/authorization-token.server";
+export type { AuthPermit } from "./shared/authorization-router";

--- a/packages/trpc-interface/src/shared/authorization-router.ts
+++ b/packages/trpc-interface/src/shared/authorization-router.ts
@@ -4,7 +4,8 @@ import { router, procedure } from "./trpc";
 import { prisma } from "@webstudio-is/prisma-client";
 
 const Relation = z.enum(["viewers", "editors", "builders", "owners"]);
-const Permit = z.enum(["view", "edit", "build", "own"]);
+const AuthPermit = z.enum(["view", "edit", "build", "own"]);
+export type AuthPermit = z.infer<typeof AuthPermit>;
 
 const DeleteCreateInput = z.discriminatedUnion("namespace", [
   z.object({
@@ -123,7 +124,7 @@ export const authorizationRouter = router({
         namespace: z.enum(["Project"]),
         id: z.string(),
 
-        permit: Permit,
+        permit: AuthPermit,
 
         subjectSet: z.object({
           namespace: z.enum(["User", "Token"]),


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

Disable sync for user/token with "view" permit and show view mode icon

<img width="294" alt="image" src="https://user-images.githubusercontent.com/5077042/216642624-00a75655-d8a8-49de-9818-a2bec00c637b.png">


## Steps for reproduction

Create Share view link. Copy link. Insert into the incognito window. See the screenshot above. Any changes should not cause savings.

_Assets saving, for now, are not prevented_

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
