### PR TITLE
Represent props on client as map

### DIFF
--- a/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.stories.tsx
@@ -10,15 +10,20 @@ export default {
 };
 
 export const NoProps: ComponentStory<typeof PropsPanel> = () => {
-  propsStore.set([
-    {
-      id: "disabled",
-      instanceId: "1",
-      name: "disabled",
-      type: "boolean",
-      value: true,
-    },
-  ]);
+  propsStore.set(
+    new Map([
+      [
+        "disabled",
+        {
+          id: "disabled",
+          instanceId: "1",
+          name: "disabled",
+          type: "boolean",
+          value: true,
+        },
+      ],
+    ])
+  );
   return (
     <PropsPanel
       selectedInstance={{
@@ -34,7 +39,7 @@ export const NoProps: ComponentStory<typeof PropsPanel> = () => {
 };
 
 export const RequiredProps: ComponentStory<typeof PropsPanel> = () => {
-  propsStore.set([]);
+  propsStore.set(new Map());
   return (
     <PropsPanel
       selectedInstance={{
@@ -50,7 +55,7 @@ export const RequiredProps: ComponentStory<typeof PropsPanel> = () => {
 };
 
 export const DefaultProps: ComponentStory<typeof PropsPanel> = () => {
-  propsStore.set([]);
+  propsStore.set(new Map());
   return (
     <PropsPanel
       selectedInstance={{
@@ -69,14 +74,19 @@ const meta = getComponentMetaProps("Button") ?? {};
 
 export const AllProps: ComponentStory<typeof PropsPanel> = () => {
   propsStore.set(
-    Object.entries(meta).map(([name, value]) => {
-      return {
-        id: name,
-        instanceId: "3",
-        name,
-        value: value?.defaultValue ?? "",
-      } as Prop;
-    })
+    new Map(
+      Object.entries(meta).map(([name, value]) => {
+        return [
+          name,
+          {
+            id: name,
+            instanceId: "3",
+            name,
+            value: value?.defaultValue ?? "",
+          } as Prop,
+        ];
+      })
+    )
   );
   return (
     <PropsPanel

--- a/apps/designer/app/designer/features/props-panel/props-panel.tsx
+++ b/apps/designer/app/designer/features/props-panel/props-panel.tsx
@@ -26,10 +26,6 @@ import {
 import { type Publish } from "~/shared/pubsub";
 import { propsStore, useInstanceProps } from "~/shared/nano-states";
 import { CollapsibleSection, ComponentInfo } from "~/designer/shared/inspector";
-import {
-  removeByMutable,
-  replaceByOrAppendMutable,
-} from "~/shared/array-utils";
 import { Control } from "./control";
 import { usePropsLogic, type UserPropValue } from "./use-props-logic";
 import {
@@ -234,17 +230,13 @@ export const PropsPanel = ({ selectedInstance, publish }: PropsPanelProps) => {
 
     updateProps: (update) => {
       store.createTransaction([propsStore], (props) => {
-        replaceByOrAppendMutable(
-          props,
-          update,
-          (item) => item.id === update.id
-        );
+        props.set(update.id, update);
       });
     },
 
     deleteProp: (id) => {
       store.createTransaction([propsStore], (props) => {
-        removeByMutable(props, (prop) => prop.id === id);
+        props.delete(id);
       });
     },
   });

--- a/apps/designer/app/shared/copy-paste/copy-paste-instance.ts
+++ b/apps/designer/app/shared/copy-paste/copy-paste-instance.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { useEffect } from "react";
 import {
   Instance,
-  Props,
+  Prop,
   Styles,
   StyleSources,
   StyleSourceSelections,
@@ -33,7 +33,7 @@ import { startCopyPaste } from "./copy-paste";
 
 const InstanceData = z.object({
   instance: Instance,
-  props: Props,
+  props: z.array(Prop),
   styleSourceSelections: StyleSourceSelections,
   styleSources: StyleSources,
   styles: Styles,
@@ -109,7 +109,9 @@ const pasteInstance = (data: InstanceData) => {
       utils.tree.insertInstanceMutable(rootInstance, data.instance, dropTarget);
       // append without checking existing
       // because all data already cloned with new ids
-      props.push(...data.props);
+      for (const prop of data.props) {
+        props.set(prop.id, prop);
+      }
       styleSourceSelections.push(...data.styleSourceSelections);
       styleSources.push(...data.styleSources);
       styles.push(...data.styles);

--- a/apps/designer/app/shared/instance-utils.ts
+++ b/apps/designer/app/shared/instance-utils.ts
@@ -46,7 +46,11 @@ export const deleteInstance = (targetInstanceId: Instance["id"]) => {
         (child) => child.type === "instance" && child.id === targetInstanceId
       );
       // delete props and styles of deleted instance and its descendants
-      removeByMutable(props, (prop) => subtreeIds.has(prop.instanceId));
+      for (const prop of props.values()) {
+        if (subtreeIds.has(prop.instanceId)) {
+          props.delete(prop.id);
+        }
+      }
       removeByMutable(styleSourceSelections, (styleSourceSelection) =>
         subtreeIds.has(styleSourceSelection.instanceId)
       );

--- a/apps/designer/app/shared/nano-states/nano-states.ts
+++ b/apps/designer/app/shared/nano-states/nano-states.ts
@@ -6,6 +6,7 @@ import type { AuthPermit } from "@webstudio-is/trpc-interface";
 import type { Asset } from "@webstudio-is/asset-uploader";
 import {
   Instance,
+  Prop,
   Props,
   Styles,
   StyleSource,
@@ -50,10 +51,10 @@ export const instancesIndexStore = computed(
   createInstancesIndex
 );
 
-export const propsStore = atom<Props>([]);
+export const propsStore = atom<Props>(new Map());
 export const propsIndexStore = computed(propsStore, (props) => {
-  const propsByInstanceId = new Map<Instance["id"], Props>();
-  for (const prop of props) {
+  const propsByInstanceId = new Map<Instance["id"], Prop[]>();
+  for (const prop of props.values()) {
     const { instanceId } = prop;
     let instanceProps = propsByInstanceId.get(instanceId);
     if (instanceProps === undefined) {
@@ -66,9 +67,9 @@ export const propsIndexStore = computed(propsStore, (props) => {
     propsByInstanceId,
   };
 });
-export const useSetProps = (props: Props) => {
+export const useSetProps = (props: [Prop["id"], Prop][]) => {
   useSyncInitializeOnce(() => {
-    propsStore.set(props);
+    propsStore.set(new Map(props));
   });
 };
 export const useInstanceProps = (instanceId: undefined | Instance["id"]) => {

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -1,4 +1,5 @@
 import store, { type Change } from "immerhin";
+import { enableMapSet } from "immer";
 import type { WritableAtom } from "nanostores";
 import { useEffect } from "react";
 import { type Publish, subscribe } from "~/shared/pubsub";
@@ -16,6 +17,8 @@ import {
   hoveredInstanceOutlineStore,
   isPreviewModeStore,
 } from "~/shared/nano-states";
+
+enableMapSet();
 
 type StoreData = {
   namespace: string;

--- a/apps/designer/app/shared/tree-utils.test.ts
+++ b/apps/designer/app/shared/tree-utils.test.ts
@@ -188,14 +188,14 @@ test("clone instance tree and provide cloned ids map", () => {
 });
 
 test("clone props with new ids and apply new instance ids", () => {
-  const props = [
-    createProp("prop1", "instance1"),
-    createProp("prop2", "instance2"),
-    createProp("prop3", "instance1"),
-    createProp("prop4", "instance3"),
-    createProp("prop5", "instance1"),
-    createProp("prop6", "instance3"),
-  ];
+  const props = new Map([
+    ["prop1", createProp("prop1", "instance1")],
+    ["prop2", createProp("prop2", "instance2")],
+    ["prop3", createProp("prop3", "instance1")],
+    ["prop4", createProp("prop4", "instance3")],
+    ["prop5", createProp("prop5", "instance1")],
+    ["prop6", createProp("prop6", "instance3")],
+  ]);
   const clonedInstanceIds = new Map<Instance["id"], Instance["id"]>();
   clonedInstanceIds.set("instance2", "newInstance2");
   clonedInstanceIds.set("instance3", "newInstance3");

--- a/apps/designer/app/shared/tree-utils.ts
+++ b/apps/designer/app/shared/tree-utils.ts
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import produce from "immer";
 import type {
   Instance,
+  Prop,
   Props,
   Styles,
   StyleSource,
@@ -149,8 +150,8 @@ export const cloneProps = (
   props: Props,
   clonedInstanceIds: Map<Instance["id"], Instance["id"]>
 ) => {
-  const clonedProps: Props = [];
-  for (const prop of props) {
+  const clonedProps: Prop[] = [];
+  for (const prop of props.values()) {
     const instanceId = clonedInstanceIds.get(prop.instanceId);
     if (instanceId === undefined) {
       continue;

--- a/packages/project-build/src/schema/props.ts
+++ b/packages/project-build/src/schema/props.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 import { Asset } from "@webstudio-is/asset-uploader";
 
+const PropId = z.string();
+
 const baseProp = {
-  id: z.string(),
+  id: PropId,
   instanceId: z.string(),
   name: z.string(),
   required: z.optional(z.boolean()),
@@ -53,6 +55,6 @@ export const Prop = z.union([
 
 export type Prop = z.infer<typeof Prop>;
 
-export const Props = z.array(Prop);
+export const Props = z.map(PropId, Prop);
 
 export type Props = z.infer<typeof Props>;

--- a/packages/project-build/src/types.ts
+++ b/packages/project-build/src/types.ts
@@ -1,5 +1,5 @@
 import type { Instance } from "./schema/instances";
-import type { Props } from "./schema/props";
+import type { Prop } from "./schema/props";
 import type { StyleSourceSelections } from "./schema/style-sources";
 
 export type Tree = {
@@ -7,6 +7,6 @@ export type Tree = {
   projectId: string;
   buildId: string;
   root: Instance;
-  props: Props;
+  props: [Prop["id"], Prop][];
   styleSourceSelections: StyleSourceSelections;
 };

--- a/packages/project/src/db/props.ts
+++ b/packages/project/src/db/props.ts
@@ -32,14 +32,14 @@ export const parseProps = async (
 
   const assetsMap = new Map(assets.map((asset) => [asset.id, asset]));
 
-  const convertedProps: Props = [];
+  const convertedProps: Props = new Map();
   for (const prop of storedProps) {
     if (prop.type === "asset") {
       const assetId = prop.value;
       const asset = assetsMap.get(assetId);
 
       if (asset) {
-        convertedProps.push({
+        convertedProps.set(prop.id, {
           id: prop.id,
           instanceId: prop.instanceId,
           name: prop.name,
@@ -55,7 +55,7 @@ export const parseProps = async (
       continue;
     }
 
-    convertedProps.push(prop);
+    convertedProps.set(prop.id, prop);
   }
 
   return convertedProps;
@@ -63,7 +63,7 @@ export const parseProps = async (
 
 export const serializeProps = (props: Props) => {
   const storedProps: StoredProps = [];
-  for (const prop of props) {
+  for (const prop of props.values()) {
     if (prop.type === "asset") {
       storedProps.push({
         id: prop.id,

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -78,7 +78,7 @@ export const create = async (
       root: "",
       styles: "",
       instances: JSON.stringify(instances),
-      props: serializeProps(treeData.props),
+      props: serializeProps(new Map(treeData.props)),
       styleSelections: JSON.stringify(styleSourceSelections),
     },
   });
@@ -151,7 +151,7 @@ export const loadById = async (
   return {
     ...tree,
     root,
-    props,
+    props: Array.from(props),
     styleSourceSelections,
   };
 };

--- a/packages/react-sdk/src/props.ts
+++ b/packages/react-sdk/src/props.ts
@@ -1,10 +1,10 @@
 import { useMemo } from "react";
 import { atom, computed, type ReadableAtom } from "nanostores";
 import { useStore } from "@nanostores/react";
-import type { Instance, Props } from "@webstudio-is/project-build";
+import type { Instance, Prop, Props } from "@webstudio-is/project-build";
 import type { Asset } from "@webstudio-is/asset-uploader";
 
-type PropsByInstanceId = Map<Instance["id"], Props>;
+type PropsByInstanceId = Map<Instance["id"], Prop[]>;
 
 type PropsByInstanceIdStore = ReadableAtom<PropsByInstanceId>;
 
@@ -20,7 +20,7 @@ export const getPropsByInstanceIdStore = () => {
 
 export const getPropsByInstanceId = (props: Props) => {
   const propsByInstanceId: PropsByInstanceId = new Map();
-  for (const prop of props) {
+  for (const prop of props.values()) {
     let instanceProps = propsByInstanceId.get(prop.instanceId);
     if (instanceProps === undefined) {
       instanceProps = [];

--- a/packages/react-sdk/src/tree/root.ts
+++ b/packages/react-sdk/src/tree/root.ts
@@ -30,7 +30,9 @@ export const InstanceRoot = ({
     throw new Error("Tree is null");
   }
 
-  setPropsByInstanceIdStore(atom(getPropsByInstanceId(data.tree.props)));
+  setPropsByInstanceIdStore(
+    atom(getPropsByInstanceId(new Map(data.tree.props)))
+  );
 
   setParams(data.params ?? null);
 


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/696

While normalized array of props give us flexibility with atomic updates we still cannot use it for collaboration because patches are applied with index in this array which may leads to unexpected results when two users collaboate on the same tree, for example both put new prop and edit it before synchronization by the same index, we are getting conflict.

To avoid such issues we can switch client representation to maps. Almost all data have ids to use in map as keys. Map makes collaboration almost conflict free.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - test it on preview
- [ ] hi @istarkov, I need you to do
  - detailed review (read every line)

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
