### PR TITLE
Represent style source as map

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -90,11 +90,7 @@ export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
           const instanceId = selectedInstance.id;
           const breakpointId = selectedBreakpoint.id;
           const styleSourceId = selectedStyleSource.id;
-          replaceByOrAppendMutable(
-            styleSources,
-            selectedStyleSource,
-            (item) => item.id === styleSourceId
-          );
+          styleSources.set(selectedStyleSource.id, selectedStyleSource);
           const selections = selectedInstanceStyleSources.map(
             (styleSource) => styleSource.id
           );

--- a/apps/designer/app/designer/features/style-panel/style-source-section.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-source-section.tsx
@@ -45,11 +45,7 @@ const createStyleSource = (name: string) => {
     (styleSources, styleSourceSelections) => {
       // set new style source and local if not set before
       for (const newStyleSource of newStyleSources) {
-        replaceByOrAppendMutable(
-          styleSources,
-          newStyleSource,
-          (styleSource) => styleSource.id === newStyleSource.id
-        );
+        styleSources.set(newStyleSource.id, newStyleSource);
       }
       replaceByOrAppendMutable(
         styleSourceSelections,
@@ -79,11 +75,7 @@ const addStyleSourceToInstace = (styleSourceId: StyleSource["id"]) => {
     (styleSources, styleSourceSelections) => {
       // set local style source if not set before
       for (const newStyleSource of selectedInstanceStyleSources) {
-        replaceByOrAppendMutable(
-          styleSources,
-          newStyleSource,
-          (styleSource) => styleSource.id === newStyleSource.id
-        );
+        styleSources.set(newStyleSource.id, newStyleSource);
       }
       replaceByOrAppendMutable(
         styleSourceSelections,

--- a/apps/designer/app/shared/copy-paste/copy-paste-instance.ts
+++ b/apps/designer/app/shared/copy-paste/copy-paste-instance.ts
@@ -5,7 +5,7 @@ import {
   Instance,
   Prop,
   Styles,
-  StyleSources,
+  StyleSource,
   StyleSourceSelections,
 } from "@webstudio-is/project-build";
 import { utils } from "@webstudio-is/project";
@@ -35,7 +35,7 @@ const InstanceData = z.object({
   instance: Instance,
   props: z.array(Prop),
   styleSourceSelections: StyleSourceSelections,
-  styleSources: StyleSources,
+  styleSources: z.array(StyleSource),
   styles: Styles,
 });
 
@@ -113,7 +113,9 @@ const pasteInstance = (data: InstanceData) => {
         props.set(prop.id, prop);
       }
       styleSourceSelections.push(...data.styleSourceSelections);
-      styleSources.push(...data.styleSources);
+      for (const styleSource of data.styleSources) {
+        styleSources.set(styleSource.id, styleSource);
+      }
       styles.push(...data.styles);
     }
   );

--- a/apps/designer/app/shared/instance-utils.ts
+++ b/apps/designer/app/shared/instance-utils.ts
@@ -54,9 +54,9 @@ export const deleteInstance = (targetInstanceId: Instance["id"]) => {
       removeByMutable(styleSourceSelections, (styleSourceSelection) =>
         subtreeIds.has(styleSourceSelection.instanceId)
       );
-      removeByMutable(styleSources, (styleSource) =>
-        subtreeLocalStyleSourceIds.has(styleSource.id)
-      );
+      for (const styleSourceId of subtreeLocalStyleSourceIds) {
+        styleSources.delete(styleSourceId);
+      }
       removeByMutable(styles, (styleDecl) =>
         subtreeLocalStyleSourceIds.has(styleDecl.styleSourceId)
       );

--- a/apps/designer/app/shared/tree-utils.test.ts
+++ b/apps/designer/app/shared/tree-utils.test.ts
@@ -207,12 +207,12 @@ test("clone props with new ids and apply new instance ids", () => {
 });
 
 test("clone style sources with new ids within provided subset", () => {
-  const styleSources = [
-    createStyleSource("local", "local1"),
-    createStyleSource("local", "local2"),
-    createStyleSource("token", "token3"),
-    createStyleSource("local", "local4"),
-  ];
+  const styleSources = new Map([
+    ["local1", createStyleSource("local", "local1")],
+    ["local2", createStyleSource("local", "local2")],
+    ["token3", createStyleSource("token", "token3")],
+    ["local4", createStyleSource("local", "local4")],
+  ]);
   const subsetIds = new Set<StyleSource["id"]>(["local2", "token3"]);
   expect(cloneStyleSources(styleSources, subsetIds)).toEqual({
     clonedStyleSources: [
@@ -277,14 +277,14 @@ test("clone styles with appled new style source ids", () => {
 
 test("find subtree local style sources", () => {
   const subtreeIds = new Set(["instance2", "instance4"]);
-  const styleSources = [
-    createStyleSource("local", "local1"),
-    createStyleSource("local", "local2"),
-    createStyleSource("token", "token3"),
-    createStyleSource("local", "local4"),
-    createStyleSource("token", "token5"),
-    createStyleSource("local", "local6"),
-  ];
+  const styleSources = new Map([
+    ["local1", createStyleSource("local", "local1")],
+    ["local2", createStyleSource("local", "local2")],
+    ["token3", createStyleSource("token", "token3")],
+    ["local4", createStyleSource("local", "local4")],
+    ["token5", createStyleSource("token", "token5")],
+    ["local6", createStyleSource("local", "local6")],
+  ]);
   const styleSourceSelections = [
     createStyleSourceSelection("instance1", ["local1"]),
     createStyleSourceSelection("instance2", ["local2"]),

--- a/apps/designer/app/shared/tree-utils.ts
+++ b/apps/designer/app/shared/tree-utils.ts
@@ -170,8 +170,8 @@ export const cloneStyleSources = (
   subsetIds: Set<StyleSource["id"]>
 ) => {
   const clonedStyleSourceIds = new Map<Instance["id"], Instance["id"]>();
-  const clonedStyleSources: StyleSources = [];
-  for (const styleSource of styleSources) {
+  const clonedStyleSources: StyleSource[] = [];
+  for (const styleSource of styleSources.values()) {
     if (subsetIds.has(styleSource.id) === false) {
       continue;
     }
@@ -234,7 +234,7 @@ export const findSubtreeLocalStyleSources = (
   styleSourceSelections: StyleSourceSelections
 ) => {
   const localStyleSourceIds = new Set<StyleSource["id"]>();
-  for (const styleSource of styleSources) {
+  for (const styleSource of styleSources.values()) {
     if (styleSource.type === "local") {
       localStyleSourceIds.add(styleSource.id);
     }

--- a/packages/project-build/src/schema/style-sources.ts
+++ b/packages/project-build/src/schema/style-sources.ts
@@ -19,7 +19,11 @@ export const StyleSource = z.union([StyleSourceToken, StyleSourceLocal]);
 
 export type StyleSource = z.infer<typeof StyleSource>;
 
-export const StyleSources = z.array(StyleSource);
+export const StyleSourcesList = z.array(StyleSource);
+
+export type StyleSourcesList = z.infer<typeof StyleSourcesList>;
+
+export const StyleSources = z.map(StyleSourceId, StyleSource);
 
 export type StyleSources = z.infer<typeof StyleSources>;
 

--- a/packages/project/src/shared/schema.ts
+++ b/packages/project/src/shared/schema.ts
@@ -1,6 +1,6 @@
 import { z, type ZodType } from "zod";
 import type { Breakpoints } from "@webstudio-is/css-data";
-import type { Styles, StyleSources } from "@webstudio-is/project-build";
+import type { Styles, StyleSource } from "@webstudio-is/project-build";
 import type { Data } from "@webstudio-is/react-sdk";
 
 const MIN_TITLE_LENGTH = 2;
@@ -100,7 +100,7 @@ export type Build = {
   pages: Pages;
   breakpoints: Breakpoints;
   styles: Styles;
-  styleSources: StyleSources;
+  styleSources: [StyleSource["id"], StyleSource][];
 };
 
 export type CanvasData = Data & {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/696

Same as props. Fast access and fast update. So we no longer need separate store with style sources index.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
