### PR TITLE
Move selected style source into separate store

### DIFF
--- a/apps/designer/app/canvas/canvas.tsx
+++ b/apps/designer/app/canvas/canvas.tsx
@@ -37,6 +37,7 @@ import {
   useSubscribeScrollState,
   useIsPreviewMode,
   useSetAssets,
+  useSetTreeId,
 } from "~/shared/nano-states";
 import { usePublishScrollState } from "./shared/use-publish-scroll-state";
 import { useDragAndDrop } from "./shared/use-drag-drop";
@@ -119,6 +120,7 @@ export const Canvas = ({ data }: CanvasProps): JSX.Element | null => {
     throw new Error("Tree is null");
   }
   const isDesignerReady = useSubscribeDesignerReady();
+  useSetTreeId(data.tree.id);
   useSetAssets(data.assets);
   useSetBreakpoints(data.build.breakpoints);
   useSetProps(data.tree.props);

--- a/apps/designer/app/designer/designer.tsx
+++ b/apps/designer/app/designer/designer.tsx
@@ -35,6 +35,7 @@ import {
   useIsPreviewMode,
   useSetAuthPermit,
   useSetIsPreviewMode,
+  useSetTreeId,
 } from "~/shared/nano-states";
 import { useClientSettings } from "./shared/client-settings";
 import { Navigator } from "./features/sidebar-left";
