### PR TITLE
Enable using css functions in CssValueInput

### DIFF
--- a/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
+++ b/apps/designer/app/designer/features/style-panel/shared/css-value-input/css-value-input.tsx
@@ -361,7 +361,17 @@ export const CssValueInput = ({
       value.type === "unit" || value.type === "intermediate"
         ? value.unit
         : undefined,
-    onChange: (unit) => onChangeComplete({ ...value, unit }, "unit-select"),
+    onChange: (unit) => {
+      if (value.type === "unit" || value.type === "intermediate") {
+        onChangeComplete({ ...value, unit }, "unit-select");
+        return;
+      }
+
+      onChangeComplete(
+        { type: "intermediate", value: toValue(value), unit },
+        "unit-select"
+      );
+    },
     onCloseAutoFocus(event) {
       // We don't want to focus the unit trigger when closing the select (no matter if unit was selected, clicked outside or esc was pressed)
       event.preventDefault();

--- a/apps/designer/app/designer/features/style-panel/shared/parse-css-value.test.ts
+++ b/apps/designer/app/designer/features/style-panel/shared/parse-css-value.test.ts
@@ -66,4 +66,42 @@ describe("Parse CSS value", () => {
       });
     });
   });
+
+  describe("Unparesd valid values", () => {
+    test("Simple valid function values", () => {
+      expect(parseCssValue("filter", "blur(4px)")).toEqual({
+        type: "unparsed",
+        value: "blur(4px)",
+      });
+
+      expect(parseCssValue("width", "calc(4px + 16em)")).toEqual({
+        type: "unparsed",
+        value: "calc(4px + 16em)",
+      });
+    });
+
+    test("Multiple valid function values", () => {
+      expect(
+        parseCssValue(
+          "filter",
+          "blur(4px) drop-shadow(16px 16px 20px blue) opacity(25%)"
+        )
+      ).toEqual({
+        type: "unparsed",
+        value: "blur(4px) drop-shadow(16px 16px 20px blue) opacity(25%)",
+      });
+
+      expect(parseCssValue("filter", "blur(calc(4px + 16em))")).toEqual({
+        type: "unparsed",
+        value: "blur(calc(4px + 16em))",
+      });
+    });
+
+    test("Invalid function values", () => {
+      expect(parseCssValue("width", "blur(4)")).toEqual({
+        type: "invalid",
+        value: "blur(4)",
+      });
+    });
+  });
 });

