### PR TITLE
Fix all cmd shortcuts

### DIFF
--- a/apps/designer/app/canvas/shared/use-shortcuts.ts
+++ b/apps/designer/app/canvas/shared/use-shortcuts.ts
@@ -1,5 +1,4 @@
 import { useHotkeys } from "react-hotkeys-hook";
-import store from "immerhin";
 import { getComponentMeta } from "@webstudio-is/react-sdk";
 import { shortcuts, options } from "~/shared/shortcuts";
 import { publish, useSubscribe } from "~/shared/pubsub";
@@ -51,8 +50,6 @@ export const useShortcuts = () => {
   const [editingInstanceId, setEditingInstanceId] = useTextEditingInstanceId();
 
   const shortcutHandlerMap = {
-    undo: store.undo.bind(store),
-    redo: store.redo.bind(store),
     preview: togglePreviewMode,
     breakpointsMenu: publishOpenBreakpointsMenu,
     breakpoint: publishSelectBreakpoint,
@@ -94,10 +91,6 @@ export const useShortcuts = () => {
     options,
     [setEditingInstanceId]
   );
-
-  useHotkeys(shortcuts.undo, shortcutHandlerMap.undo, options, []);
-
-  useHotkeys(shortcuts.redo, shortcutHandlerMap.redo, options, []);
 
   useHotkeys(shortcuts.preview, shortcutHandlerMap.preview, options, []);
 

--- a/apps/designer/app/designer/features/topbar/menu/menu.tsx
+++ b/apps/designer/app/designer/features/topbar/menu/menu.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "@remix-run/react";
+import store from "immerhin";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
 import {
   theme,
@@ -133,27 +134,13 @@ export const Menu = ({ publish }: MenuProps) => {
             Dashboard
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onSelect={() => {
-              publish({
-                type: "shortcut",
-                payload: { name: "undo" },
-              });
-            }}
-          >
+          <DropdownMenuItem onSelect={() => store.undo()}>
             Undo
             <DropdownMenuItemRightSlot>
               <ShortcutHint value={["cmd", "z"]} />
             </DropdownMenuItemRightSlot>
           </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => {
-              publish({
-                type: "shortcut",
-                payload: { name: "redo" },
-              });
-            }}
-          >
+          <DropdownMenuItem onSelect={() => store.redo()}>
             Redo
             <DropdownMenuItemRightSlot>
               <ShortcutHint value={["shift", "cmd", "z"]} />

--- a/apps/designer/app/shared/shortcuts/shortcuts.ts
+++ b/apps/designer/app/shared/shortcuts/shortcuts.ts
@@ -1,16 +1,15 @@
 import { Options, useHotkeys } from "react-hotkeys-hook";
+import store from "immerhin";
 import { selectedInstanceIdStore } from "../nano-states";
 import { zoomIn, zoomOut } from "../nano-states/breakpoints";
 import { deleteInstance } from "../instance-utils";
 
 export const shortcuts = {
   esc: "esc",
-  undo: "cmd+z, ctrl+z",
-  redo: "cmd+shift+z, ctrl+shift+z",
-  preview: "cmd+shift+p, ctrl+shift+p",
-  breakpointsMenu: "cmd+b, ctrl+b",
+  preview: "meta+shift+p, ctrl+shift+p",
+  breakpointsMenu: "meta+b, ctrl+b",
   breakpoint: Array.from(new Array(9))
-    .map((_, index) => `cmd+${index + 1}, ctrl+${index + 1}`)
+    .map((_, index) => `meta+${index + 1}, ctrl+${index + 1}`)
     .join(", "),
 } as const;
 
@@ -19,6 +18,22 @@ export const options: Options = {
 };
 
 export const useSharedShortcuts = () => {
+  useHotkeys(
+    // safari use cmd+z to reopen closed tabs so fallback to ctrl
+    "meta+z, ctrl+z",
+    () => store.undo(),
+    { enableOnFormTags: true, enableOnContentEditable: false },
+    []
+  );
+
+  useHotkeys(
+    // safari use cmd+shift+z to close reopened tabs so fallback to ctrl
+    "meta+shift+z, ctrl+shift+z",
+    () => store.redo(),
+    { enableOnFormTags: true, enableOnContentEditable: false },
+    []
+  );
+
   useHotkeys(
     "backspace, delete",
     () => {


### PR DESCRIPTION
Ref https://github.com/webstudio-is/webstudio-designer/issues/1004

After react-hotkeys-hook bump I didn't notice "cmd" stopped working because replaced with "meta" word as cross-platform variant.

Also moved undo/redo to shared shortcuts.

## Code Review

- [ ] hi @kof, I need you to do
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [ ] made a self-review
- [ ] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [ ] tested locally and on preview environment (preview dev login: 5de6)
- [ ] updated [test cases](https://github.com/webstudio-is/webstudio-designer/blob/main/apps/designer/docs/test-cases.md) document
- [ ] added tests
- [ ] if any new env variables are added, added them to `.env.example` and the `designer/env-check.js` if mandatory
