### PR TITLE
Implement basic style source ui

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -98,17 +98,17 @@ export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
           const selections = selectedInstanceStyleSources.map(
             (styleSource) => styleSource.id
           );
-          if (selections.includes(styleSourceId) === false) {
-            replaceByOrAppendMutable(
-              styleSourceSelections,
-              {
-                instanceId,
-                values: [...selections, styleSourceId],
-              },
-              (styleSourceSelection) =>
-                styleSourceSelection.instanceId === instanceId
-            );
-          }
+          replaceByOrAppendMutable(
+            styleSourceSelections,
+            {
+              instanceId,
+              values: selections.includes(styleSourceId)
+                ? selections
+                : [...selections, styleSourceId],
+            },
+            (styleSourceSelection) =>
+              styleSourceSelection.instanceId === instanceId
+          );
 
           for (const update of updates) {
             if (update.operation === "set") {

--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -98,15 +98,17 @@ export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
           const selections = selectedInstanceStyleSources.map(
             (styleSource) => styleSource.id
           );
-          replaceByOrAppendMutable(
-            styleSourceSelections,
-            {
-              instanceId,
-              values: [...selections, styleSourceId],
-            },
-            (styleSourceSelection) =>
-              styleSourceSelection.instanceId === instanceId
-          );
+          if (selections.includes(styleSourceId) === false) {
+            replaceByOrAppendMutable(
+              styleSourceSelections,
+              {
+                instanceId,
+                values: [...selections, styleSourceId],
+              },
+              (styleSourceSelection) =>
+                styleSourceSelection.instanceId === instanceId
+            );
+          }
 
           for (const update of updates) {
             if (update.operation === "set") {

--- a/apps/designer/app/designer/features/style-panel/style-panel.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-panel.tsx
@@ -1,20 +1,20 @@
-import type { Publish } from "~/shared/pubsub";
-import { willRender } from "~/designer/shared/breakpoints";
+import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import {
+  theme,
   Box,
   Card,
   DeprecatedParagraph,
-  SearchField,
 } from "@webstudio-is/design-system";
 import type { Instance } from "@webstudio-is/project-build";
+import type { Publish } from "~/shared/pubsub";
+import { willRender } from "~/designer/shared/breakpoints";
 import { useStyleData } from "./shared/use-style-data";
 import { StyleSettings } from "./style-settings";
-import { useState } from "react";
 import {
   useCanvasWidth,
   useSelectedBreakpoint,
 } from "~/designer/shared/nano-states";
-import { theme } from "@webstudio-is/design-system";
+import { StyleSourcesSection } from "./style-source-section";
 
 type StylePanelProps = {
   publish: Publish;
@@ -30,7 +30,6 @@ export const StylePanel = ({ selectedInstance, publish }: StylePanelProps) => {
 
   const [breakpoint] = useSelectedBreakpoint();
   const [canvasWidth] = useCanvasWidth();
-  const [search, setSearch] = useState("");
 
   if (
     currentStyle === undefined ||
@@ -57,17 +56,17 @@ export const StylePanel = ({ selectedInstance, publish }: StylePanelProps) => {
 
   return (
     <>
-      <Box css={{ px: theme.spacing[9], py: theme.spacing[3] }}>
-        <SearchField
-          placeholder="Search"
-          onChange={(event) => {
-            setSearch(event.target.value);
+      {isFeatureEnabled("styleSourceInput") && (
+        <Box
+          css={{
+            px: theme.spacing[9],
+            pb: theme.spacing[9],
+            boxShadow: `0px 1px 0 ${theme.colors.panelOutline}`,
           }}
-          onCancel={() => {
-            setSearch("");
-          }}
-        />
-      </Box>
+        >
+          <StyleSourcesSection />
+        </Box>
+      )}
 
       <Box
         css={{
@@ -75,7 +74,7 @@ export const StylePanel = ({ selectedInstance, publish }: StylePanelProps) => {
         }}
       >
         <StyleSettings
-          search={search}
+          search=""
           currentStyle={currentStyle}
           setProperty={setProperty}
           deleteProperty={deleteProperty}

--- a/apps/designer/app/designer/features/style-panel/style-source-section.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-source-section.tsx
@@ -1,0 +1,199 @@
+import store from "immerhin";
+import { nanoid } from "nanoid";
+import { theme, DeprecatedText2 } from "@webstudio-is/design-system";
+import type {
+  StyleSource,
+  StyleSourceSelection,
+} from "@webstudio-is/project-build";
+import { ItemState, StyleSourceInput } from "./style-source";
+import { useStore } from "@nanostores/react";
+import {
+  availableStyleSourcesStore,
+  selectedInstanceIdStore,
+  selectedInstanceStyleSourcesStore,
+  selectedStyleSourceIdStore,
+  selectedStyleSourceStore,
+  styleSourceSelectionsStore,
+  styleSourcesStore,
+} from "~/shared/nano-states";
+import {
+  removeByMutable,
+  replaceByOrAppendMutable,
+} from "~/shared/array-utils";
+
+const createStyleSource = (name: string) => {
+  const selectedInstanceId = selectedInstanceIdStore.get();
+  const selectedInstanceStyleSources = selectedInstanceStyleSourcesStore.get();
+  if (selectedInstanceId === undefined) {
+    return;
+  }
+  const newStyleSource: StyleSource = {
+    type: "token",
+    id: nanoid(),
+    name,
+  };
+  const newStyleSources = [...selectedInstanceStyleSources, newStyleSource];
+  const newStyleSourceSelection: StyleSourceSelection = {
+    instanceId: selectedInstanceId,
+    values: [
+      ...selectedInstanceStyleSources.map((styleSource) => styleSource.id),
+      newStyleSource.id,
+    ],
+  };
+  store.createTransaction(
+    [styleSourcesStore, styleSourceSelectionsStore],
+    (styleSources, styleSourceSelections) => {
+      // set new style source and local if not set before
+      for (const newStyleSource of newStyleSources) {
+        replaceByOrAppendMutable(
+          styleSources,
+          newStyleSource,
+          (styleSource) => styleSource.id === newStyleSource.id
+        );
+      }
+      replaceByOrAppendMutable(
+        styleSourceSelections,
+        newStyleSourceSelection,
+        (styleSourceSelection) =>
+          styleSourceSelection.instanceId === selectedInstanceId
+      );
+    }
+  );
+};
+
+const addStyleSourceToInstace = (styleSourceId: StyleSource["id"]) => {
+  const selectedInstanceId = selectedInstanceIdStore.get();
+  const selectedInstanceStyleSources = selectedInstanceStyleSourcesStore.get();
+  if (selectedInstanceId === undefined) {
+    return;
+  }
+  const newStyleSourceSelection: StyleSourceSelection = {
+    instanceId: selectedInstanceId,
+    values: [
+      ...selectedInstanceStyleSources.map((styleSource) => styleSource.id),
+      styleSourceId,
+    ],
+  };
+  store.createTransaction(
+    [styleSourcesStore, styleSourceSelectionsStore],
+    (styleSources, styleSourceSelections) => {
+      // set local style source if not set before
+      for (const newStyleSource of selectedInstanceStyleSources) {
+        replaceByOrAppendMutable(
+          styleSources,
+          newStyleSource,
+          (styleSource) => styleSource.id === newStyleSource.id
+        );
+      }
+      replaceByOrAppendMutable(
+        styleSourceSelections,
+        newStyleSourceSelection,
+        (styleSourceSelection) =>
+          styleSourceSelection.instanceId === selectedInstanceId
+      );
+    }
+  );
+};
+
+const removeStyleSourceFromInstance = (styleSourceId: StyleSource["id"]) => {
+  const selectedInstanceId = selectedInstanceIdStore.get();
+  store.createTransaction(
+    [styleSourceSelectionsStore],
+    (styleSourceSelections) => {
+      const styleSourceSelection = styleSourceSelections.find(
+        (styleSourceSelection) =>
+          styleSourceSelection.instanceId === selectedInstanceId
+      );
+      if (styleSourceSelection === undefined) {
+        return;
+      }
+      removeByMutable(
+        styleSourceSelection.values,
+        (item) => item === styleSourceId
+      );
+    }
+  );
+};
+
+const reorderStyleSources = (styleSourceIds: StyleSource["id"][]) => {
+  const selectedInstanceId = selectedInstanceIdStore.get();
+  store.createTransaction(
+    [styleSourceSelectionsStore],
+    (styleSourceSelections) => {
+      const styleSourceSelection = styleSourceSelections.find(
+        (styleSourceSelection) =>
+          styleSourceSelection.instanceId === selectedInstanceId
+      );
+      if (styleSourceSelection === undefined) {
+        return;
+      }
+      styleSourceSelection.values = styleSourceIds;
+    }
+  );
+};
+
+const convertToInputItem = (
+  styleSource: StyleSource,
+  selectedStyleSource?: StyleSource["id"]
+) => {
+  const state: ItemState =
+    selectedStyleSource === styleSource.id ? "selected" : "unselected";
+  if (styleSource.type === "local") {
+    return {
+      id: styleSource.id,
+      label: "Local",
+      isEditable: false,
+      state,
+      source: styleSource.type,
+    };
+  }
+  return {
+    id: styleSource.id,
+    label: styleSource.name,
+    isEditable: true,
+    state,
+    source: styleSource.type,
+  };
+};
+
+export const StyleSourcesSection = () => {
+  const availableStyleSources = useStore(availableStyleSourcesStore);
+  const selectedInstanceStyleSources = useStore(
+    selectedInstanceStyleSourcesStore
+  );
+  const selectedStyleSource = useStore(selectedStyleSourceStore);
+  const items = availableStyleSources.map((styleSource) =>
+    convertToInputItem(styleSource)
+  );
+  const value = selectedInstanceStyleSources.map((styleSource) =>
+    convertToInputItem(styleSource, selectedStyleSource?.id)
+  );
+
+  return (
+    <>
+      <DeprecatedText2 css={{ py: theme.spacing[9] }} variant="label">
+        Style Sources
+      </DeprecatedText2>
+
+      <StyleSourceInput
+        items={items}
+        value={value}
+        onCreateItem={({ label }) => {
+          createStyleSource(label);
+        }}
+        onSelectAutocompleteItem={({ id }) => {
+          addStyleSourceToInstace(id);
+        }}
+        onRemoveItem={({ id }) => {
+          removeStyleSourceFromInstance(id);
+        }}
+        onSort={(items) => {
+          reorderStyleSources(items.map((item) => item.id));
+        }}
+        onSelectItem={(selectedItem) => {
+          selectedStyleSourceIdStore.set(selectedItem?.id);
+        }}
+      />
+    </>
+  );
+};

--- a/packages/feature-flags/src/flags.ts
+++ b/packages/feature-flags/src/flags.ts
@@ -3,3 +3,4 @@ export const example = false;
 export const dark = false;
 export const propertyReset = false;
 export const share2 = false;
+export const styleSourceInput = false;


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/807

Here basic support for styles sources in style panel

- new token creation
- existing token adding for instance
- token removing from instance
- sorting with dnd
- style source selection for styles  editing

Added feature flag to hide it on prod for now.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
