### PR TITLE
Fix double delete when focused navigator tree

### DIFF
--- a/apps/designer/app/designer/features/sidebar-left/navigator/navigator.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/navigator/navigator.tsx
@@ -9,7 +9,6 @@ import {
   useRootInstance,
 } from "~/shared/nano-states";
 import { InstanceTree } from "~/designer/shared/tree";
-import { deleteInstance } from "~/shared/instance-utils";
 import { Header, CloseButton } from "../header";
 
 declare module "~/shared/pubsub" {
@@ -74,7 +73,6 @@ export const Navigator = ({ publish, isClosable, onClose }: NavigatorProps) => {
           onSelect={handleSelect}
           onHover={handleHover}
           onDragEnd={handleDragEnd}
-          onDelete={deleteInstance}
         />
       </Flex>
     </Flex>

--- a/packages/design-system/src/components/tree/tree.stories.tsx
+++ b/packages/design-system/src/components/tree/tree.stories.tsx
@@ -94,7 +94,6 @@ export const StressTest = ({ animate }: { animate: boolean }) => {
           </TreeItemBody>
         )}
         onDragEnd={(payload) => setRoot((root) => reparent(root, payload))}
-        onDelete={() => null}
       />
     </Flex>
   );

--- a/packages/design-system/src/components/tree/tree.tsx
+++ b/packages/design-system/src/components/tree/tree.tsx
@@ -36,7 +36,6 @@ export type TreeProps<Data extends { id: string }> = {
     itemId: string;
     dropTarget: { itemId: string; position: number | "end" };
   }) => void;
-  onDelete: (itemId: string) => void;
 };
 
 export const Tree = <Data extends { id: string }>({
@@ -53,7 +52,6 @@ export const Tree = <Data extends { id: string }>({
   onHover,
   animate,
   onDragEnd,
-  onDelete,
 }: TreeProps<Data>) => {
   const { getIsExpanded, setIsExpanded } = useExpandState({
     root,
@@ -236,7 +234,6 @@ export const Tree = <Data extends { id: string }>({
     selectedItemId,
     getIsExpanded,
     setIsExpanded,
-    onDelete,
     onEsc: dragHandlers.cancelCurrentDrag,
   });
 
@@ -303,7 +300,6 @@ const useKeyboardNavigation = <Data extends { id: string }>({
   selectedItemId,
   getIsExpanded,
   setIsExpanded,
-  onDelete,
   onEsc,
 }: {
   root: Data;
@@ -312,7 +308,6 @@ const useKeyboardNavigation = <Data extends { id: string }>({
   selectedItemId: string | undefined;
   getIsExpanded: (instance: Data) => boolean;
   setIsExpanded: (instance: Data, isExpanded: boolean) => void;
-  onDelete: (itemId: string) => void;
   onEsc: () => void;
 }) => {
   const selectedItem = useMemo(() => {
@@ -368,9 +363,6 @@ const useKeyboardNavigation = <Data extends { id: string }>({
         // prevent scrolling
         event.preventDefault();
       }
-    }
-    if (event.key === "Backspace" || event.key === "Delete") {
-      onDelete(selectedItem.id);
     }
     if (event.key === "Escape") {
       onEsc();


### PR DESCRIPTION
Looks like calling onDelete in navigator duplicates global delete shortcut.

## Code Review

- [ ] hi @rpominov, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
