### PR TITLE
Assets view mode

### DIFF
--- a/apps/designer/app/designer/shared/assets/asset-upload.tsx
+++ b/apps/designer/app/designer/shared/assets/asset-upload.tsx
@@ -1,9 +1,10 @@
 import { ChangeEvent, useRef } from "react";
-import { Button, Flex } from "@webstudio-is/design-system";
+import { Button, Flex, Tooltip } from "@webstudio-is/design-system";
 import { UploadIcon } from "@webstudio-is/icons";
 import { type AssetType } from "@webstudio-is/asset-uploader";
 import { FONT_MIME_TYPES } from "@webstudio-is/fonts";
 import { useAssets } from "./use-assets";
+import { useAuthPermit } from "~/shared/nano-states";
 
 const useUpload = (type: AssetType) => {
   const { handleSubmit } = useAssets(type);
@@ -33,6 +34,13 @@ type AssetUploadProps = {
 
 export const AssetUpload = ({ type }: AssetUploadProps) => {
   const { inputRef, onChange } = useUpload(type);
+  const [authPermit] = useAuthPermit();
+
+  const uploadDisabled = authPermit === "view";
+  const tooltipContent = uploadDisabled
+    ? "View mode. You can't upload assets."
+    : undefined;
+
   return (
     <form onChange={onChange}>
       <Flex>
@@ -44,14 +52,17 @@ export const AssetUpload = ({ type }: AssetUploadProps) => {
           ref={inputRef}
           style={{ display: "none" }}
         />
-        <Button
-          type="button"
-          onClick={() => inputRef?.current?.click()}
-          css={{ flexGrow: 1 }}
-          prefix={<UploadIcon />}
-        >
-          Upload
-        </Button>
+        <Tooltip side="bottom" content={tooltipContent}>
+          <Button
+            type="button"
+            onClick={() => inputRef?.current?.click()}
+            css={{ flexGrow: 1 }}
+            prefix={<UploadIcon />}
+            disabled={uploadDisabled}
+          >
+            Upload
+          </Button>
+        </Tooltip>
       </Flex>
     </form>
   );

--- a/apps/designer/app/designer/shared/assets/asset-upload.tsx
+++ b/apps/designer/app/designer/shared/assets/asset-upload.tsx
@@ -36,8 +36,8 @@ export const AssetUpload = ({ type }: AssetUploadProps) => {
   const { inputRef, onChange } = useUpload(type);
   const [authPermit] = useAuthPermit();
 
-  const uploadDisabled = authPermit === "view";
-  const tooltipContent = uploadDisabled
+  const isUploadDisabled = authPermit === "view";
+  const tooltipContent = isUploadDisabled
     ? "View mode. You can't upload assets."
     : undefined;
 
@@ -58,7 +58,7 @@ export const AssetUpload = ({ type }: AssetUploadProps) => {
             onClick={() => inputRef?.current?.click()}
             css={{ flexGrow: 1 }}
             prefix={<UploadIcon />}
-            disabled={uploadDisabled}
+            disabled={isUploadDisabled}
           >
             Upload
           </Button>

--- a/apps/designer/app/designer/shared/fonts-manager/item-menu.tsx
+++ b/apps/designer/app/designer/shared/fonts-manager/item-menu.tsx
@@ -7,10 +7,12 @@ import {
   DeprecatedText2,
   DropdownMenuPortal,
   styled,
+  Tooltip,
 } from "@webstudio-is/design-system";
 import { MenuIcon } from "@webstudio-is/icons";
 import { type FocusEventHandler, useState, useRef, useEffect } from "react";
 import { theme } from "@webstudio-is/design-system";
+import { useAuthPermit } from "~/shared/nano-states";
 
 const MenuButton = styled(DeprecatedIconButton, {
   color: theme.colors.hint,
@@ -42,6 +44,13 @@ const ItemMenu = ({
     };
   }, []);
 
+  const [authPermit] = useAuthPermit();
+
+  const deleteDisabled = authPermit === "view";
+  const tooltipContent = deleteDisabled
+    ? "View mode. You can't delete assets."
+    : undefined;
+
   return (
     <DropdownMenu
       open={isOpen}
@@ -70,17 +79,20 @@ const ItemMenu = ({
       </DropdownMenuTrigger>
       <DropdownMenuPortal>
         <DropdownMenuContent align="start">
-          <DropdownMenuItem
-            onClick={(event) => {
-              // Prevent setting the current font to the item.
-              event.stopPropagation();
-            }}
-            onSelect={() => {
-              onDelete();
-            }}
-          >
-            <DeprecatedText2>Delete font</DeprecatedText2>
-          </DropdownMenuItem>
+          <Tooltip side="bottom" content={tooltipContent}>
+            <DropdownMenuItem
+              disabled={deleteDisabled}
+              onClick={(event) => {
+                // Prevent setting the current font to the item.
+                event.stopPropagation();
+              }}
+              onSelect={() => {
+                onDelete();
+              }}
+            >
+              <DeprecatedText2>Delete font</DeprecatedText2>
+            </DropdownMenuItem>
+          </Tooltip>
         </DropdownMenuContent>
       </DropdownMenuPortal>
     </DropdownMenu>

--- a/apps/designer/app/designer/shared/fonts-manager/item-menu.tsx
+++ b/apps/designer/app/designer/shared/fonts-manager/item-menu.tsx
@@ -4,7 +4,7 @@ import {
   DeprecatedIconButton,
   DropdownMenuContent,
   DropdownMenuItem,
-  DeprecatedText2,
+  Text,
   DropdownMenuPortal,
   styled,
   Tooltip,
@@ -46,8 +46,8 @@ const ItemMenu = ({
 
   const [authPermit] = useAuthPermit();
 
-  const deleteDisabled = authPermit === "view";
-  const tooltipContent = deleteDisabled
+  const isDeleteDisabled = authPermit === "view";
+  const tooltipContent = isDeleteDisabled
     ? "View mode. You can't delete assets."
     : undefined;
 
@@ -81,7 +81,7 @@ const ItemMenu = ({
         <DropdownMenuContent align="start">
           <Tooltip side="bottom" content={tooltipContent}>
             <DropdownMenuItem
-              disabled={deleteDisabled}
+              disabled={isDeleteDisabled}
               onClick={(event) => {
                 // Prevent setting the current font to the item.
                 event.stopPropagation();
@@ -90,7 +90,7 @@ const ItemMenu = ({
                 onDelete();
               }}
             >
-              <DeprecatedText2>Delete font</DeprecatedText2>
+              <Text>Delete font</Text>
             </DropdownMenuItem>
           </Tooltip>
         </DropdownMenuContent>

--- a/apps/designer/app/designer/shared/image-manager/image-info.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-info.tsx
@@ -4,6 +4,7 @@ import {
   Grid,
   DeprecatedText2,
   Button,
+  Tooltip,
 } from "@webstudio-is/design-system";
 import { getFormattedAspectRatio } from "./utils";
 import {
@@ -16,6 +17,7 @@ import prettyBytes from "pretty-bytes";
 import { Asset } from "@webstudio-is/asset-uploader";
 import { Filename } from "./filename";
 import { theme } from "@webstudio-is/design-system";
+import { useAuthPermit } from "~/shared/nano-states";
 
 type ImageInfoProps = {
   asset: Asset;
@@ -24,6 +26,13 @@ type ImageInfoProps = {
 
 export const ImageInfo = ({ asset, onDelete }: ImageInfoProps) => {
   const { size, meta, id, name } = asset;
+  const [authPermit] = useAuthPermit();
+
+  const deleteDisabled = authPermit === "view";
+  const tooltipContent = deleteDisabled
+    ? "View mode. You can't delete assets."
+    : undefined;
+
   return (
     <>
       <Box css={{ p: `${theme.spacing[5]} ${theme.spacing[9]}` }}>
@@ -58,13 +67,16 @@ export const ImageInfo = ({ asset, onDelete }: ImageInfoProps) => {
         </Box>
       ) : null}
       <Box css={{ p: `${theme.spacing[5]} ${theme.spacing[9]}` }}>
-        <Button
-          color="destructive"
-          onClick={() => onDelete([id])}
-          prefix={<TrashIcon />}
-        >
-          Delete
-        </Button>
+        <Tooltip side="bottom" content={tooltipContent}>
+          <Button
+            color="destructive"
+            onClick={() => onDelete([id])}
+            prefix={<TrashIcon />}
+            disabled={deleteDisabled}
+          >
+            Delete
+          </Button>
+        </Tooltip>
       </Box>
     </>
   );

--- a/apps/designer/app/designer/shared/image-manager/image-info.tsx
+++ b/apps/designer/app/designer/shared/image-manager/image-info.tsx
@@ -28,8 +28,8 @@ export const ImageInfo = ({ asset, onDelete }: ImageInfoProps) => {
   const { size, meta, id, name } = asset;
   const [authPermit] = useAuthPermit();
 
-  const deleteDisabled = authPermit === "view";
-  const tooltipContent = deleteDisabled
+  const isDeleteDisabled = authPermit === "view";
+  const tooltipContent = isDeleteDisabled
     ? "View mode. You can't delete assets."
     : undefined;
 
@@ -72,7 +72,7 @@ export const ImageInfo = ({ asset, onDelete }: ImageInfoProps) => {
             color="destructive"
             onClick={() => onDelete([id])}
             prefix={<TrashIcon />}
-            disabled={deleteDisabled}
+            disabled={isDeleteDisabled}
           >
             Delete
           </Button>


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

In view mode, we need to prevent users from deleting / creating assets in UI. (Server-side protection already done in the previous PR)

The other way can be just to hide buttons from the UI.
Also tooltip duration for disabled actions can be smaller.

## Steps for reproduction

Share the Link with View permissions.
Open that link in incognito mode.
Try to create/delete an asset

<img width="265" alt="image" src="https://user-images.githubusercontent.com/5077042/216938724-d8e0e3b3-28fe-405e-8997-0a8dd84a105e.png">


<img width="355" alt="image" src="https://user-images.githubusercontent.com/5077042/216938784-a1a59926-b41e-4193-8584-8387cae221f6.png">

<img width="263" alt="image" src="https://user-images.githubusercontent.com/5077042/216939092-13d59ddd-c601-4ebb-b536-d7c0bd4a572a.png">

<img width="308" alt="image" src="https://user-images.githubusercontent.com/5077042/216940665-f185e9b7-84c3-4ad7-8c61-43b3447a5777.png">


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
