### PR TITLE
Represet style source selections as map

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/use-style-data.ts
@@ -94,17 +94,12 @@ export const useStyleData = ({ selectedInstance, publish }: UseStyleData) => {
           const selections = selectedInstanceStyleSources.map(
             (styleSource) => styleSource.id
           );
-          replaceByOrAppendMutable(
-            styleSourceSelections,
-            {
-              instanceId,
-              values: selections.includes(styleSourceId)
-                ? selections
-                : [...selections, styleSourceId],
-            },
-            (styleSourceSelection) =>
-              styleSourceSelection.instanceId === instanceId
-          );
+          styleSourceSelections.set(instanceId, {
+            instanceId,
+            values: selections.includes(styleSourceId)
+              ? selections
+              : [...selections, styleSourceId],
+          });
 
           for (const update of updates) {
             if (update.operation === "set") {

--- a/apps/designer/app/designer/features/style-panel/style-source-section.tsx
+++ b/apps/designer/app/designer/features/style-panel/style-source-section.tsx
@@ -16,10 +16,7 @@ import {
   styleSourceSelectionsStore,
   styleSourcesStore,
 } from "~/shared/nano-states";
-import {
-  removeByMutable,
-  replaceByOrAppendMutable,
-} from "~/shared/array-utils";
+import { removeByMutable } from "~/shared/array-utils";
 
 const createStyleSource = (name: string) => {
   const selectedInstanceId = selectedInstanceIdStore.get();
@@ -47,12 +44,7 @@ const createStyleSource = (name: string) => {
       for (const newStyleSource of newStyleSources) {
         styleSources.set(newStyleSource.id, newStyleSource);
       }
-      replaceByOrAppendMutable(
-        styleSourceSelections,
-        newStyleSourceSelection,
-        (styleSourceSelection) =>
-          styleSourceSelection.instanceId === selectedInstanceId
-      );
+      styleSourceSelections.set(selectedInstanceId, newStyleSourceSelection);
     }
   );
 };
@@ -77,12 +69,7 @@ const addStyleSourceToInstace = (styleSourceId: StyleSource["id"]) => {
       for (const newStyleSource of selectedInstanceStyleSources) {
         styleSources.set(newStyleSource.id, newStyleSource);
       }
-      replaceByOrAppendMutable(
-        styleSourceSelections,
-        newStyleSourceSelection,
-        (styleSourceSelection) =>
-          styleSourceSelection.instanceId === selectedInstanceId
-      );
+      styleSourceSelections.set(selectedInstanceId, newStyleSourceSelection);
     }
   );
 };