@@ -266,6 +267,7 @@ export const Designer = ({
   useSetAuthPermit(authPermit);
   useSubscribeBreakpoints();
   useSetProject(project);
+  useSetTreeId(treeId);
   useSetPages(pages);
   useSetCurrentPageId(pageId);
   const [publish, publishRef] = usePublish();
@@ -354,7 +356,7 @@ export const Designer = ({
           {dragAndDropState.isDragging ? (
             <TreePrevew />
           ) : (
-            <Inspector treeId={treeId} publish={publish} />
+            <Inspector publish={publish} />
           )}
         </SidePanel>
         <Footer />

--- a/apps/designer/app/designer/features/inspector/inspector.tsx
+++ b/apps/designer/app/designer/features/inspector/inspector.tsx
@@ -1,6 +1,5 @@
 import { useRef } from "react";
 import { useStore } from "@nanostores/react";
-import { Tree } from "@webstudio-is/project-build";
 import type { Publish } from "~/shared/pubsub";
 import {
   DeprecatedText2,
@@ -21,7 +20,6 @@ import { theme } from "@webstudio-is/design-system";
 import { selectedInstanceStore } from "~/shared/nano-states";
 
 type InspectorProps = {
-  treeId: Tree["id"];
   publish: Publish;
 };
 
@@ -31,7 +29,7 @@ const contentStyle = {
   overflow: "auto",
 };
 
-export const Inspector = ({ treeId, publish }: InspectorProps) => {
+export const Inspector = ({ publish }: InspectorProps) => {
   const selectedInstance = useStore(selectedInstanceStore);
   const tabsRef = useRef<HTMLDivElement>(null);
 
@@ -71,15 +69,10 @@ export const Inspector = ({ treeId, publish }: InspectorProps) => {
             </TabsTrigger>
           </TabsList>
           <TabsContent value="style" css={contentStyle}>
-            <StylePanel
-              treeId={treeId}
-              publish={publish}
-              selectedInstance={selectedInstance}
-            />
+            <StylePanel publish={publish} selectedInstance={selectedInstance} />
           </TabsContent>
           <TabsContent value="props" css={contentStyle}>
             <PropsPanel
-              treeId={treeId}
               publish={publish}
               key={selectedInstance.id /* Re-render when instance changes */}
               selectedInstance={selectedInstance}

--- a/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
@@ -21,7 +21,6 @@ export const NoProps: ComponentStory<typeof PropsPanel> = () => {
   ]);
   return (
     <PropsPanel
-      treeId="treeId"
       selectedInstance={{
         type: "instance",
         id: "1",
@@ -38,7 +37,6 @@ export const RequiredProps: ComponentStory<typeof PropsPanel> = () => {
   propsStore.set([]);
   return (
     <PropsPanel
-      treeId="treeId"
       selectedInstance={{
         type: "instance",
         id: "1",
@@ -55,7 +53,6 @@ export const DefaultProps: ComponentStory<typeof PropsPanel> = () => {
   propsStore.set([]);
   return (
     <PropsPanel
-      treeId="treeId"
       selectedInstance={{
         type: "instance",
         id: "1",
@@ -83,7 +80,6 @@ export const AllProps: ComponentStory<typeof PropsPanel> = () => {
   );
   return (
     <PropsPanel
-      treeId="treeId"
       selectedInstance={{
         type: "instance",
         id: "3",

--- a/apps/designer/app/designer/features/props-panel/props-panel.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import store from "immerhin";
-import type { Instance, Prop, Tree } from "@webstudio-is/project-build";
+import type { Instance, Prop } from "@webstudio-is/project-build";
 import { getComponentMetaProps } from "@webstudio-is/react-sdk";
 import {
   theme,
@@ -213,16 +213,11 @@ const Property = ({
 };
 
 type PropsPanelProps = {
-  treeId: Tree["id"];
   publish: Publish;
   selectedInstance: Instance;
 };
 
-export const PropsPanel = ({
-  treeId,
-  selectedInstance,
-  publish,
-}: PropsPanelProps) => {
+export const PropsPanel = ({ selectedInstance, publish }: PropsPanelProps) => {
   const instanceId = selectedInstance.id;
   const instanceProps = useInstanceProps(instanceId);
 
@@ -255,7 +250,6 @@ export const PropsPanel = ({
   });
 
   const { setProperty: setCssProperty } = useStyleData({
-    treeId,
     selectedInstance,
     publish,
   });

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -1,14 +1,14 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { useStore } from "@nanostores/react";
-import { nanoid } from "nanoid";
 import store from "immerhin";
 import warnOnce from "warn-once";
-import type { Instance, Tree } from "@webstudio-is/project-build";
+import type { Instance } from "@webstudio-is/project-build";
 import type { StyleUpdates } from "@webstudio-is/project";
 import type { StyleProperty, StyleValue } from "@webstudio-is/css-data";
 import { type Publish } from "~/shared/pubsub";
 import {
-  styleSourceSelectionsIndexStore,
+  selectedInstanceStyleSourcesStore,
+  selectedStyleSourceStore,
   styleSourceSelectionsStore,
   styleSourcesStore,
   stylesStore,
@@ -21,7 +21,6 @@ import {
 // @todo: must be removed, now it's only for compatibility with existing code
 import { parseCssValue } from "./parse-css-value";
 import { useStyleInfo } from "./style-info";
-import { shallowComputed } from "~/shared/store-utils";
 
 declare module "~/shared/pubsub" {
   export interface PubsubMap {
@@ -31,7 +30,6 @@ declare module "~/shared/pubsub" {
 }
 
 type UseStyleData = {
-  treeId: Tree["id"];
   publish: Publish;
   selectedInstance: Instance;
 };
@@ -56,34 +54,22 @@ export type CreateBatchUpdate = () => {
   publish: (options?: StyleUpdateOptions) => void;
 };
 
-export const useStyleData = ({
-  treeId,
-  selectedInstance,
-  publish,
-}: UseStyleData) => {
+export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
   const [selectedBreakpoint] = useSelectedBreakpoint();
-  const instanceStyleSourcesStore = useMemo(() => {
-    return shallowComputed(
-      [styleSourceSelectionsIndexStore],
-      (styleSourceSelectionsIndex) => {
-        return (
-          styleSourceSelectionsIndex.styleSourcesByInstanceId.get(
-            selectedInstance.id
-          ) ?? []
-        );
-      }
-    );
-  }, [selectedInstance.id]);
-  const instanceStyleSources = useStore(instanceStyleSourcesStore);
-  const localStyleSource = instanceStyleSources.find(
-    (styleSource) => styleSource.type === "local"
+  const selectedInstanceStyleSources = useStore(
+    selectedInstanceStyleSourcesStore
   );
+  const selectedStyleSource = useStore(selectedStyleSourceStore);
 
   const currentStyle = useStyleInfo();
 
   const publishUpdates = useCallback(
     (type: "update" | "preview", updates: StyleUpdates["updates"]) => {
-      if (updates.length === 0 || selectedBreakpoint === undefined) {
+      if (
+        updates.length === 0 ||
+        selectedBreakpoint === undefined ||
+        selectedStyleSource === undefined
+      ) {
         return;
       }
       publish({
@@ -104,24 +90,24 @@ export const useStyleData = ({
         (styleSourceSelections, styleSources, styles) => {
           const instanceId = selectedInstance.id;
           const breakpointId = selectedBreakpoint.id;
-          const styleSourceId = localStyleSource?.id ?? nanoid();
-          // crate style source and its selection on currently selected instance
-          if (localStyleSource === undefined) {
-            styleSources.push({
-              type: "local",
-              id: styleSourceId,
-              treeId,
-            });
-            replaceByOrAppendMutable(
-              styleSourceSelections,
-              {
-                instanceId,
-                values: [styleSourceId],
-              },
-              (styleSourceSelection) =>
-                styleSourceSelection.instanceId === instanceId
-            );
-          }
+          const styleSourceId = selectedStyleSource.id;
+          replaceByOrAppendMutable(
+            styleSources,
+            selectedStyleSource,
+            (item) => item.id === styleSourceId
+          );
+          const selections = selectedInstanceStyleSources.map(
+            (styleSource) => styleSource.id
+          );
+          replaceByOrAppendMutable(
+            styleSourceSelections,
+            {
+              instanceId,
+              values: [...selections, styleSourceId],
+            },
+            (styleSourceSelection) =>
+              styleSourceSelection.instanceId === instanceId
+          );
 
           for (const update of updates) {
             if (update.operation === "set") {
@@ -153,7 +139,7 @@ export const useStyleData = ({
         }
       );
     },
-    [publish, selectedBreakpoint, selectedInstance, localStyleSource, treeId]
+    [publish, selectedBreakpoint, selectedInstance, selectedStyleSource]
   );
 
   // @deprecated should not be called

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -1,5 +1,4 @@
 import { useCallback } from "react";
-import { useStore } from "@nanostores/react";
 import store from "immerhin";
 import warnOnce from "warn-once";
 import type { Instance } from "@webstudio-is/project-build";
@@ -56,15 +55,15 @@ export type CreateBatchUpdate = () => {
 
 export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
   const [selectedBreakpoint] = useSelectedBreakpoint();
-  const selectedInstanceStyleSources = useStore(
-    selectedInstanceStyleSourcesStore
-  );
-  const selectedStyleSource = useStore(selectedStyleSourceStore);
 
   const currentStyle = useStyleInfo();
 
   const publishUpdates = useCallback(
     (type: "update" | "preview", updates: StyleUpdates["updates"]) => {
+      const selectedStyleSource = selectedStyleSourceStore.get();
+      const selectedInstanceStyleSources =
+        selectedInstanceStyleSourcesStore.get();
+
       if (
         updates.length === 0 ||
         selectedBreakpoint === undefined ||
@@ -139,7 +138,7 @@ export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
         }
       );
     },
-    [publish, selectedBreakpoint, selectedInstance, selectedStyleSource]
+    [publish, selectedBreakpoint, selectedInstance]
   );
 
   // @deprecated should not be called

--- a/apps/designer/app/designer/features/style-panel/style-panel.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-panel.tsx
@@ -6,7 +6,7 @@ import {
   DeprecatedParagraph,
   SearchField,
 } from "@webstudio-is/design-system";
-import type { Instance, Tree } from "@webstudio-is/project-build";
+import type { Instance } from "@webstudio-is/project-build";
 import { useStyleData } from "./shared/use-style-data";
 import { StyleSettings } from "./style-settings";
 import { useState } from "react";
@@ -17,19 +17,13 @@ import {
 import { theme } from "@webstudio-is/design-system";
 
 type StylePanelProps = {
-  treeId: Tree["id"];
   publish: Publish;
   selectedInstance: Instance;
 };
 
-export const StylePanel = ({
-  treeId,
-  selectedInstance,
-  publish,
-}: StylePanelProps) => {
+export const StylePanel = ({ selectedInstance, publish }: StylePanelProps) => {
   const { currentStyle, setProperty, deleteProperty, createBatchUpdate } =
     useStyleData({
-      treeId,
       selectedInstance,
       publish,
     });


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/807

this will let to reuse the logic and newly generated local style source with style source input.

## Code Review

- [ ] hi @kof, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
