### PR TITLE
Add support of saas edge-api trpc preview router

### DIFF
--- a/apps/designer/app/env/env.server.ts
+++ b/apps/designer/app/env/env.server.ts
@@ -27,16 +27,28 @@ const env = {
   BUILD_REQUIRE_SUBDOMAIN: process.env.BUILD_REQUIRE_SUBDOMAIN,
 
   PORT: process.env.PORT,
+
+  // Preview support
+  BRANCH_NAME: process.env.BRANCH_NAME,
 };
 
 export type ServerEnv = typeof env;
 
+// https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables
 if (process.env.VERCEL !== undefined) {
   if (env.DEPLOYMENT_ENVIRONMENT === undefined) {
     env.DEPLOYMENT_ENVIRONMENT = process.env.VERCEL_ENV;
   }
   if (env.DEPLOYMENT_URL === undefined) {
     env.DEPLOYMENT_URL = process.env.VERCEL_URL;
+  }
+
+  if (env.DEPLOYMENT_URL === undefined) {
+    env.DEPLOYMENT_URL = process.env.VERCEL_URL;
+  }
+
+  if (env.BRANCH_NAME === undefined) {
+    env.BRANCH_NAME = process.env.VERCEL_GIT_COMMIT_REF;
   }
 }
 

--- a/apps/designer/app/services/trpc.server.ts
+++ b/apps/designer/app/services/trpc.server.ts
@@ -3,12 +3,14 @@ import env from "~/env/env.server";
 
 const TRPC_SERVER_URL = env.TRPC_SERVER_URL;
 const TRPC_SERVER_API_TOKEN = env.TRPC_SERVER_API_TOKEN;
+const BRANCH_NAME = env.BRANCH_NAME;
 
 export const trpcClient = createTrpcProxyServiceClient(
   TRPC_SERVER_URL !== undefined && TRPC_SERVER_API_TOKEN !== undefined
     ? {
         url: TRPC_SERVER_URL,
         token: TRPC_SERVER_API_TOKEN,
+        branchName: BRANCH_NAME,
       }
     : undefined
 );

--- a/packages/trpc-interface/src/shared/client.ts
+++ b/packages/trpc-interface/src/shared/client.ts
@@ -9,6 +9,7 @@ import { callerLink } from "../trpc-caller-link";
 type SharedClientOptions = {
   url: string;
   token: string;
+  headers: Record<string, string>;
 };
 
 export const createTrpcProxyServiceClient = (
@@ -21,6 +22,7 @@ export const createTrpcProxyServiceClient = (
           url: options.url,
           headers: () => ({
             Authorization: options.token,
+            ...options.headers,
           }),
         }),
       ],

--- a/packages/trpc-interface/src/shared/client.ts
+++ b/packages/trpc-interface/src/shared/client.ts
@@ -9,7 +9,7 @@ import { callerLink } from "../trpc-caller-link";
 type SharedClientOptions = {
   url: string;
   token: string;
-  headers: Record<string, string>;
+  branchName: string | undefined;
 };
 
 export const createTrpcProxyServiceClient = (
@@ -22,7 +22,7 @@ export const createTrpcProxyServiceClient = (
           url: options.url,
           headers: () => ({
             Authorization: options.token,
-            ...options.headers,
+            "x-branch-name": options.branchName,
           }),
         }),
       ],

--- a/packages/trpc-interface/src/shared/client.ts
+++ b/packages/trpc-interface/src/shared/client.ts
@@ -22,6 +22,7 @@ export const createTrpcProxyServiceClient = (
           url: options.url,
           headers: () => ({
             Authorization: options.token,
+            // We use this header for SaaS preview service discovery proxy
             "x-branch-name": options.branchName,
           }),
         }),


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

This branch will allow preview deployments of trpc authorization and other saas services 
Currently in this branch following variables are set:

```env
TRPC_SERVER_URL=https://wstd.work/services
TRPC_SERVER_API_TOKEN=secrettoken
```
It should use preview saas trpc service having `ory_setup` name
Here `https://wstd.work/services` is router url, router using `x-branch-name` reroutes traffic to the right saas preview

This is for test ONLY, variables would be removed if all is ok and testing will proceed on saas side

## Steps for reproduction

Create a new Project, create auth tokens, and check it works.
Check saas service preview logs that requests are there.



## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
