### PR TITLE
Track delete shortcut on both canvas and designer

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -13,6 +13,7 @@ import {
 } from "@webstudio-is/react-sdk";
 import { publish } from "~/shared/pubsub";
 import { registerContainers, useCanvasStore } from "~/shared/sync";
+import { useSharedShortcuts } from "~/shared/shortcuts";
 import { useShortcuts } from "./shared/use-shortcuts";
 import {
   useInsertInstance,
@@ -137,6 +138,7 @@ export const Canvas = ({ data }: CanvasProps): JSX.Element | null => {
 
   // e.g. toggling preview is still needed in both modes
   useShortcuts();
+  useSharedShortcuts();
 
   const elements = useElementsTree();
 

--- a/apps/designer/app/canvas/shared/use-shortcuts.ts
+++ b/apps/designer/app/canvas/shared/use-shortcuts.ts
@@ -9,7 +9,6 @@ import {
   useTextEditingInstanceId,
   isPreviewModeStore,
 } from "~/shared/nano-states";
-import { deleteInstance } from "~/shared/instance-utils";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -67,28 +66,15 @@ const publishCancelCurrentDrag = () => {
 export const useShortcuts = () => {
   const [editingInstanceId, setEditingInstanceId] = useTextEditingInstanceId();
 
-  const deleteSelectedInstance = () => {
-    const selectedInstanceId = selectedInstanceIdStore.get();
-    if (selectedInstanceId === undefined) {
-      return;
-    }
-    deleteInstance(selectedInstanceId);
-  };
-
   const shortcutHandlerMap = {
     undo: store.undo.bind(store),
     redo: store.redo.bind(store),
-    delete: deleteSelectedInstance,
     preview: togglePreviewMode,
     breakpointsMenu: publishOpenBreakpointsMenu,
     breakpoint: publishSelectBreakpoint,
     zoom: publishZoom,
     esc: publishCancelCurrentDrag,
   } as const;
-
-  useHotkeys("backspace, delete", shortcutHandlerMap.delete, options, [
-    shortcutHandlerMap.delete,
-  ]);
 
   useHotkeys(
     "esc",

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -12,6 +12,7 @@ import { useSyncServer } from "./shared/sync/sync-server";
 import interFont from "@fontsource/inter/variable.css";
 // eslint-disable-next-line import/no-internal-modules
 import robotoMonoFont from "@fontsource/roboto-mono/index.css";
+import { useSharedShortcuts } from "~/shared/shortcuts";
 import { SidebarLeft } from "./features/sidebar-left";
 import { Inspector } from "./features/inspector";
 import { usePages, useProject, useCurrentPageId } from "./shared/nano-states";
@@ -267,6 +268,7 @@ export const Designer = ({
   const [publish, publishRef] = usePublish();
   useDesignerStore(publish);
   useSyncServer({ buildId, treeId, projectId: project.id, authToken });
+  useSharedShortcuts();
   useSetIsPreviewMode(authPermit === "view");
   const [isPreviewMode] = useIsPreviewMode();
   usePublishShortcuts(publish);

--- a/apps/designer/app/designer/features/topbar/menu/menu.tsx
+++ b/apps/designer/app/designer/features/topbar/menu/menu.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import { useNavigate } from "@remix-run/react";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import {
+  theme,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -25,9 +27,11 @@ import {
 } from "~/shared/theme";
 import { useClientSettings } from "~/designer/shared/client-settings";
 import { dashboardPath } from "~/shared/router-utils";
-import { theme } from "@webstudio-is/design-system";
-import { useIsPreviewMode } from "~/shared/nano-states";
-import { useState } from "react";
+import {
+  selectedInstanceIdStore,
+  useIsPreviewMode,
+} from "~/shared/nano-states";
+import { deleteInstance } from "~/shared/instance-utils";
 import { MenuButton } from "./menu-button";
 
 const ThemeMenuItem = () => {
@@ -165,10 +169,11 @@ export const Menu = ({ publish }: MenuProps) => {
           */}
           <DropdownMenuItem
             onSelect={() => {
-              publish({
-                type: "shortcut",
-                payload: { name: "delete" },
-              });
+              const selectedInstanceId = selectedInstanceIdStore.get();
+              if (selectedInstanceId === undefined) {
+                return;
+              }
+              deleteInstance(selectedInstanceId);
             }}
           >
             Delete

--- a/apps/designer/app/shared/shortcuts/shortcuts.ts
+++ b/apps/designer/app/shared/shortcuts/shortcuts.ts
@@ -1,11 +1,12 @@
-import type { Options } from "react-hotkeys-hook";
+import { Options, useHotkeys } from "react-hotkeys-hook";
+import { selectedInstanceIdStore } from "../nano-states";
+import { deleteInstance } from "../instance-utils";
 
 export const shortcuts = {
   esc: "esc",
   undo: "cmd+z, ctrl+z",
   redo: "cmd+shift+z, ctrl+shift+z",
   preview: "cmd+shift+p, ctrl+shift+p",
-  delete: "backspace, delete",
   breakpointsMenu: "cmd+b, ctrl+b",
   breakpoint: Array.from(new Array(9))
     .map((_, index) => `cmd+${index + 1}, ctrl+${index + 1}`)
@@ -14,7 +15,21 @@ export const shortcuts = {
 } as const;
 
 export const options: Options = {
-  splitKey: "+",
-  keydown: true,
-  enableOnTags: ["INPUT", "SELECT", "TEXTAREA"],
+  enableOnFormTags: true,
+};
+
+export const useSharedShortcuts = () => {
+  useHotkeys(
+    "backspace, delete",
+    () => {
+      const selectedInstanceId = selectedInstanceIdStore.get();
+      if (selectedInstanceId === undefined) {
+        return;
+      }
+      deleteInstance(selectedInstanceId);
+    },
+    // prevent instance deletion while deleting text
+    { enableOnFormTags: false, enableOnContentEditable: false },
+    []
+  );
 };

--- a/apps/designer/package.json
+++ b/apps/designer/package.json
@@ -82,7 +82,7 @@
     "react-color": "^2.19.3",
     "react-dom": "^17.0.2",
     "react-error-boundary": "^3.1.4",
-    "react-hotkeys-hook": "^3.4.7",
+    "react-hotkeys-hook": "^4.3.4",
     "react-use": "^17.3.2",
     "remix-auth": "^3.2.2",
     "remix-auth-form": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
       react-color: ^2.19.3
       react-dom: 17.0.2
       react-error-boundary: ^3.1.4
-      react-hotkeys-hook: ^3.4.7
+      react-hotkeys-hook: ^4.3.4
       react-test-renderer: ^17.0.2
       react-use: ^17.3.2
       relative-deps: ^1.0.7
@@ -221,7 +221,7 @@ importers:
       react-color: 2.19.3_react@17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-error-boundary: 3.1.4_react@17.0.2
-      react-hotkeys-hook: 3.4.7_sfoxds7t5ydpegc3knd667wn6m
+      react-hotkeys-hook: 4.3.4_sfoxds7t5ydpegc3knd667wn6m
       react-use: 17.4.0_sfoxds7t5ydpegc3knd667wn6m
       remix-auth: 3.2.2_@remix-run+react@1.12.0
       remix-auth-form: 1.1.2_@remix-run+react@1.12.0
@@ -16105,10 +16105,6 @@ packages:
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
-  /hotkeys-js/3.9.4:
-    resolution: {integrity: sha512-2zuLt85Ta+gIyvs4N88pCYskNrxf1TFv3LR9t5mdAZIX8BcgQQ48F2opUptvHa6m8zsy5v/a0i9mWzTrlNWU0Q==}
-    dev: false
-
   /html-entities/2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
 
@@ -20172,13 +20168,12 @@ packages:
       - csstype
     dev: false
 
-  /react-hotkeys-hook/3.4.7_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-+bbPmhPAl6ns9VkXkNNyxlmCAIyDAcWbB76O4I0ntr3uWCRuIQf/aRLartUahe9chVMPj+OEzzfk3CQSjclUEQ==}
+  /react-hotkeys-hook/4.3.4_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-XV/tMK8n0joWa4tSklfddLUDirbu8T/H1hRPPm+UnfdT2ajp/jZPDh0q3L24nYjsCSwNIA6XFewYPguqrTIXkg==}
     peerDependencies:
       react: '>=16.8.1'
       react-dom: '>=16.8.1'
     dependencies:
-      hotkeys-js: 3.9.4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: false


### PR DESCRIPTION
Here's the issue. We track shortcuts on canvas and designer though designer invoke hotkeys with shared configuration and loose edge cases. For example delete should not be invoked on inputs though shared configuration enforce it. If we disable inputs then undo/redo will stop working.

So for better safety we should track shortcuts in both designer and canvas with the same code and update synchronized stores instead of synchronizing shortcuts.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