--- a/apps/designer/app/shared/copy-paste/copy-paste-instance.ts
+++ b/apps/designer/app/shared/copy-paste/copy-paste-instance.ts
@@ -128,7 +128,7 @@ const startCopyPasteInstance = () => {
   return startCopyPaste({
     version: "@webstudio/instance/v0.1",
     type: InstanceData,
-    allowAnyTarget: true,
+    allowAnyTarget: false,
 
     onCopy: () => {
       const selectedInstanceId = selectedInstanceIdStore.get();

--- a/apps/designer/package.json
+++ b/apps/designer/package.json
@@ -55,7 +55,7 @@
     "@webstudio-is/trpc-interface": "workspace:^",
     "camelcase": "^6.3.0",
     "colord": "^2.9.3",
-    "css-tree": "^2.3.0",
+    "css-tree": "^2.3.1",
     "debug": "^4.3.4",
     "detect-font": "^0.1.5",
     "djb2a": "^2.0.0",

--- a/packages/css-data/package.json
+++ b/packages/css-data/package.json
@@ -13,14 +13,13 @@
     "build:mdn-data": "tsx ./bin/mdn-data.ts ./src/__generated__ &&  prettier --write \"./src/__generated__/**/*.ts\"",
     "lint": "eslint ./src --ext .ts,.tsx --max-warnings 0"
   },
-  "dependencies": {},
   "devDependencies": {
     "@types/css-tree": "^2.0.0",
+    "@webstudio-is/asset-uploader": "workspace:^",
     "@webstudio-is/scripts": "workspace:^",
     "@webstudio-is/tsconfig": "workspace:^",
-    "@webstudio-is/asset-uploader": "workspace:^",
     "camelcase": "^6.3.0",
-    "css-tree": "^2.3.0",
+    "css-tree": "^2.3.1",
     "mdn-data": "2.0.30",
     "typescript": "4.7.4",
     "zod": "^3.19.1"

--- a/packages/css-data/src/schema.ts
+++ b/packages/css-data/src/schema.ts
@@ -45,6 +45,14 @@ const KeywordValue = z.object({
 });
 export type KeywordValue = z.infer<typeof KeywordValue>;
 
+/**
+ * Valid unparsed css value
+ **/
+const UnparsedValue = z.object({
+  type: z.literal("unparsed"),
+  value: z.string(),
+});
+
 const FontFamilyValue = z.object({
   type: z.literal("fontFamily"),
   value: z.array(z.string()),
@@ -87,6 +95,7 @@ export const validStaticValueTypes = [
   "fontFamily",
   "rgb",
   "image",
+  "unparsed",
 ] as const;
 
 /**
@@ -98,6 +107,7 @@ const SharedStaticStyleValue = z.union([
   KeywordValue,
   FontFamilyValue,
   RgbValue,
+  UnparsedValue,
 ]);
 
 const ValidStaticStyleValue = z.union([ImageValue, SharedStaticStyleValue]);

--- a/packages/css-engine/src/core/to-value.ts
+++ b/packages/css-engine/src/core/to-value.ts
@@ -71,6 +71,10 @@ export const toValue = (
       .join(", ");
   }
 
+  if (value.type === "unparsed") {
+    return value.value;
+  }
+
   // Will give ts error in case of missing type
   assertUnreachable(value, `Unknown value type`);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,7 +108,7 @@ importers:
       babel-loader: ^8.2.5
       camelcase: ^6.3.0
       colord: ^2.9.3
-      css-tree: ^2.3.0
+      css-tree: ^2.3.1
       debug: ^4.3.4
       detect-font: ^0.1.5
       djb2a: ^2.0.0
@@ -194,7 +194,7 @@ importers:
       '@webstudio-is/trpc-interface': link:../../packages/trpc-interface
       camelcase: 6.3.0
       colord: 2.9.3
-      css-tree: 2.3.0
+      css-tree: 2.3.1
       debug: 4.3.4
       detect-font: 0.1.5
       djb2a: 2.0.0
@@ -346,7 +346,7 @@ importers:
       '@webstudio-is/scripts': workspace:^
       '@webstudio-is/tsconfig': workspace:^
       camelcase: ^6.3.0
-      css-tree: ^2.3.0
+      css-tree: ^2.3.1
       mdn-data: 2.0.30
       typescript: 4.7.4
       zod: ^3.19.1
@@ -356,7 +356,7 @@ importers:
       '@webstudio-is/scripts': link:../scripts
       '@webstudio-is/tsconfig': link:../tsconfig
       camelcase: 6.3.0
-      css-tree: 2.3.0
+      css-tree: 2.3.1
       mdn-data: 2.0.30
       typescript: 4.7.4
       zod: 3.19.1
@@ -13784,6 +13784,14 @@ packages:
   /css-tree/2.3.0:
     resolution: {integrity: sha512-1rg0LiK2MFi4R3/lVvnRokEWTZb30ljSAe5x+0HHkZ+OqZaAeiP8g8Eh91VmkyCtQn9vMgQRiaTDYgLBt+2Qyw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+    dependencies:
+      mdn-data: 2.0.30
+      source-map-js: 1.0.2
+    dev: true
+
+  /css-tree/2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
     dependencies:
       mdn-data: 2.0.30
       source-map-js: 1.0.2


### PR DESCRIPTION
## Description

1. What is this PR about (link the issue and add a short description)

Enable using css functions in CssValueInput 
closes #990 

## Steps for reproduction

Add 
`blur(2px)` or 
`drop-shadow(16px 16px 20px blue)` or 
`blur(2px) drop-shadow(16px 16px 20px blue)` to the filter field

It should work.


## Code Review

- [ ] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
