### PR TITLE
Fix crash when duplicating a project

### DIFF
--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -157,15 +157,17 @@ export const loadById = async (
 };
 
 export const clone = async (
-  { projectId, treeId }: { projectId: Project["id"]; treeId: Tree["id"] },
+  from: { projectId: Project["id"]; treeId: Tree["id"] },
+  to: { projectId: Project["id"]; buildId: Project["id"] },
   context: AppContext,
   client: Prisma.TransactionClient = prisma
 ) => {
-  const tree = await loadById({ projectId, treeId }, context, client);
+  const tree = await loadById(from, context, client);
   if (tree === null) {
-    throw new Error(`Tree ${treeId} not found`);
+    throw new Error(`Tree ${from.projectId}/${from.treeId} not found`);
   }
-  return await create(tree, client);
+
+  return await create({ ...tree, ...to }, client);
 };
 
 export const patch = async (


### PR DESCRIPTION
## Description

Currently if you try to duplicate a project the app crashes like this:

![image](https://user-images.githubusercontent.com/825702/217212801-a4b994f0-656d-41da-923c-536df138ee93.png)

The problem is that we use destination `projectId` when trying to load source tree. This PR fixes the issue.

## Steps for reproduction

Go to dashboard and duplicate a project

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
- [ ] hi @istarkov, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)


## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