@@ -92,10 +79,11 @@ const removeStyleSourceFromInstance = (styleSourceId: StyleSource["id"]) => {
   store.createTransaction(
     [styleSourceSelectionsStore],
     (styleSourceSelections) => {
-      const styleSourceSelection = styleSourceSelections.find(
-        (styleSourceSelection) =>
-          styleSourceSelection.instanceId === selectedInstanceId
-      );
+      if (selectedInstanceId === undefined) {
+        return;
+      }
+      const styleSourceSelection =
+        styleSourceSelections.get(selectedInstanceId);
       if (styleSourceSelection === undefined) {
         return;
       }
@@ -112,10 +100,11 @@ const reorderStyleSources = (styleSourceIds: StyleSource["id"][]) => {
   store.createTransaction(
     [styleSourceSelectionsStore],
     (styleSourceSelections) => {
-      const styleSourceSelection = styleSourceSelections.find(
-        (styleSourceSelection) =>
-          styleSourceSelection.instanceId === selectedInstanceId
-      );
+      if (selectedInstanceId === undefined) {
+        return;
+      }
+      const styleSourceSelection =
+        styleSourceSelections.get(selectedInstanceId);
       if (styleSourceSelection === undefined) {
         return;
       }

--- a/apps/designer/app/shared/copy-paste/copy-paste-instance.ts
+++ b/apps/designer/app/shared/copy-paste/copy-paste-instance.ts
@@ -6,7 +6,7 @@ import {
   Prop,
   Styles,
   StyleSource,
-  StyleSourceSelections,
+  StyleSourceSelection,
 } from "@webstudio-is/project-build";
 import { utils } from "@webstudio-is/project";
 import {
@@ -34,7 +34,7 @@ import { startCopyPaste } from "./copy-paste";
 const InstanceData = z.object({
   instance: Instance,
   props: z.array(Prop),
-  styleSourceSelections: StyleSourceSelections,
+  styleSourceSelections: z.array(StyleSourceSelection),
   styleSources: z.array(StyleSource),
   styles: Styles,
 });
@@ -112,7 +112,12 @@ const pasteInstance = (data: InstanceData) => {
       for (const prop of data.props) {
         props.set(prop.id, prop);
       }
-      styleSourceSelections.push(...data.styleSourceSelections);
+      for (const styleSourceSelection of data.styleSourceSelections) {
+        styleSourceSelections.set(
+          styleSourceSelection.instanceId,
+          styleSourceSelection
+        );
+      }
       for (const styleSource of data.styleSources) {
         styleSources.set(styleSource.id, styleSource);
       }

--- a/apps/designer/app/shared/css-utils/generate-css-text.ts
+++ b/apps/designer/app/shared/css-utils/generate-css-text.ts
@@ -55,7 +55,7 @@ export const generateCssText = async (
 
   const styleRules = getStyleRules(
     canvasData.build?.styles,
-    canvasData.tree?.styleSourceSelections
+    new Map(canvasData.tree?.styleSourceSelections)
   );
   for (const { breakpointId, instanceId, style } of styleRules) {
     engine.addStyleRule(`[${idAttribute}="${instanceId}"]`, {

--- a/apps/designer/app/shared/instance-utils.ts
+++ b/apps/designer/app/shared/instance-utils.ts
@@ -51,9 +51,9 @@ export const deleteInstance = (targetInstanceId: Instance["id"]) => {
           props.delete(prop.id);
         }
       }
-      removeByMutable(styleSourceSelections, (styleSourceSelection) =>
-        subtreeIds.has(styleSourceSelection.instanceId)
-      );
+      for (const instanceId of subtreeIds) {
+        styleSourceSelections.delete(instanceId);
+      }
       for (const styleSourceId of subtreeLocalStyleSourceIds) {
         styleSources.delete(styleSourceId);
       }

--- a/apps/designer/app/shared/tree-utils.test.ts
+++ b/apps/designer/app/shared/tree-utils.test.ts
@@ -227,11 +227,17 @@ test("clone style sources with new ids within provided subset", () => {
 });
 
 test("clone style source selections with applied instance ids and style source ids", () => {
-  const styleSourceSelections = [
-    createStyleSourceSelection("instance1", ["local1", "token2"]),
-    createStyleSourceSelection("instance2", ["token3", "local4", "token5"]),
-    createStyleSourceSelection("instance3", ["local6"]),
-  ];
+  const styleSourceSelections = new Map([
+    [
+      "instance1",
+      createStyleSourceSelection("instance1", ["local1", "token2"]),
+    ],
+    [
+      "instance2",
+      createStyleSourceSelection("instance2", ["token3", "local4", "token5"]),
+    ],
+    ["instance3", createStyleSourceSelection("instance3", ["local6"])],
+  ]);
   const clonedStyleSourceIds = new Map<StyleSource["id"], StyleSource["id"]>([
     ["local1", "newLocal1"],
     ["local4", "newLocal4"],
@@ -285,13 +291,16 @@ test("find subtree local style sources", () => {
     ["token5", createStyleSource("token", "token5")],
     ["local6", createStyleSource("local", "local6")],
   ]);
-  const styleSourceSelections = [
-    createStyleSourceSelection("instance1", ["local1"]),
-    createStyleSourceSelection("instance2", ["local2"]),
-    createStyleSourceSelection("instance3", ["token3"]),
-    createStyleSourceSelection("instance4", ["local4", "token5"]),
-    createStyleSourceSelection("instance5", ["local6"]),
-  ];
+  const styleSourceSelections = new Map([
+    ["instance1", createStyleSourceSelection("instance1", ["local1"])],
+    ["instance2", createStyleSourceSelection("instance2", ["local2"])],
+    ["instance3", createStyleSourceSelection("instance3", ["token3"])],
+    [
+      "instance4",
+      createStyleSourceSelection("instance4", ["local4", "token5"]),
+    ],
+    ["instance5", createStyleSourceSelection("instance5", ["local6"])],
+  ]);
 
   expect(
     findSubtreeLocalStyleSources(

--- a/apps/designer/app/shared/tree-utils.ts
+++ b/apps/designer/app/shared/tree-utils.ts
@@ -7,6 +7,7 @@ import type {
   Styles,
   StyleSource,
   StyleSources,
+  StyleSourceSelection,
   StyleSourceSelections,
 } from "@webstudio-is/project-build";
 import { getComponentMeta } from "@webstudio-is/react-sdk";
@@ -190,8 +191,8 @@ export const cloneStyleSourceSelections = (
   clonedInstanceIds: Map<Instance["id"], Instance["id"]>,
   clonedStyleSourceIds: Map<Instance["id"], Instance["id"]>
 ) => {
-  const clonedStyleSourceSelections: StyleSourceSelections = [];
-  for (const styleSourceSelection of styleSourceSelections) {
+  const clonedStyleSourceSelections: StyleSourceSelection[] = [];
+  for (const styleSourceSelection of styleSourceSelections.values()) {
     const instanceId = clonedInstanceIds.get(styleSourceSelection.instanceId);
     if (instanceId === undefined) {
       continue;
@@ -241,7 +242,7 @@ export const findSubtreeLocalStyleSources = (
   }
 
   const subtreeLocalStyleSourceIds = new Set<StyleSource["id"]>();
-  for (const { instanceId, values } of styleSourceSelections) {
+  for (const { instanceId, values } of styleSourceSelections.values()) {
     // skip selections outside of subtree
     if (subtreeIds.has(instanceId) === false) {
       continue;

--- a/packages/project-build/src/index.ts
+++ b/packages/project-build/src/index.ts
@@ -2,4 +2,5 @@ export * from "./schema/instances";
 export * from "./schema/props";
 export * from "./schema/styles";
 export * from "./schema/style-sources";
+export * from "./schema/style-source-selections";
 export * from "./types";

--- a/packages/project-build/src/schema/style-source-selections.ts
+++ b/packages/project-build/src/schema/style-source-selections.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+const InstanceId = z.string();
+
+const StyleSourceId = z.string();
+
+export const StyleSourceSelection = z.object({
+  instanceId: InstanceId,
+  values: z.array(StyleSourceId),
+});
+
+export type StyleSourceSelection = z.infer<typeof StyleSourceSelection>;
+
+export const StyleSourceSelectionsList = z.array(StyleSourceSelection);
+
+export type StyleSourceSelectionsList = z.infer<
+  typeof StyleSourceSelectionsList
+>;
+
+export const StyleSourceSelections = z.map(InstanceId, StyleSourceSelection);
+
+export type StyleSourceSelections = z.infer<typeof StyleSourceSelections>;

--- a/packages/project-build/src/schema/style-sources.ts
+++ b/packages/project-build/src/schema/style-sources.ts
@@ -26,14 +26,3 @@ export type StyleSourcesList = z.infer<typeof StyleSourcesList>;
 export const StyleSources = z.map(StyleSourceId, StyleSource);
 
 export type StyleSources = z.infer<typeof StyleSources>;
-
-export const StyleSourceSelection = z.object({
-  instanceId: z.string(),
-  values: z.array(StyleSourceId),
-});
-
-export type StyleSourceSelection = z.infer<typeof StyleSourceSelection>;
-
-export const StyleSourceSelections = z.array(StyleSourceSelection);
-
-export type StyleSourceSelections = z.infer<typeof StyleSourceSelections>;

--- a/packages/project-build/src/types.ts
+++ b/packages/project-build/src/types.ts
@@ -1,6 +1,6 @@
 import type { Instance } from "./schema/instances";
 import type { Prop } from "./schema/props";
-import type { StyleSourceSelections } from "./schema/style-sources";
+import type { StyleSourceSelection } from "./schema/style-source-selections";
 
 export type Tree = {
   id: string;
@@ -8,5 +8,5 @@ export type Tree = {
   buildId: string;
   root: Instance;
   props: [Prop["id"], Prop][];
-  styleSourceSelections: StyleSourceSelections;
+  styleSourceSelections: [Instance["id"], StyleSourceSelection][];
 };

--- a/packages/project/src/db/style-source-selections.ts
+++ b/packages/project/src/db/style-source-selections.ts
@@ -4,8 +4,32 @@ import {
   authorizeProject,
   type AppContext,
 } from "@webstudio-is/trpc-interface/server";
-import { StyleSourceSelections, type Tree } from "@webstudio-is/project-build";
+import {
+  StyleSourceSelectionsList,
+  StyleSourceSelections,
+  type Tree,
+} from "@webstudio-is/project-build";
 import type { Project } from "../shared/schema";
+
+export const parseStyleSourceSelections = (
+  styleSourceSelectionsString: string
+): StyleSourceSelections => {
+  const styleSourceSelectionsList = StyleSourceSelectionsList.parse(
+    JSON.parse(styleSourceSelectionsString)
+  );
+  return new Map(
+    styleSourceSelectionsList.map((item) => [item.instanceId, item])
+  );
+};
+
+export const serializeStyleSourceSelections = (
+  styleSourceSelectionsMap: StyleSourceSelections
+) => {
+  const styleSourceSelectionsList: StyleSourceSelectionsList = Array.from(
+    styleSourceSelectionsMap.values()
+  );
+  return JSON.stringify(styleSourceSelectionsList);
+};
 
 export const patch = async (
   { treeId, projectId }: { treeId: Tree["id"]; projectId: Project["id"] },
@@ -30,8 +54,8 @@ export const patch = async (
     return;
   }
 
-  const styleSourceSelections = StyleSourceSelections.parse(
-    JSON.parse(tree.styleSelections)
+  const styleSourceSelections = parseStyleSourceSelections(
+    tree.styleSelections
   );
 
   const patchedStyleSourceSelections = StyleSourceSelections.parse(
@@ -40,7 +64,9 @@ export const patch = async (
 
   await prisma.tree.update({
     data: {
-      styleSelections: JSON.stringify(patchedStyleSourceSelections),
+      styleSelections: serializeStyleSourceSelections(
+        patchedStyleSourceSelections
+      ),
     },
     where: {
       id_projectId: { projectId, id: treeId },

--- a/packages/project/src/db/tree.ts
+++ b/packages/project/src/db/tree.ts
@@ -6,7 +6,6 @@ import {
   type InstancesItem,
   Instance,
   Instances,
-  StyleSourceSelections,
 } from "@webstudio-is/project-build";
 import { prisma, type Prisma } from "@webstudio-is/prisma-client";
 import { utils } from "../index";
@@ -16,6 +15,10 @@ import {
   authorizeProject,
   type AppContext,
 } from "@webstudio-is/trpc-interface/server";
+import {
+  parseStyleSourceSelections,
+  serializeStyleSourceSelections,
+} from "./style-source-selections";
 
 type TreeData = Omit<Tree, "id">;
 
@@ -67,9 +70,6 @@ export const create = async (
 
   const newTreeId = uuid();
 
-  const styleSourceSelections: StyleSourceSelections =
-    treeData.styleSourceSelections;
-
   return await client.tree.create({
     data: {
       id: newTreeId,
@@ -79,7 +79,9 @@ export const create = async (
       styles: "",
       instances: JSON.stringify(instances),
       props: serializeProps(new Map(treeData.props)),
-      styleSelections: JSON.stringify(styleSourceSelections),
+      styleSelections: serializeStyleSourceSelections(
+        new Map(treeData.styleSourceSelections)
+      ),
     },
   });
 };
@@ -144,15 +146,15 @@ export const loadById = async (
     context
   );
 
-  const styleSourceSelections = StyleSourceSelections.parse(
-    JSON.parse(tree.styleSelections)
+  const styleSourceSelections = parseStyleSourceSelections(
+    tree.styleSelections
   );
 
   return {
     ...tree,
     root,
     props: Array.from(props),
-    styleSourceSelections,
+    styleSourceSelections: Array.from(styleSourceSelections),
   };
 };
 

--- a/packages/project/src/shared/styles/style-rules.test.ts
+++ b/packages/project/src/shared/styles/style-rules.test.ts
@@ -50,20 +50,29 @@ test("compute styles from different style sources", () => {
       value: { type: "keyword", value: "blue" },
     },
   ];
-  const styleSourceSelections: StyleSourceSelections = [
-    {
-      instanceId: "instance1",
-      values: ["styleSource1"],
-    },
-    {
-      instanceId: "instance2",
-      values: ["styleSource4", "styleSource5", "styleSource3"],
-    },
-    {
-      instanceId: "instance3",
-      values: ["styleSource6"],
-    },
-  ];
+  const styleSourceSelections: StyleSourceSelections = new Map([
+    [
+      "instance1",
+      {
+        instanceId: "instance1",
+        values: ["styleSource1"],
+      },
+    ],
+    [
+      "instance2",
+      {
+        instanceId: "instance2",
+        values: ["styleSource4", "styleSource5", "styleSource3"],
+      },
+    ],
+    [
+      "instance3",
+      {
+        instanceId: "instance3",
+        values: ["styleSource6"],
+      },
+    ],
+  ]);
 
   expect(getStyleRules(styles, styleSourceSelections)).toMatchInlineSnapshot(`
     [

--- a/packages/project/src/shared/styles/style-rules.ts
+++ b/packages/project/src/shared/styles/style-rules.ts
@@ -35,7 +35,7 @@ export const getStyleRules = (
   }
 
   const styleRules: StyleRule[] = [];
-  for (const { instanceId, values } of styleSourceSelections) {
+  for (const { instanceId, values } of styleSourceSelections.values()) {
     const styleRuleByBreakpointId = new Map<Breakpoint["id"], StyleRule>();
 
     for (const styleSourceId of values) {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/696

Patches by indexes are replaced with patches by keys so we could get almost conflict free collaboration.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
