### PR TITLE
Sync zoom and modify with shared shortcuts

### DIFF
--- a/apps/designer/app/canvas/shared/use-shortcuts.ts
+++ b/apps/designer/app/canvas/shared/use-shortcuts.ts
@@ -15,7 +15,6 @@ declare module "~/shared/pubsub" {
     cancelCurrentDrag: undefined;
     openBreakpointsMenu: undefined;
     selectBreakpointFromShortcut: number;
-    zoom: "zoomOut" | "zoomIn";
   }
 }
 
@@ -40,21 +39,6 @@ const publishSelectBreakpoint = ({ key }: HandlerEvent) => {
   });
 };
 
-const publishZoom = (event: HandlerEvent) => {
-  if (!event.key) {
-    throw new Error(
-      "`publishZoom` doesn't account for being called without a `key`"
-    );
-  }
-  if (event.preventDefault !== undefined) {
-    event.preventDefault();
-  }
-  publish({
-    type: "zoom",
-    payload: event.key === "-" ? "zoomOut" : "zoomIn",
-  });
-};
-
 const publishOpenBreakpointsMenu = () => {
   publish({ type: "openBreakpointsMenu" });
 };
@@ -72,7 +56,6 @@ export const useShortcuts = () => {
     preview: togglePreviewMode,
     breakpointsMenu: publishOpenBreakpointsMenu,
     breakpoint: publishSelectBreakpoint,
-    zoom: publishZoom,
     esc: publishCancelCurrentDrag,
   } as const;
 
