### PR TITLE
Synchronize initial state of client stores

### DIFF
--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -170,6 +170,12 @@ export const useCanvasStore = (publish: Publish) => {
         value: container.get(),
       });
     }
+    for (const [namespace, store] of clientStores) {
+      data.push({
+        namespace,
+        value: store.get(),
+      });
+    }
     publish({
       type: "sendStoreData",
       payload: {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/959

We usually rely on default which is the same everywhere. Though with assets initial state comes from server so it should be synchronized.

The issue was not visible because we also load assets in runtime which does not seem to happen on project switch.

## Code Review

- [ ] hi @kof, I need you to do
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
