### PR TITLE
Rename singular props and styles names

### DIFF
--- a/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
+++ b/apps/designer/app/canvas/features/wrapper-component/selected-instance-connector.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import type { Instance, PropsItem, Styles } from "@webstudio-is/project-build";
+import type { Instance, Prop, Styles } from "@webstudio-is/project-build";
 import { getBrowserStyle } from "@webstudio-is/react-sdk";
 import { publish, subscribe, subscribeAll } from "~/shared/pubsub";
 import {
@@ -54,7 +54,7 @@ export const SelectedInstanceConnector = ({
   instanceElementRef: { current: undefined | HTMLElement };
   instance: Instance;
   instanceStyles: Styles;
-  instanceProps: undefined | PropsItem[];
+  instanceProps: undefined | Prop[];
 }) => {
   useEffect(() => {
     const element = instanceElementRef.current;

--- a/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
+++ b/apps/designer/app/canvas/features/wrapper-component/wrapper-component.tsx
@@ -2,7 +2,7 @@ import type { MouseEvent, FormEvent } from "react";
 import { Suspense, lazy, useCallback, useMemo, useRef } from "react";
 import { useStore } from "@nanostores/react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import type { Instance, PropsItem } from "@webstudio-is/project-build";
+import type { Instance, Prop } from "@webstudio-is/project-build";
 import {
   type OnChangeChildren,
   renderWrapperComponentChildren,
@@ -41,7 +41,7 @@ const ContentEditable = ({
   return <Component ref={ref} {...props} contentEditable={true} />;
 };
 
-type UserProps = Record<PropsItem["name"], string | number | boolean>;
+type UserProps = Record<Prop["name"], string | number | boolean>;
 
 type WrapperComponentDevProps = {
   instance: Instance;

--- a/apps/designer/app/designer/features/props-panel/control.tsx
+++ b/apps/designer/app/designer/features/props-panel/control.tsx
@@ -1,4 +1,4 @@
-import type { Instance, PropsItem } from "@webstudio-is/project-build";
+import type { Instance, Prop } from "@webstudio-is/project-build";
 import { getComponentMetaProps } from "@webstudio-is/react-sdk";
 import warnOnce from "warn-once";
 import {
@@ -176,7 +176,7 @@ const assertUnreachable = (_arg: never, errorMessage: string) => {
 
 type ControlProps = {
   component: Instance["component"];
-  userProp: PropsItem;
+  userProp: Prop;
   onChangePropValue: (value: UserPropValue) => void;
   setCssProperty: SetProperty;
 };

--- a/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentStory } from "@storybook/react";
-import type { PropsItem } from "@webstudio-is/project-build";
+import type { Prop } from "@webstudio-is/project-build";
 import { getComponentMetaProps } from "@webstudio-is/react-sdk";
 import { propsStore } from "~/shared/nano-states";
 import { PropsPanel } from "./props-panel";
@@ -78,7 +78,7 @@ export const AllProps: ComponentStory<typeof PropsPanel> = () => {
         instanceId: "3",
         name,
         value: value?.defaultValue ?? "",
-      } as PropsItem;
+      } as Prop;
     })
   );
   return (

--- a/apps/designer/app/designer/features/props-panel/props-panel.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import store from "immerhin";
-import type { Instance, PropsItem, Tree } from "@webstudio-is/project-build";
+import type { Instance, Prop, Tree } from "@webstudio-is/project-build";
 import { getComponentMetaProps } from "@webstudio-is/react-sdk";
 import {
   theme,
@@ -119,7 +119,7 @@ const Combobox = ({
 };
 
 type PropertyProps = {
-  userProp: PropsItem;
+  userProp: Prop;
   component: Instance["component"];
   onChangePropName: (name: string) => void;
   onChangePropValue: (value: UserPropValue) => void;

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -174,14 +174,14 @@ export const stylesIndexStore = computed(
   [stylesStore, styleSourceSelectionsStore],
   (styles, styleSourceSelections) => {
     const stylesByStyleSourceId = new Map<StyleSource["id"], Styles>();
-    for (const stylesItem of styles) {
-      const { styleSourceId } = stylesItem;
+    for (const styleDecl of styles) {
+      const { styleSourceId } = styleDecl;
       let styleSourceStyles = stylesByStyleSourceId.get(styleSourceId);
       if (styleSourceStyles === undefined) {
         styleSourceStyles = [];
         stylesByStyleSourceId.set(styleSourceId, styleSourceStyles);
       }
-      styleSourceStyles.push(stylesItem);
+      styleSourceStyles.push(styleDecl);
     }
 
     const stylesByInstanceId = new Map<Instance["id"], Styles>();

--- a/apps/designer/app/shared/tree-utils.test.ts
+++ b/apps/designer/app/shared/tree-utils.test.ts
@@ -1,8 +1,8 @@
 import { test, expect } from "@jest/globals";
 import type {
   Instance,
-  PropsItem,
-  StylesItem,
+  Prop,
+  StyleDecl,
   StyleSource,
   StyleSourceSelection,
 } from "@webstudio-is/project-build";
@@ -27,7 +27,7 @@ const createInstance = (id: Instance["id"], children: Instance[]): Instance => {
   };
 };
 
-const createProp = (id: string, instanceId: string): PropsItem => {
+const createProp = (id: string, instanceId: string): Prop => {
   return {
     id,
     instanceId,
@@ -65,7 +65,7 @@ const createStyleSourceSelection = (
   };
 };
 
-const createStyleDecl = (styleSourceId: string): StylesItem => {
+const createStyleDecl = (styleSourceId: string): StyleDecl => {
   return {
     styleSourceId,
     breakpointId: "breakpointId",

--- a/packages/project-build/src/schema/props.ts
+++ b/packages/project-build/src/schema/props.ts
@@ -1,58 +1,58 @@
 import { z } from "zod";
 import { Asset } from "@webstudio-is/asset-uploader";
 
-const basePropsItem = {
+const baseProp = {
   id: z.string(),
   instanceId: z.string(),
   name: z.string(),
   required: z.optional(z.boolean()),
 };
 
-const SharedPropsItem = z.union([
+const SharedProp = z.union([
   z.object({
-    ...basePropsItem,
+    ...baseProp,
     type: z.literal("number"),
     value: z.number(),
   }),
   z.object({
-    ...basePropsItem,
+    ...baseProp,
     type: z.literal("string"),
     value: z.string(),
   }),
   z.object({
-    ...basePropsItem,
+    ...baseProp,
     type: z.literal("boolean"),
     value: z.boolean(),
   }),
 ]);
 
-export const StoredPropsItem = z.union([
-  SharedPropsItem,
+export const StoredProp = z.union([
+  SharedProp,
   z.object({
-    ...basePropsItem,
+    ...baseProp,
     type: z.literal("asset"),
     // asset.id is stored in database
     value: z.string(),
   }),
 ]);
 
-export type StoredPropsItem = z.infer<typeof StoredPropsItem>;
+export type StoredProp = z.infer<typeof StoredProp>;
 
-export const StoredProps = z.array(StoredPropsItem);
+export const StoredProps = z.array(StoredProp);
 
 export type StoredProps = z.infer<typeof StoredProps>;
 
-export const PropsItem = z.union([
-  SharedPropsItem,
+export const Prop = z.union([
+  SharedProp,
   z.object({
-    ...basePropsItem,
+    ...baseProp,
     type: z.literal("asset"),
     value: Asset,
   }),
 ]);
 
-export type PropsItem = z.infer<typeof PropsItem>;
+export type Prop = z.infer<typeof Prop>;
 
-export const Props = z.array(PropsItem);
+export const Props = z.array(Prop);
 
 export type Props = z.infer<typeof Props>;

--- a/packages/project-build/src/schema/styles.ts
+++ b/packages/project-build/src/schema/styles.ts
@@ -10,7 +10,7 @@ const StoredImageValue = z.object({
   value: z.array(z.object({ type: z.literal("asset"), value: z.string() })),
 });
 
-export const StoredStylesItem = z.object({
+export const StoredStyleDecl = z.object({
   styleSourceId: z.string(),
   breakpointId: z.string(),
   // @todo can't figure out how to make property to be enum
@@ -18,13 +18,13 @@ export const StoredStylesItem = z.object({
   value: z.union([StoredImageValue, SharedStyleValue]),
 });
 
-export type StoredStylesItem = z.infer<typeof StoredStylesItem>;
+export type StoredStyleDecl = z.infer<typeof StoredStyleDecl>;
 
-export const StoredStyles = z.array(StoredStylesItem);
+export const StoredStyles = z.array(StoredStyleDecl);
 
 export type StoredStyles = z.infer<typeof StoredStyles>;
 
-export const StylesItem = z.object({
+export const StyleDecl = z.object({
   styleSourceId: z.string(),
   breakpointId: z.string(),
   // @todo can't figure out how to make property to be enum
@@ -32,8 +32,8 @@ export const StylesItem = z.object({
   value: z.union([ImageValue, SharedStyleValue]),
 });
 
-export type StylesItem = z.infer<typeof StylesItem>;
+export type StyleDecl = z.infer<typeof StyleDecl>;
 
-export const Styles = z.array(StylesItem);
+export const Styles = z.array(StyleDecl);
 
 export type Styles = z.infer<typeof Styles>;


### PR DESCRIPTION
We decided to get rid of "Item" naming, here renamed everything left.

- PropsItem -> Prop
- StylesItem -> StyleDecl

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