@@ -119,7 +102,6 @@ export const useShortcuts = () => {
   useHotkeys(shortcuts.preview, shortcutHandlerMap.preview, options, []);
 
   useHotkeys(shortcuts.breakpoint, shortcutHandlerMap.breakpoint, options, []);
-  useHotkeys(shortcuts.zoom, shortcutHandlerMap.zoom, options, []);
   useHotkeys(
     shortcuts.breakpointsMenu,
     shortcutHandlerMap.breakpointsMenu,

--- a/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
+++ b/apps/designer/app/designer/features/breakpoints/breakpoints.tsx
@@ -18,10 +18,7 @@ import { Preview } from "./preview";
 import { ZoomSetting } from "./zoom-setting";
 import { TriggerButton } from "./trigger-button";
 import { WidthSetting } from "./width-setting";
-import {
-  useSubscribeSelectBreakpointFromShortcut,
-  useSubscribeZoomFromShortcut,
-} from "./use-subscribe-shortcuts";
+import { useSubscribeSelectBreakpointFromShortcut } from "./use-subscribe-shortcuts";
 import { ConfirmationDialog } from "./confirmation-dialog";
 import {
   breakpointsContainer,
@@ -44,7 +41,6 @@ export const Breakpoints = () => {
   const [breakpointPreview, setBreakpointPreview] =
     useState(selectedBreakpoint);
   useSubscribeSelectBreakpointFromShortcut();
-  useSubscribeZoomFromShortcut();
 
   useEffect(() => {
     setBreakpointPreview(selectedBreakpoint);

--- a/apps/designer/app/designer/features/breakpoints/trigger-button.tsx
+++ b/apps/designer/app/designer/features/breakpoints/trigger-button.tsx
@@ -1,11 +1,12 @@
 import { forwardRef, type ComponentProps, type ElementRef } from "react";
+import { useStore } from "@nanostores/react";
+import { Button, Text } from "@webstudio-is/design-system";
 import {
   useCanvasWidth,
-  useZoom,
   useSelectedBreakpoint,
 } from "~/designer/shared/nano-states";
 import { willRender } from "~/designer/shared/breakpoints";
-import { Button, Text } from "@webstudio-is/design-system";
+import { zoomStore } from "~/shared/nano-states/breakpoints";
 
 type TriggerButtonProps = ComponentProps<typeof Button>;
 
@@ -13,7 +14,7 @@ export const TriggerButton = forwardRef<
   ElementRef<typeof Button>,
   TriggerButtonProps
 >((props, ref) => {
-  const [zoom] = useZoom();
+  const zoom = useStore(zoomStore);
   const [breakpoint] = useSelectedBreakpoint();
   const [canvasWidth] = useCanvasWidth();
   if (breakpoint === undefined) {

--- a/apps/designer/app/designer/features/breakpoints/use-subscribe-shortcuts.ts
+++ b/apps/designer/app/designer/features/breakpoints/use-subscribe-shortcuts.ts
@@ -1,7 +1,6 @@
 import { useSubscribe } from "~/shared/pubsub";
 import { useBreakpoints } from "~/shared/nano-states";
-import { useZoom, useSelectedBreakpoint } from "../../shared/nano-states";
-import { minZoom } from "./zoom-setting";
+import { useSelectedBreakpoint } from "../../shared/nano-states";
 import { utils } from "@webstudio-is/project";
 
 export const useSubscribeSelectBreakpointFromShortcut = () => {
@@ -12,20 +11,5 @@ export const useSubscribeSelectBreakpointFromShortcut = () => {
     if (breakpoint) {
       setSelectedBreakpoint(breakpoint);
     }
-  });
-};
-
-const zoomStep = 20;
-
-export const useSubscribeZoomFromShortcut = () => {
-  const [zoom, setZoom] = useZoom();
-
-  useSubscribe("zoom", (direction) => {
-    if (direction === "zoomIn") {
-      setZoom(Math.min(zoom + zoomStep, 100));
-      return;
-    }
-
-    setZoom(Math.max(zoom - zoomStep, minZoom));
   });
 };

--- a/apps/designer/app/designer/features/breakpoints/zoom-setting.tsx
+++ b/apps/designer/app/designer/features/breakpoints/zoom-setting.tsx
@@ -1,11 +1,14 @@
-import { useZoom } from "~/designer/shared/nano-states";
-import { Slider, DeprecatedText2, Flex } from "@webstudio-is/design-system";
-import { theme } from "@webstudio-is/design-system";
-
-export const minZoom = 10;
+import { useStore } from "@nanostores/react";
+import {
+  theme,
+  Slider,
+  DeprecatedText2,
+  Flex,
+} from "@webstudio-is/design-system";
+import { minZoom, zoomStore } from "~/shared/nano-states/breakpoints";
 
 export const ZoomSetting = () => {
-  const [value, setValue] = useZoom();
+  const value = useStore(zoomStore);
   return (
     <Flex
       css={{ px: theme.spacing[11], py: theme.spacing[3] }}
@@ -18,7 +21,7 @@ export const ZoomSetting = () => {
           min={minZoom}
           value={value}
           onValueChange={([value]) => {
-            setValue(value);
+            zoomStore.set(value);
           }}
         />
         <DeprecatedText2>{value}%</DeprecatedText2>

--- a/apps/designer/app/designer/features/sidebar-left/panels/components/components.tsx
+++ b/apps/designer/app/designer/features/sidebar-left/panels/components/components.tsx
@@ -1,4 +1,5 @@
 import { type MouseEventHandler, useState } from "react";
+import { useStore } from "@nanostores/react";
 import { createPortal } from "react-dom";
 import type { Instance } from "@webstudio-is/project-build";
 import {
@@ -15,8 +16,9 @@ import {
   selectedInstanceIdStore,
 } from "~/shared/nano-states";
 import { useSubscribe, type Publish } from "~/shared/pubsub";
-import { useCanvasRect, useZoom } from "~/designer/shared/nano-states";
+import { useCanvasRect } from "~/designer/shared/nano-states";
 import { insertInstance } from "~/shared/instance-utils";
+import { zoomStore } from "~/shared/nano-states/breakpoints";
 import type { TabName } from "../../types";
 import { Header, CloseButton } from "../../header";
 import { ComponentThumb } from "./component-thumb";
@@ -92,7 +94,7 @@ export const TabContent = ({ publish, onSetActiveTab }: TabContentProps) => {
   const [point, setPoint] = useState<Point>({ x: 0, y: 0 });
 
   const [canvasRect] = useCanvasRect();
-  const [zoom] = useZoom();
+  const zoom = useStore(zoomStore);
 
   const toCanvasCoordinates = ({ x, y }: Point) => {
     if (canvasRect === undefined) {

--- a/apps/designer/app/designer/features/topbar/menu/menu.tsx
+++ b/apps/designer/app/designer/features/topbar/menu/menu.tsx
@@ -34,6 +34,7 @@ import {
 import { deleteInstance } from "~/shared/instance-utils";
 import { MenuButton } from "./menu-button";
 import { useAuthPermit } from "~/shared/nano-states";
+import { zoomIn, zoomOut } from "~/shared/nano-states/breakpoints";
 
 const ThemeMenuItem = () => {
   if (isFeatureEnabled("dark") === false) {
@@ -204,27 +205,13 @@ export const Menu = ({ publish }: MenuProps) => {
               <ShortcutHint value={["cmd", "b"]} />
             </DropdownMenuItemRightSlot>
           </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => {
-              publish({
-                type: "zoom",
-                payload: "zoomIn",
-              });
-            }}
-          >
+          <DropdownMenuItem onSelect={zoomIn}>
             Zoom in
             <DropdownMenuItemRightSlot>
               <ShortcutHint value={["+"]} />
             </DropdownMenuItemRightSlot>
           </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => {
-              publish({
-                type: "zoom",
-                payload: "zoomOut",
-              });
-            }}
-          >
+          <DropdownMenuItem onSelect={zoomOut}>
             Zoom out
             <DropdownMenuItemRightSlot>
               <ShortcutHint value={["-"]} />

--- a/apps/designer/app/designer/features/workspace/use-read-canvas-rect.ts
+++ b/apps/designer/app/designer/features/workspace/use-read-canvas-rect.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
-import { useZoom } from "~/designer/shared/nano-states";
+import { useStore } from "@nanostores/react";
 import { useCanvasRect, useCanvasWidth } from "~/designer/shared/nano-states";
 import { useWindowResize } from "~/shared/dom-hooks";
+import { zoomStore } from "~/shared/nano-states/breakpoints";
 
 /**
  * Reads the canvas iframe dom rect and puts it into nano state
@@ -13,7 +14,7 @@ export const useReadCanvasRect = () => {
   );
   const [, setCanvasRect] = useCanvasRect();
   const [canvasWidth] = useCanvasWidth();
-  const [zoom] = useZoom();
+  const zoom = useStore(zoomStore);
   const [recalcFlag, forceRecalc] = useState(false);
   useWindowResize(() => {
     forceRecalc(!recalcFlag);

--- a/apps/designer/app/designer/features/workspace/workspace.tsx
+++ b/apps/designer/app/designer/features/workspace/workspace.tsx
@@ -1,9 +1,10 @@
-import { Box, Flex, Toaster } from "@webstudio-is/design-system";
-import { useCanvasWidth, useZoom } from "~/designer/shared/nano-states";
-import { CanvasTools } from "./canvas-tools";
+import { useStore } from "@nanostores/react";
+import { theme, Box, Flex, Toaster } from "@webstudio-is/design-system";
+import { useCanvasWidth } from "~/designer/shared/nano-states";
 import { type Publish } from "~/shared/pubsub";
-import { theme } from "@webstudio-is/design-system";
 import { selectedInstanceIdStore } from "~/shared/nano-states";
+import { zoomStore } from "~/shared/nano-states/breakpoints";
+import { CanvasTools } from "./canvas-tools";
 
 const workspaceStyle = {
   flexGrow: 1,
@@ -37,7 +38,7 @@ export const Workspace = ({
   onTransitionEnd,
   publish,
 }: WorkspaceProps) => {
-  const [zoom] = useZoom();
+  const zoom = useStore(zoomStore);
   const [canvasWidth] = useCanvasWidth();
 
   const handleWorkspaceClick = () => {

--- a/apps/designer/app/designer/shared/nano-states/index.ts
+++ b/apps/designer/app/designer/shared/nano-states/index.ts
@@ -20,9 +20,6 @@ const selectedBreakpointContainer = atom<Breakpoint | undefined>();
 export const useSelectedBreakpoint = () =>
   useValue(selectedBreakpointContainer);
 
-const zoomContainer = atom<number>(100);
-export const useZoom = () => useValue(zoomContainer);
-
 const canvasWidthContainer = atom<number>(0);
 export const useCanvasWidth = () => useValue(canvasWidthContainer);
 

--- a/apps/designer/app/shared/nano-states/breakpoints.ts
+++ b/apps/designer/app/shared/nano-states/breakpoints.ts
@@ -1,0 +1,19 @@
+import { atom } from "nanostores";
+
+export const minZoom = 10;
+const maxZoom = 100;
+const zoomStep = 20;
+
+export const zoomStore = atom<number>(100);
+
+export const zoomIn = () => {
+  zoomStore.set(Math.min(zoomStore.get() + zoomStep, maxZoom));
+};
+
+export const zoomOut = () => {
+  zoomStore.set(Math.max(zoomStore.get() - zoomStep, minZoom));
+};
+
+export const synchronizedBreakpointsStores = [
+  ["zoomStore", zoomStore],
+] as const;

--- a/apps/designer/app/shared/shortcuts/shortcuts.ts
+++ b/apps/designer/app/shared/shortcuts/shortcuts.ts
@@ -34,7 +34,7 @@ export const useSharedShortcuts = () => {
   );
 
   useHotkeys(
-    "Equal, alt+Equal",
+    "Equal",
     zoomIn,
     // prevent zoom while typing
     { enableOnFormTags: false, enableOnContentEditable: false },
@@ -42,10 +42,24 @@ export const useSharedShortcuts = () => {
   );
 
   useHotkeys(
-    "Minus, alt+Minus",
+    "ctrl+Equal",
+    zoomIn,
+    { enableOnFormTags: true, enableOnContentEditable: true },
+    []
+  );
+
+  useHotkeys(
+    "Minus",
     zoomOut,
     // prevent zoom while typing
     { enableOnFormTags: false, enableOnContentEditable: false },
+    []
+  );
+
+  useHotkeys(
+    "ctrl+Minus",
+    zoomOut,
+    { enableOnFormTags: true, enableOnContentEditable: true },
     []
   );
 };

--- a/apps/designer/app/shared/shortcuts/shortcuts.ts
+++ b/apps/designer/app/shared/shortcuts/shortcuts.ts
@@ -34,7 +34,7 @@ export const useSharedShortcuts = () => {
   );
 
   useHotkeys(
-    "=",
+    "Equal, alt+Equal",
     zoomIn,
     // prevent zoom while typing
     { enableOnFormTags: false, enableOnContentEditable: false },
@@ -42,7 +42,7 @@ export const useSharedShortcuts = () => {
   );
 
   useHotkeys(
-    "-",
+    "Minus, alt+Minus",
     zoomOut,
     // prevent zoom while typing
     { enableOnFormTags: false, enableOnContentEditable: false },

--- a/apps/designer/app/shared/shortcuts/shortcuts.ts
+++ b/apps/designer/app/shared/shortcuts/shortcuts.ts
@@ -34,7 +34,7 @@ export const useSharedShortcuts = () => {
   );
 
   useHotkeys(
-    "Equal",
+    "equal",
     zoomIn,
     // prevent zoom while typing
     { enableOnFormTags: false, enableOnContentEditable: false },
@@ -42,14 +42,14 @@ export const useSharedShortcuts = () => {
   );
 
   useHotkeys(
-    "ctrl+Equal",
+    "ctrl+equal",
     zoomIn,
     { enableOnFormTags: true, enableOnContentEditable: true },
     []
   );
 
   useHotkeys(
-    "Minus",
+    "minus",
     zoomOut,
     // prevent zoom while typing
     { enableOnFormTags: false, enableOnContentEditable: false },
@@ -57,7 +57,7 @@ export const useSharedShortcuts = () => {
   );
 
   useHotkeys(
-    "ctrl+Minus",
+    "ctrl+minus",
     zoomOut,
     { enableOnFormTags: true, enableOnContentEditable: true },
     []

--- a/apps/designer/app/shared/shortcuts/shortcuts.ts
+++ b/apps/designer/app/shared/shortcuts/shortcuts.ts
@@ -1,5 +1,6 @@
 import { Options, useHotkeys } from "react-hotkeys-hook";
 import { selectedInstanceIdStore } from "../nano-states";
+import { zoomIn, zoomOut } from "../nano-states/breakpoints";
 import { deleteInstance } from "../instance-utils";
 
 export const shortcuts = {
@@ -11,7 +12,6 @@ export const shortcuts = {
   breakpoint: Array.from(new Array(9))
     .map((_, index) => `cmd+${index + 1}, ctrl+${index + 1}`)
     .join(", "),
-  zoom: "=, -",
 } as const;
 
 export const options: Options = {
@@ -29,6 +29,22 @@ export const useSharedShortcuts = () => {
       deleteInstance(selectedInstanceId);
     },
     // prevent instance deletion while deleting text
+    { enableOnFormTags: false, enableOnContentEditable: false },
+    []
+  );
+
+  useHotkeys(
+    "=",
+    zoomIn,
+    // prevent zoom while typing
+    { enableOnFormTags: false, enableOnContentEditable: false },
+    []
+  );
+
+  useHotkeys(
+    "-",
+    zoomOut,
+    // prevent zoom while typing
     { enableOnFormTags: false, enableOnContentEditable: false },
     []
   );

--- a/apps/designer/app/shared/shortcuts/shortcuts.ts
+++ b/apps/designer/app/shared/shortcuts/shortcuts.ts
@@ -42,8 +42,11 @@ export const useSharedShortcuts = () => {
   );
 
   useHotkeys(
-    "ctrl+equal",
-    zoomIn,
+    "meta+shift+equal",
+    (event) => {
+      event.preventDefault();
+      zoomIn();
+    },
     { enableOnFormTags: true, enableOnContentEditable: true },
     []
   );
@@ -57,8 +60,11 @@ export const useSharedShortcuts = () => {
   );
 
   useHotkeys(
-    "ctrl+minus",
-    zoomOut,
+    "meta+shift+minus",
+    (event) => {
+      event.preventDefault();
+      zoomOut();
+    },
     { enableOnFormTags: true, enableOnContentEditable: true },
     []
   );

--- a/apps/designer/app/shared/sync/sync-stores.ts
+++ b/apps/designer/app/shared/sync/sync-stores.ts
@@ -17,6 +17,7 @@ import {
   hoveredInstanceOutlineStore,
   isPreviewModeStore,
 } from "~/shared/nano-states";
+import { synchronizedBreakpointsStores } from "~/shared/nano-states/breakpoints";
 
 enableMapSet();
 
@@ -62,6 +63,9 @@ export const registerContainers = () => {
   clientStores.set("hoveredInstanceIdStore", hoveredInstanceIdStore);
   clientStores.set("hoveredInstanceOutlineStore", hoveredInstanceOutlineStore);
   clientStores.set("isPreviewModeStore", isPreviewModeStore);
+  for (const [name, store] of synchronizedBreakpointsStores) {
+    clientStores.set(name, store);
+  }
 };
 
 const syncStoresChanges = (name: SyncEventSource, publish: Publish) => {

--- a/apps/designer/package.json
+++ b/apps/designer/package.json
@@ -82,7 +82,7 @@
     "react-color": "^2.19.3",
     "react-dom": "^17.0.2",
     "react-error-boundary": "^3.1.4",
-    "react-hotkeys-hook": "^4.3.4",
+    "react-hotkeys-hook": "^4.3.5",
     "react-use": "^17.3.2",
     "remix-auth": "^3.2.2",
     "remix-auth-form": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
       react-color: ^2.19.3
       react-dom: 17.0.2
       react-error-boundary: ^3.1.4
-      react-hotkeys-hook: ^4.3.4
+      react-hotkeys-hook: ^4.3.5
       react-test-renderer: ^17.0.2
       react-use: ^17.3.2
       relative-deps: ^1.0.7
@@ -221,7 +221,7 @@ importers:
       react-color: 2.19.3_react@17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-error-boundary: 3.1.4_react@17.0.2
-      react-hotkeys-hook: 4.3.4_sfoxds7t5ydpegc3knd667wn6m
+      react-hotkeys-hook: 4.3.5_sfoxds7t5ydpegc3knd667wn6m
       react-use: 17.4.0_sfoxds7t5ydpegc3knd667wn6m
       remix-auth: 3.2.2_@remix-run+react@1.12.0
       remix-auth-form: 1.1.2_@remix-run+react@1.12.0
@@ -20290,8 +20290,8 @@ packages:
       - csstype
     dev: false
 
-  /react-hotkeys-hook/4.3.4_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-XV/tMK8n0joWa4tSklfddLUDirbu8T/H1hRPPm+UnfdT2ajp/jZPDh0q3L24nYjsCSwNIA6XFewYPguqrTIXkg==}
+  /react-hotkeys-hook/4.3.5_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-tfwTwKP3ga7n4naNS/JOByaEwEkTCoXYCepDuhXpj8mBx+sFszV5JecRWM2dv+PbOowmmBpHAFtTXTnG/p8UkQ==}
     peerDependencies:
       react: '>=16.8.1'
       react-dom: '>=16.8.1'


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/1002

Synchronizing shortcuts with pubsub is complicated because we need to configure each case. Here instead I synchronized zoom store and run shortcuts on both designer and canvas. This way whole logic tied to state instead of event.

## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
